### PR TITLE
feat: add composite sources support WIP

### DIFF
--- a/src/composite_source.rs
+++ b/src/composite_source.rs
@@ -1,0 +1,45 @@
+use std::io;
+
+use tilejson::{TileJSON, TileJSONBuilder};
+
+use crate::db::Connection;
+use crate::source::{Query, Source, Tile, XYZ};
+use crate::table_source::TableSource;
+
+#[derive(Clone, Debug)]
+pub struct CompositeSource {
+    pub id: String,
+    pub table_sources: Vec<TableSource>,
+}
+
+impl Source for CompositeSource {
+    fn get_id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    fn get_tilejson(&self) -> Result<TileJSON, io::Error> {
+        let mut tilejson_builder = TileJSONBuilder::new();
+
+        tilejson_builder.scheme("xyz");
+        tilejson_builder.name(&self.id);
+
+        Ok(tilejson_builder.finalize())
+    }
+
+    fn get_tile(
+        &self,
+        conn: &mut Connection,
+        xyz: &XYZ,
+        _query: &Option<Query>,
+    ) -> Result<Tile, io::Error> {
+        let tile: Tile = self
+            .table_sources
+            .clone()
+            .into_iter()
+            .filter_map(|source| source.get_tile(conn, xyz, _query).ok())
+            .collect::<Vec<Tile>>()
+            .concat();
+
+        Ok(tile)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 
+pub mod composite_source;
 pub mod config;
 pub mod coordinator_actor;
 pub mod db;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::rc::Rc;
 
 use actix::{Actor, Addr, SyncArbiter, SystemRunner};
@@ -9,6 +10,7 @@ use actix_web::{
     error, http, middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer, Result,
 };
 
+use crate::composite_source::CompositeSource;
 use crate::config::Config;
 use crate::coordinator_actor::CoordinatorActor;
 use crate::db::Pool;
@@ -16,7 +18,7 @@ use crate::db_actor::DBActor;
 use crate::function_source::FunctionSources;
 use crate::messages;
 use crate::source::{Source, XYZ};
-use crate::table_source::TableSources;
+use crate::table_source::{TableSource, TableSources};
 use crate::worker_actor::WorkerActor;
 
 pub struct AppState {
@@ -33,8 +35,23 @@ struct SourceRequest {
 }
 
 #[derive(Deserialize)]
+struct CompositeSourceRequest {
+    source_ids: String,
+}
+
+#[derive(Deserialize)]
 struct TileRequest {
     source_id: String,
+    z: u32,
+    x: u32,
+    y: u32,
+    #[allow(dead_code)]
+    format: String,
+}
+
+#[derive(Deserialize)]
+struct CompositeTileRequest {
+    source_ids: String,
     z: u32,
     x: u32,
     y: u32,
@@ -65,9 +82,9 @@ async fn get_table_sources(state: web::Data<AppState>) -> Result<HttpResponse, E
     Ok(HttpResponse::Ok().json(table_sources))
 }
 
-async fn get_table_source(
+async fn get_composite_source(
     req: HttpRequest,
-    path: web::Path<SourceRequest>,
+    path: web::Path<CompositeSourceRequest>,
     state: web::Data<AppState>,
 ) -> Result<HttpResponse> {
     let table_sources = state
@@ -76,9 +93,17 @@ async fn get_table_source(
         .clone()
         .ok_or_else(|| error::ErrorNotFound("There is no table sources"))?;
 
-    let source = table_sources.get(&path.source_id).ok_or_else(|| {
-        error::ErrorNotFound(format!("Table source '{}' not found", path.source_id))
-    })?;
+    let sources: Vec<TableSource> = path
+        .source_ids
+        .split(',')
+        .filter_map(|source_id| table_sources.get(source_id))
+        .map(|source| source.deref().clone())
+        .collect();
+
+    let source = CompositeSource {
+        id: path.source_ids.clone(),
+        table_sources: sources,
+    };
 
     let mut tilejson = source
         .get_tilejson()
@@ -116,8 +141,8 @@ async fn get_table_source(
     Ok(HttpResponse::Ok().json(tilejson))
 }
 
-async fn get_table_source_tile(
-    path: web::Path<TileRequest>,
+async fn get_composite_source_tile(
+    path: web::Path<CompositeTileRequest>,
     state: web::Data<AppState>,
 ) -> Result<HttpResponse, Error> {
     let table_sources = state
@@ -126,9 +151,17 @@ async fn get_table_source_tile(
         .clone()
         .ok_or_else(|| error::ErrorNotFound("There is no table sources"))?;
 
-    let source = table_sources.get(&path.source_id).ok_or_else(|| {
-        error::ErrorNotFound(format!("Table source '{}' not found", path.source_id))
-    })?;
+    let sources: Vec<TableSource> = path
+        .source_ids
+        .split(',')
+        .filter_map(|source_id| table_sources.get(source_id))
+        .map(|source| source.deref().clone())
+        .collect();
+
+    let source = CompositeSource {
+        id: path.source_ids.clone(),
+        table_sources: sources,
+    };
 
     let xyz = XYZ {
         z: path.z,
@@ -139,7 +172,7 @@ async fn get_table_source_tile(
     let message = messages::GetTile {
         xyz,
         query: None,
-        source: source.clone(),
+        source: Box::new(source),
     };
 
     let tile = state
@@ -279,10 +312,10 @@ async fn get_function_source_tile(
 
 pub fn router(cfg: &mut web::ServiceConfig) {
     cfg.route("/index.json", web::get().to(get_table_sources))
-        .route("/{source_id}.json", web::get().to(get_table_source))
+        .route("/{source_ids}.json", web::get().to(get_composite_source))
         .route(
-            "/{source_id}/{z}/{x}/{y}.{format}",
-            web::get().to(get_table_source_tile),
+            "/{source_ids}/{z}/{x}/{y}.{format}",
+            web::get().to(get_composite_source_tile),
         )
         .route("/rpc/index.json", web::get().to(get_function_sources))
         .route("/rpc/{source_id}.json", web::get().to(get_function_source))

--- a/src/server.rs
+++ b/src/server.rs
@@ -100,6 +100,10 @@ async fn get_composite_source(
         .map(|source| source.deref().clone())
         .collect();
 
+    if sources.is_empty() {
+        return Err(error::ErrorNotFound("There is no such table sources"));
+    }
+
     let source = CompositeSource {
         id: path.source_ids.clone(),
         table_sources: sources,
@@ -157,6 +161,10 @@ async fn get_composite_source_tile(
         .filter_map(|source_id| table_sources.get(source_id))
         .map(|source| source.deref().clone())
         .collect();
+
+    if sources.is_empty() {
+        return Err(error::ErrorNotFound("There is no such table sources"));
+    }
 
     let source = CompositeSource {
         id: path.source_ids.clone(),

--- a/tests/composite_source.html
+++ b/tests/composite_source.html
@@ -42,20 +42,37 @@
         center: [0, 0]
       });
 
-      const sourceId = 'public.points1';
-
       map.on('load', function () {
-        map.addLayer({
-          id: sourceId,
-          type: 'circle',
-          source: {
-            type: 'vector',
-            url: `http://0.0.0.0:3000/${sourceId}.json`
-          },
-          'source-layer': sourceId
+        map.addSource('points', {
+          type: 'vector',
+          url: `http://0.0.0.0:3000/public.points1,public.points2.json`
         });
 
-        map.on('click', sourceId, function (event) {
+        map.addLayer({
+          id: 'red_points',
+          type: 'circle',
+          source: 'points',
+          'source-layer': 'public.points1',
+          paint: {
+            'circle-color': 'red'
+          }
+        });
+
+        map.on('click', 'red_points', function (event) {
+          console.log(event.features);
+        });
+
+        map.addLayer({
+          id: 'blue_points',
+          type: 'circle',
+          source: 'points',
+          'source-layer': 'public.points2',
+          paint: {
+            'circle-color': 'blue'
+          }
+        });
+
+        map.on('click', 'blue_points', function (event) {
           console.log(event.features);
         });
       });

--- a/tests/fixtures/points1_source.sql
+++ b/tests/fixtures/points1_source.sql
@@ -1,6 +1,6 @@
-CREATE TABLE points(gid SERIAL PRIMARY KEY, geom GEOMETRY(POINT, 4326));
+CREATE TABLE points1(gid SERIAL PRIMARY KEY, geom GEOMETRY(POINT, 4326));
 
-INSERT INTO points
+INSERT INTO points1
     SELECT
         generate_series(1, 10000) as id,
         (
@@ -12,5 +12,5 @@ INSERT INTO points
             )
         ).geom;
 
-CREATE INDEX ON points USING GIST(geom);
-CLUSTER points_geom_idx ON points;
+CREATE INDEX ON points1 USING GIST(geom);
+CLUSTER points1_geom_idx ON points1;

--- a/tests/fixtures/points2_source.sql
+++ b/tests/fixtures/points2_source.sql
@@ -1,0 +1,16 @@
+CREATE TABLE points2(gid SERIAL PRIMARY KEY, geom GEOMETRY(POINT, 4326));
+
+INSERT INTO points2
+    SELECT
+        generate_series(1, 10000) as id,
+        (
+            ST_DUMP(
+                ST_GENERATEPOINTS(
+                    ST_GEOMFROMTEXT('POLYGON ((-180 90, 180 90, 180 -90, -180 -90, -180 90))', 4326),
+                    10000
+                )
+            )
+        ).geom;
+
+CREATE INDEX ON points2 USING GIST(geom);
+CLUSTER points2_geom_idx ON points2;

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -73,6 +73,13 @@ async fn test_get_table_source_tile_ok() {
     let mut app = test::init_service(App::new().data(state).configure(router)).await;
 
     let req = test::TestRequest::get()
+        .uri("/public.non_existant/0/0/0.pbf")
+        .to_request();
+
+    let response = test::call_service(&mut app, req).await;
+    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+
+    let req = test::TestRequest::get()
         .uri("/public.table_source/0/0/0.pbf")
         .to_request();
 


### PR DESCRIPTION
This PR allows composing multiple table sources into one composite source. Table sources endpoints now support multiple tables in one request. E.g you can request tiles that contain data from multiple tables by listing the tables separated by a comma:

```
/{schema_name1}.{table_name1},{schema_name2}.{table_name2}.json
/{schema_name1}.{table_name1},{schema_name2}.{table_name2}/0/0/0.pbf
``` 

Using with Mapbox GL JS

```js
map.addSource('points', {
  type: 'vector',
  url: `http://0.0.0.0:3000/public.red_points,public.blue_points.json`
});

map.addLayer({
  id: 'red_points',
  type: 'circle',
  source: 'points',
  'source-layer': 'public.red_points',
  paint: {
    'circle-color': 'red'
  }
});

map.addLayer({
  id: 'blue_points',
  type: 'circle',
  source: 'points',
  'source-layer': 'public.blue_points',
  paint: {
    'circle-color': 'blue'
  }
});
``` 

You can try [this docker image](https://hub.docker.com/layers/urbica/martin/pr-107-merge/images/sha256-fd9cf3defe0d3f7968434ed5b27ed50804fde51e9b93f2958d8de6bee1d1381d?context=explore) with composite sources support and give any feedback on this

```
docker pull urbica/martin:pr-107-merge
```

Relates: #36

