### PR TITLE
(don't merge) buffer should apply at query time

### DIFF
--- a/src/composite_source.rs
+++ b/src/composite_source.rs
@@ -22,7 +22,7 @@ impl CompositeSource {
             .into_iter()
             .map(|source| source.srid)
             .unique()
-            .map(|srid| get_srid_bounds(srid, xyz))
+            .map(|srid| get_srid_bounds(srid, xyz, 64.0/4096.0))
             .collect::<Vec<String>>()
             .join(", ");
 

--- a/src/table_source.rs
+++ b/src/table_source.rs
@@ -68,7 +68,7 @@ pub type TableSources = HashMap<String, Box<TableSource>>;
 
 impl TableSource {
     pub fn get_geom_query(&self, xyz: &Xyz) -> String {
-        let mercator_bounds = utils::tilebbox(xyz);
+        let mercator_bounds = utils::tilebbox(xyz,0.0);
 
         let properties = if self.properties.is_empty() {
             String::new()
@@ -114,8 +114,14 @@ impl TableSource {
         )
     }
 
+    pub fn buffering_factor(&self) -> f64 {
+        let extent = self.extent.unwrap_or(DEFAULT_EXTENT) as f64;
+        let buffer = self.buffer.unwrap_or(DEFAULT_BUFFER) as f64;
+        return buffer / extent;
+    }
+
     pub fn build_tile_query(&self, xyz: &Xyz) -> String {
-        let srid_bounds = utils::get_srid_bounds(self.srid, xyz);
+        let srid_bounds = utils::get_srid_bounds(self.srid, xyz, self.buffering_factor());
         let bounds_cte = utils::get_bounds_cte(srid_bounds);
         let tile_query = self.get_tile_query(xyz);
 


### PR DESCRIPTION
Hi,

with the `buffer` table source setting set, right now this only applies as a parameter to ST_AsMVTGeom and not the spatial query itself:

```
[2021-11-03T09:41:08Z DEBUG tokio_postgres::prepare] preparing query s6: WITH bounds AS (SELECT ST_Transform(ST_MakeEnvelope(0, 6731350.457968749, 78271.516953125, 6653078.941015624, 3857), 4326) AS srid_4326) SELECT (SELECT
      ST_AsMVT (tile, 'public.drinking_water', 4096, 'geom' ) FROM (SELECT
      ST_AsMVTGeom (ST_Transform (ST_CurveToLine(wkb_geometry), 3857), ST_MakeEnvelope(0, 6731350.457968749, 78271.516953125, 6653078.941015624, 3857), 4096, 64, true) AS geom , ... FROM public.drinking_water, bounds
      WHERE
        wkb_geometry && bounds.srid_4326
```
the bbox `(0, 6731350.457968749, 78271.516953125, 6653078.941015624, 3857),` appears twice here, but the `bounds` used to test against wkb_geometry should be buffered too, otherwise geometries will not be properly duplicated across tile edges:

<img width="593" alt="Screen Shot 2021-11-03 at 4 53 12 PM" src="https://user-images.githubusercontent.com/77501/140039532-be055213-8d4f-442f-8669-d49a14d33764.png">

This PR is a work-in-progress on how this might be solved by expanding the extent of the bounds by a factor (buffer/extent) when querying - but it doesn't interact correctly with `CompositeSource`, since the TableSource inside of CompositeSource might have different values for `buffer` and `extent`. Thoughts on the best way to solve this?

