### PR TITLE
fix: escape table and schema in function source tiles url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "num_cpus",
  "postgres",
  "postgres-native-tls",
+ "postgres-protocol",
  "r2d2",
  "r2d2_postgres",
  "semver 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ native-tls = "0.2"
 num_cpus = "1.13"
 postgres = { version = "0.19.1", features = ["with-time-0_2", "with-uuid-0_8", "with-serde_json-1"] }
 postgres-native-tls = "0.5.0"
+postgres-protocol = "0.6.1"
 r2d2 = "0.8"
 r2d2_postgres = "0.18"
 semver = "1.0"

--- a/src/function_source.rs
+++ b/src/function_source.rs
@@ -1,9 +1,9 @@
 use postgres::types::{Json, Type};
+use postgres_protocol::escape::escape_identifier;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io;
 use tilejson::{TileJSON, TileJSONBuilder};
-use postgres_protocol::escape::escape_identifier;
 
 use crate::db::Connection;
 use crate::source::{Query, Source, Tile, Xyz};

--- a/src/scripts/call_rpc.sql
+++ b/src/scripts/call_rpc.sql
@@ -1,1 +1,1 @@
-SELECT {schema}.{function}(z => {z}, x => {x}, y => {y}, query_params => '{query_params}'::json);
+SELECT {schema}.{function}(z => $3, x => $1, y => $2, query_params => $4::json);

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,9 +42,9 @@ struct CompositeSourceRequest {
 #[derive(Deserialize)]
 struct TileRequest {
     source_id: String,
-    z: u32,
-    x: u32,
-    y: u32,
+    z: i32,
+    x: i32,
+    y: i32,
     #[allow(dead_code)]
     format: String,
 }
@@ -52,9 +52,9 @@ struct TileRequest {
 #[derive(Deserialize)]
 struct CompositeTileRequest {
     source_ids: String,
-    z: u32,
-    x: u32,
-    y: u32,
+    z: i32,
+    x: i32,
+    y: i32,
     #[allow(dead_code)]
     format: String,
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -11,9 +11,9 @@ pub type Query = HashMap<String, String>;
 
 #[derive(Copy, Clone)]
 pub struct Xyz {
-    pub z: u32,
-    pub x: u32,
-    pub y: u32,
+    pub z: i32,
+    pub x: i32,
+    pub y: i32,
 }
 
 pub trait Source: Debug {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ pub fn tilebbox(xyz: &Xyz) -> String {
     let z = xyz.z;
 
     let max = 20_037_508.34;
-    let res = (max * 2.0) / f64::from(2_i32.pow(z));
+    let res = (max * 2.0) / f64::from(2_i32.pow(z as u32));
 
     let xmin = -max + (f64::from(x) * res);
     let ymin = max - (f64::from(y) * res);


### PR DESCRIPTION
Since the end user controls the query json that is
passed to postgres, it is possible to perform
a SQL injection on the function source tiles endpoint.
By preparing the query we avoid such issues. However
we still need to sanitize by hand the schema and function
parameters since they can't be a part of the prepared query.

Using prepared queries also forces us to use the right
data types when passing parameters to postgres. As such,
the coordinates system that were using unsigned
integers uses signed integers since they map directly
to postgres types.

Thanks to Frédéric Rodrigo for discovering this issue.

Before merging this PR, there are a few things to consider :
1) Does using i32 instead of u32 leads to range issues ?
2) What to do about this cast :  `let res = (max * 2.0) / f64::from(2_i32.pow(z as u32));`

Once this PR is in an acceptable state, we should consider fixing the other endpoints.