### PR TITLE
CORS - Add GET to the list of allowed_methods

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -407,7 +407,7 @@ pub fn new(pool: Pool, config: Config) -> SystemRunner {
         let cors_middleware = Cors::default()
             .allow_any_origin()
             .allowed_methods(vec!["GET"]);
-        
+
         App::new()
             .data(state)
             .wrap(cors_middleware)

--- a/src/server.rs
+++ b/src/server.rs
@@ -404,8 +404,10 @@ pub fn new(pool: Pool, config: Config) -> SystemRunner {
     HttpServer::new(move || {
         let state = create_state(db.clone(), coordinator.clone(), config.clone());
 
-        let cors_middleware = Cors::default().allow_any_origin().allowed_methods(vec!["GET"]);
-
+        let cors_middleware = Cors::default()
+            .allow_any_origin()
+            .allowed_methods(vec!["GET"]);
+        
         App::new()
             .data(state)
             .wrap(cors_middleware)

--- a/src/server.rs
+++ b/src/server.rs
@@ -404,7 +404,7 @@ pub fn new(pool: Pool, config: Config) -> SystemRunner {
     HttpServer::new(move || {
         let state = create_state(db.clone(), coordinator.clone(), config.clone());
 
-        let cors_middleware = Cors::default().allow_any_origin();
+        let cors_middleware = Cors::default().allow_any_origin().allowed_methods(vec!["GET"]);
 
         App::new()
             .data(state)


### PR DESCRIPTION
Thanks to @chanange for the hint

We should add `GET` to the list of allowed_methods otherwise it's `deny all` by default, as documented here: https://actix.rs/actix-extras/actix_cors/struct.Cors.html#method.default

This allows CORS to work correctly when deployed without nginx