### PR TITLE
Deckgl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,18 @@ const pointsLayer = new MVTLayer({
   pointRadiusUnits: 'pixels',
   getRadius: 5,
   getFillColor: [230, 0, 0]
-})
+});
 
-map.addLayer(pointsLayer);
+const deckgl = new DeckGL({
+  container: 'map',
+  mapStyle: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+  initialViewState: {
+    latitude: 0,
+    longitude: 0,
+    zoom: 1
+  },
+  layers: [pointsLayer]
+});
 ```
 
 ## Table Sources

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Martin is a [PostGIS](https://github.com/postgis/postgis) [vector tiles](https:/
 - [API](#api)
 - [Using with Mapbox GL JS](#using-with-mapbox-gl-js)
 - [Using with Leaflet](#using-with-leaflet)
+- [Using with deck.gl](#using-with-deck.gl)
 - [Table Sources](#table-sources)
   - [Table Sources List](#table-sources-list)
   - [Table Source TileJSON](#table-source-tilejson)
@@ -125,6 +126,29 @@ L.vectorGrid
     },
   })
   .addTo(map);
+```
+
+## Using with deck.gl
+
+[deck.gl](https://deck.gl/) is a WebGL-powered framework for visual exploratory data analysis of large datasets.
+
+You can add vector tiles using [MVTLayer](https://deck.gl/docs/api-reference/geo-layers/mvt-layer).
+
+`data` property defines the remote data for the MVT layer.
+
+- String: Either a URL template or a [TileJSON](https://github.com/mapbox/tilejson-spec) URL. 
+
+- Array: an array of URL templates. It allows to balance the requests across different tile endpoints. For example, if you define an array with 4 urls and 16 tiles need to be loaded, each endpoint is responsible to server 16/4 tiles.
+
+- JSON: A valid [TileJSON object](https://github.com/mapbox/tilejson-spec/tree/master/2.2.0).
+
+```js
+new MVTLayer({
+  data: 'http://localhost:3000/public.points.json', // 'http://localhost:3000/public.table_source/{z}/{x}/{y}.pbf'
+  pointRadiusUnits: 'pixels',
+  getRadius: 5,
+  getFillColor: [230, 0, 0]
+})
 ```
 
 ## Table Sources

--- a/tests/debug-deckgl.html
+++ b/tests/debug-deckgl.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Martin Debug Page</title>
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <script src="https://unpkg.com/deck.gl@^8.4.0/dist.min.js"></script>
+    <script src="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.js"></script>
+    <link href="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.css" rel="stylesheet" />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="map"></div>
+
+    <script>
+      const deckgl = new deck.DeckGL({
+        container: 'map',
+        mapStyle: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+        initialViewState: {
+          latitude: 0,
+          longitude: 0,
+          zoom: 3,
+          pitch: 40
+        },
+        controller: true,
+        layers: [
+          new deck.MVTLayer({
+            data: 'http://localhost:3000/public.points.json',
+            uniqueIdProperty: 'gid',
+            getFillColor: f => {
+              const alpha = f.geometry.coordinates[1] * 255;
+              return f.properties.gid % 2 === 0 ? [51, 204, 204, alpha] : [255, 128, 223, alpha]
+            },
+            getRadius: f => Math.sqrt(f.properties.gid) / 12,
+            pointRadiusUnits: 'pixels',
+            pickable: true,
+            autoHighlight: true,
+            highlightColor: [102, 255, 153],
+            onClick: info => console.log(info.object)
+          })
+        ],
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Hey! It's me again :P

Just modifying the deck code example, `addLayer` is a Mapbox GL method, not belonging to deck.gl.

```javascript
const pointsLayer = new MVTLayer({
  data: 'http://localhost:3000/public.points.json', // 'http://localhost:3000/public.table_source/{z}/{x}/{y}.pbf'
  pointRadiusUnits: 'pixels',
  getRadius: 5,
  getFillColor: [230, 0, 0]
});

const deckgl = new DeckGL({
  container: 'map',
  mapStyle: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
  initialViewState: {
    latitude: 0,
    longitude: 0,
    zoom: 1
  },
  layers: [pointsLayer]
});
```

Cheers!