### PR TITLE
Detect Martin server heartbeat for monitoring the service health

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -42,6 +42,11 @@ struct TileRequest {
     format: String,
 }
 
+async fn get_health() -> Result<HttpResponse, Error> {
+    let response = HttpResponse::Ok().body("OK");
+    return Ok(response);
+}
+
 async fn get_table_sources(state: web::Data<AppState>) -> Result<HttpResponse, Error> {
     if !state.watch_mode {
         let table_sources = state.table_sources.borrow().clone();
@@ -280,6 +285,7 @@ async fn get_function_source_tile(
 pub fn router(cfg: &mut web::ServiceConfig) {
     cfg.route("/index.json", web::get().to(get_table_sources))
         .route("/{source_id}.json", web::get().to(get_table_source))
+        .route("/healthz", web::get().to(get_health))
         .route(
             "/{source_id}/{z}/{x}/{y}.{format}",
             web::get().to(get_table_source_tile),

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -148,3 +148,15 @@ async fn test_get_function_source_tile_ok() {
     let response = test::call_service(&mut app, req).await;
     assert!(response.status().is_success());
 }
+
+#[actix_rt::test]
+async fn test_get_health_returns_ok() {
+    init();
+
+    let state = mock_state(None, mock_function_sources(), false);
+    let mut app = test::init_service(App::new().data(state).configure(router)).await;
+
+    let req = test::TestRequest::get().uri("/healthz").to_request();
+    let response = test::call_service(&mut app, req).await;
+    assert!(response.status().is_success());
+}


### PR DESCRIPTION
Detect Martin server heartbeat for monitoring the service health:
- Simply returns HTTP `200 OK`

NOTE: we have deployed Martin via Kubernetes. This PR helps to do a lightweight ping by both Kubelet as well as load balancer probes to detect the service health before auto-restart on failure or sending traffic. This is also used by monitors to alert on unexpected failures.