### PR TITLE
Use 2021 edition, modern format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "martin"
 version = "1.0.0-alpha.0"
-edition = "2018"
+edition = "2021"
 authors = ["Stepan Kuzmin <to.stepan.kuzmin@gmail.com>"]
 description = "Blazing fast and lightweight PostGIS vector tiles server"
 repository = "https://github.com/urbica/martin/"

--- a/benches/sources.rs
+++ b/benches/sources.rs
@@ -11,7 +11,7 @@ use martin::table_source::TableSource;
 
 fn mock_table_source(schema: &str, table: &str) -> TableSource {
     TableSource {
-        id: format!("{}.{}", schema, table),
+        id: format!("{schema}.{table}"),
         schema: schema.to_owned(),
         table: table.to_owned(),
         id_column: None,
@@ -30,7 +30,7 @@ fn mock_table_source(schema: &str, table: &str) -> TableSource {
 
 fn mock_function_source(schema: &str, function: &str) -> FunctionSource {
     FunctionSource {
-        id: format!("{}.{}", schema, function),
+        id: format!("{schema}.{function}"),
         schema: schema.to_owned(),
         function: function.to_owned(),
         minzoom: None,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -177,11 +177,11 @@ fn parse_env(args: Args) -> Args {
 }
 
 fn start(args: Args) -> io::Result<actix::SystemRunner> {
-    info!("Starting martin v{}", VERSION);
+    info!("Starting martin v{VERSION}");
 
     let (config, pool) = match args.flag_config {
         Some(config_file_name) => {
-            info!("Using {}", config_file_name);
+            info!("Using {config_file_name}");
             setup_from_config(config_file_name)?
         }
         None => {
@@ -199,7 +199,7 @@ fn start(args: Args) -> io::Result<actix::SystemRunner> {
 
     let listen_addresses = config.listen_addresses.clone();
     let server = server::new(pool, config);
-    info!("Martin has been started on {}.", listen_addresses);
+    info!("Martin has been started on {listen_addresses}.");
 
     Ok(server)
 }
@@ -215,12 +215,12 @@ fn main() -> io::Result<()> {
     let args = parse_env(args);
 
     if args.flag_help {
-        println!("{}", USAGE);
+        println!("{USAGE}");
         std::process::exit(0);
     }
 
     if args.flag_version {
-        println!("v{}", VERSION);
+        println!("v{VERSION}");
         std::process::exit(0);
     }
 
@@ -235,7 +235,7 @@ fn main() -> io::Result<()> {
     let server = match start(args) {
         Ok(server) => server,
         Err(error) => {
-            error!("{}", error);
+            error!("{error}");
             std::process::exit(-1);
         }
     };

--- a/src/composite_source.rs
+++ b/src/composite_source.rs
@@ -38,14 +38,14 @@ impl CompositeSource {
             .collect::<Vec<String>>()
             .join(" || ");
 
-        format!("SELECT {} AS tile", tile_query)
+        format!("SELECT {tile_query} AS tile")
     }
 
     pub fn build_tile_query(&self, xyz: &Xyz) -> String {
         let bounds_cte = self.get_bounds_cte(xyz);
         let tile_query = self.get_tile_query(xyz);
 
-        format!("{} {}", bounds_cte, tile_query)
+        format!("{bounds_cte} {tile_query}")
     }
 
     pub fn get_minzoom(&self) -> Option<u8> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -25,7 +25,7 @@ fn make_tls_connector(
     }
 
     if let Some(ca_root_file) = ca_root_file {
-        info!("Using {} as trusted root certificate", ca_root_file);
+        info!("Using {ca_root_file} as trusted root certificate");
         builder.set_ca_file(ca_root_file)?;
     }
 
@@ -88,10 +88,7 @@ pub fn check_postgis_version(required_postgis_version: &str, pool: &Pool) -> io:
     let matches = req.matches(&version);
 
     if !matches {
-        error!(
-            "Martin requires PostGIS {}, current version is {}",
-            required_postgis_version, postgis_version
-        );
+        error!("Martin requires PostGIS {required_postgis_version}, current version is {postgis_version}");
     }
 
     Ok(matches)

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -167,10 +167,10 @@ pub fn mock_default_function_sources() -> FunctionSources {
 
 pub fn make_pool() -> Pool {
     let connection_string: String = env::var("DATABASE_URL").unwrap();
-    info!("Connecting to {}", connection_string);
+    info!("Connecting to {connection_string}");
 
     let pool = setup_connection_pool(&connection_string, &None, Some(1), false).unwrap();
-    info!("Connected to {}", connection_string);
+    info!("Connected to {connection_string}");
 
     pool
 }

--- a/src/function_source.rs
+++ b/src/function_source.rs
@@ -123,9 +123,9 @@ pub fn get_function_sources(conn: &mut Connection) -> Result<FunctionSources, io
     for row in &rows {
         let schema: String = row.get("specific_schema");
         let function: String = row.get("routine_name");
-        let id = format!("{}.{}", schema, function);
+        let id = format!("{schema}.{function}");
 
-        info!("Found {} function source", id);
+        info!("Found {id} function source");
 
         let source = FunctionSource {
             id: id.clone(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,6 +63,7 @@ struct CompositeTileRequest {
 }
 
 fn map_internal_error<T: std::fmt::Display>(e: T) -> Error {
+    // FIXME: is e.to_string() needed here, or can it just be error!("{e}")  ?
     error!("{}", e.to_string());
     error::ErrorInternalServerError(e.to_string())
 }
@@ -126,7 +127,7 @@ async fn get_composite_source(
 
     let mut tilejson = source
         .get_tilejson()
-        .map_err(|e| error::ErrorBadRequest(format!("Can't build TileJSON: {}", e)))?;
+        .map_err(|e| error::ErrorBadRequest(format!("Can't build TileJSON: {e}")))?;
 
     let tiles_path = req
         .headers()
@@ -137,13 +138,9 @@ async fn get_composite_source(
     let connection_info = req.connection_info();
 
     let path_and_query = if req.query_string().is_empty() {
-        format!("{}/{{z}}/{{x}}/{{y}}.pbf", tiles_path)
+        format!("{tiles_path}/{{z}}/{{x}}/{{y}}.pbf")
     } else {
-        format!(
-            "{}/{{z}}/{{x}}/{{y}}.pbf?{}",
-            tiles_path,
-            req.query_string()
-        )
+        format!("{tiles_path}/{{z}}/{{x}}/{{y}}.pbf?{}", req.query_string())
     };
 
     let tiles_url = Uri::builder()
@@ -152,7 +149,7 @@ async fn get_composite_source(
         .path_and_query(path_and_query)
         .build()
         .map(|tiles_url| tiles_url.to_string())
-        .map_err(|e| error::ErrorBadRequest(format!("Can't build tiles URL: {}", e)))?;
+        .map_err(|e| error::ErrorBadRequest(format!("Can't build tiles URL: {e}")))?;
 
     tilejson.tiles = vec![tiles_url];
     Ok(HttpResponse::Ok().json(tilejson))
@@ -264,7 +261,7 @@ async fn get_function_source(
 
     let mut tilejson = source
         .get_tilejson()
-        .map_err(|e| error::ErrorBadRequest(format!("Can't build TileJSON: {}", e)))?;
+        .map_err(|e| error::ErrorBadRequest(format!("Can't build TileJSON: {e}")))?;
 
     let tiles_path = req
         .headers()
@@ -275,13 +272,9 @@ async fn get_function_source(
     let connection_info = req.connection_info();
 
     let path_and_query = if req.query_string().is_empty() {
-        format!("{}/{{z}}/{{x}}/{{y}}.pbf", tiles_path)
+        format!("{tiles_path}/{{z}}/{{x}}/{{y}}.pbf")
     } else {
-        format!(
-            "{}/{{z}}/{{x}}/{{y}}.pbf?{}",
-            tiles_path,
-            req.query_string()
-        )
+        format!("{tiles_path}/{{z}}/{{x}}/{{y}}.pbf?{}", req.query_string())
     };
 
     let tiles_url = Uri::builder()
@@ -290,7 +283,7 @@ async fn get_function_source(
         .path_and_query(path_and_query)
         .build()
         .map(|tiles_url| tiles_url.to_string())
-        .map_err(|e| error::ErrorBadRequest(format!("Can't build tiles URL: {}", e)))?;
+        .map_err(|e| error::ErrorBadRequest(format!("Can't build tiles URL: {e}")))?;
 
     tilejson.tiles = vec![tiles_url];
     Ok(HttpResponse::Ok().json(tilejson))
@@ -423,7 +416,7 @@ pub fn new(pool: Pool, config: Config) -> SystemRunner {
             .configure(router)
     })
     .bind(listen_addresses.clone())
-    .unwrap_or_else(|_| panic!("Can't bind to {}", listen_addresses))
+    .unwrap_or_else(|_| panic!("Can't bind to {listen_addresses}"))
     .keep_alive(keep_alive)
     .shutdown_timeout(0)
     .workers(worker_processes)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use postgres::types::Json;
 use serde_json::Value;
 
 pub fn prettify_error<E: std::fmt::Display>(message: String) -> impl Fn(E) -> std::io::Error {
-    move |error| std::io::Error::new(std::io::ErrorKind::Other, format!("{}: {}", message, error))
+    move |error| std::io::Error::new(std::io::ErrorKind::Other, format!("{message}: {error}"))
 }
 
 // https://github.com/mapbox/postgis-vt-util/blob/master/src/TileBBox.sql

--- a/tests/function_source_test.rs
+++ b/tests/function_source_test.rs
@@ -15,7 +15,7 @@ async fn test_get_function_sources_ok() {
     let mut connection = dev::make_pool().get().unwrap();
     let function_sources = get_function_sources(&mut connection).unwrap();
 
-    log::info!("function_sources = {:#?}", function_sources);
+    log::info!("function_sources = {function_sources:#?}");
 
     assert!(!function_sources.is_empty());
     assert!(function_sources.contains_key("public.function_source"));
@@ -38,7 +38,7 @@ async fn test_function_source_tilejson_ok() {
     let function_source = function_sources.get("public.function_source").unwrap();
     let tilejson = function_source.get_tilejson().unwrap();
 
-    log::info!("tilejson = {:#?}", tilejson);
+    log::info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
     assert_eq!(tilejson.version, Some("1.0.0".to_owned()));

--- a/tests/table_source_test.rs
+++ b/tests/table_source_test.rs
@@ -17,7 +17,7 @@ async fn test_get_table_sources_ok() {
     let mut connection = dev::make_pool().get().unwrap();
     let table_sources = get_table_sources(&mut connection, &None).unwrap();
 
-    log::info!("table_sources = {:#?}", table_sources);
+    log::info!("table_sources = {table_sources:#?}");
 
     assert!(!table_sources.is_empty());
     assert!(table_sources.contains_key("public.table_source"));
@@ -51,7 +51,7 @@ async fn test_table_source_tilejson_ok() {
     let table_source = table_sources.get("public.table_source").unwrap();
     let tilejson = table_source.get_tilejson().unwrap();
 
-    log::info!("tilejson = {:#?}", tilejson);
+    log::info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
     assert_eq!(tilejson.version, Some("1.0.0".to_owned()));


### PR DESCRIPTION
* switch to 2021 rust edition
* use `format!("{var}")` instead of `"{}", var`