### PR TITLE
Escape quote from json to sql

### DIFF
--- a/src/function_source.rs
+++ b/src/function_source.rs
@@ -50,7 +50,7 @@ impl Source for FunctionSource {
             z = xyz.z,
             x = xyz.x,
             y = xyz.y,
-            query_params = query_json_string
+            query_params = query_json_string.replace("'", "''")
         );
 
         let tile: Tile = conn


### PR DESCRIPTION
Parameter from URL can contains quote. Then quote as set into the JSON parameter. But the quote is not escaped on SQL and make syntax error.
A couple of quote is the quote escape for SQL.
