### PR TITLE
Add bounds to table info

### DIFF
--- a/src/dev.rs
+++ b/src/dev.rs
@@ -26,6 +26,7 @@ pub fn mock_table_sources() -> Option<TableSources> {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        bounds:[-180.0,-90.0,180.0,90.0].to_vec()
     };
 
     let mut table_sources: TableSources = HashMap::new();

--- a/src/table_source.rs
+++ b/src/table_source.rs
@@ -21,6 +21,7 @@ pub struct TableSource {
     pub clip_geom: Option<bool>,
     pub geometry_type: Option<String>,
     pub properties: HashMap<String, String>,
+    pub bounds: Vec<f32>
 }
 
 pub type TableSources = HashMap<String, Box<TableSource>>;
@@ -35,6 +36,7 @@ impl Source for TableSource {
 
         tilejson_builder.scheme("xyz");
         tilejson_builder.name(&self.id);
+        tilejson_builder.bounds(self.bounds.to_vec());
 
         Ok(tilejson_builder.finalize())
     }
@@ -116,6 +118,22 @@ pub fn get_table_sources(conn: &mut Connection) -> Result<TableSources, io::Erro
         let geometry_column: String = row.get("f_geometry_column");
         let srid: i32 = row.get("srid");
 
+        let query_bounds = format!("SELECT ST_Extent(geom)::TEXT as bounds from  {}", id);
+        let rows_bounds=conn.query(&*query_bounds, &[]).map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+        let mut bounds: Vec<f32> = Vec::new();
+        for row_bounds in &rows_bounds {
+            let bounds_string_column:String = row_bounds.get("bounds");
+            let new_string:String = bounds_string_column.replace("(", "").replace(")", "").replace("BOX", "").replace(" ", ",");
+
+            let bounds_string:Vec<String>  =new_string.split(',').map(|s| s.to_string()).collect();
+
+            bounds.push(bounds_string[0].parse::<f32>().unwrap());
+            bounds.push(bounds_string[1].parse::<f32>().unwrap());
+            bounds.push(bounds_string[2].parse::<f32>().unwrap());
+            bounds.push(bounds_string[3].parse::<f32>().unwrap()); 
+            break;
+        }
+
         info!("Found {} table source", id);
 
         if srid == 0 {
@@ -137,6 +155,7 @@ pub fn get_table_sources(conn: &mut Connection) -> Result<TableSources, io::Erro
             clip_geom: Some(DEFAULT_CLIP_GEOM),
             geometry_type: row.get("type"),
             properties,
+            bounds
         };
 
         sources.insert(id, Box::new(source));


### PR DESCRIPTION
Use exact bounds in table info based on the sql query: "SELECT ST_Extent(geom)::TEXT as bbox from public.tableName"

**Result**
`{"tilejson":"2.2.0","id":null,"name":"public.tableName","description":null,"version":"1.0.0","attribution":null,"template":null,"legend":null,"scheme":"xyz","tiles":["http://localhost:8080/public. public.tableName/{z}/{x}/{y}.pbf"],"grids":null,"data":null,"minzoom":0,"maxzoom":30,"bounds":[3.8209655,50.95215,3.922962,51.028217],"center":null}`