### PR TITLE
Possible fix for complex geoms

### DIFF
--- a/src/scripts/get_geom.sql
+++ b/src/scripts/get_geom.sql
@@ -1,4 +1,4 @@
 SELECT
-  ST_AsMVTGeom (ST_Transform ({geometry_column}, 3857), {mercator_bounds}, {extent}, {buffer}, {clip_geom}) AS geom {properties} FROM {id}, bounds
+  ST_AsMVTGeom (ST_Transform (ST_CurveToLine({geometry_column}), 3857), {mercator_bounds}, {extent}, {buffer}, {clip_geom}) AS geom {properties} FROM {id}, bounds
   WHERE
     {geometry_column} && bounds.srid_{srid}


### PR DESCRIPTION
As far as I can see this fixes #215 out-of-the-box for complex geometries (`CURVEPOLYGON`, `MULTISURFACE`, ...) without spatial inequality for simple types (`POINT`, `LINESTRING`, ...) occurring because of it (see #215).