### PR TITLE
fix: #279 500 error on Uppercase Table name

### DIFF
--- a/src/scripts/get_geom.sql
+++ b/src/scripts/get_geom.sql
@@ -1,4 +1,4 @@
 SELECT
-  ST_AsMVTGeom (ST_Transform (ST_CurveToLine({geometry_column}), 3857), {mercator_bounds}, {extent}, {buffer}, {clip_geom}) AS geom {properties} FROM {schema}.{table}, bounds
+  ST_AsMVTGeom (ST_Transform (ST_CurveToLine({geometry_column}), 3857), {mercator_bounds}, {extent}, {buffer}, {clip_geom}) AS geom {properties} FROM {schema}."{table}", bounds
   WHERE
     {geometry_column} && bounds.srid_{srid}


### PR DESCRIPTION
Postgres requires capital case Table names to be wrapped in double quotes.