### PR TITLE
Optimize prettify_error function

### DIFF
--- a/src/composite_source.rs
+++ b/src/composite_source.rs
@@ -110,7 +110,7 @@ impl Source for CompositeSource {
         let tile: Tile = conn
             .query_one(tile_query.as_str(), &[])
             .map(|row| row.get("tile"))
-            .map_err(prettify_error("Can't get composite source tile".to_owned()))?;
+            .map_err(|e| prettify_error!(e, "Can't get composite source tile"))?;
 
         Ok(tile)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ pub fn read_config(file_name: &str) -> io::Result<Config> {
     file.read_to_string(&mut contents)?;
 
     let config_builder: ConfigBuilder = serde_yaml::from_str(contents.as_str())
-        .map_err(prettify_error("Can't read config file".to_owned()))?;
+        .map_err(|e| prettify_error!(e, "Can't read config file"))?;
 
     Ok(config_builder.finalize())
 }

--- a/src/function_source.rs
+++ b/src/function_source.rs
@@ -101,17 +101,22 @@ impl Source for FunctionSource {
                 &raw_query,
                 &[Type::INT4, Type::INT4, Type::INT4, Type::JSON],
             )
-            .map_err(prettify_error(
-                "Can't create prepared statement for the tile".to_owned(),
-            ))?;
+            .map_err(|e| prettify_error!(e, "Can't create prepared statement for the tile"))?;
 
         let tile = conn
             .query_one(&query, &[&xyz.x, &xyz.y, &xyz.z, &query_json])
             .map(|row| row.get(self.function.as_str()))
-            .map_err(prettify_error(format!(
-                r#"Can't get "{}" tile at /{}/{}/{} with {:?} params"#,
-                self.id, &xyz.z, &xyz.x, &xyz.z, &query_json
-            )))?;
+            .map_err(|error| {
+                prettify_error!(
+                    error,
+                    r#"Can't get "{}" tile at /{}/{}/{} with {:?} params"#,
+                    self.id,
+                    xyz.z,
+                    xyz.x,
+                    xyz.z,
+                    query_json
+                )
+            })?;
 
         Ok(tile)
     }
@@ -122,7 +127,7 @@ pub fn get_function_sources(conn: &mut Connection) -> Result<FunctionSources, io
 
     let rows = conn
         .query(include_str!("scripts/get_function_sources.sql"), &[])
-        .map_err(prettify_error("Can't get function sources".to_owned()))?;
+        .map_err(|e| prettify_error!(e, "Can't get function sources"))?;
 
     for row in &rows {
         let schema: String = row.get("specific_schema");

--- a/src/table_source.rs
+++ b/src/table_source.rs
@@ -164,10 +164,16 @@ impl Source for TableSource {
         let tile: Tile = conn
             .query_one(tile_query.as_str(), &[])
             .map(|row| row.get("st_asmvt"))
-            .map_err(utils::prettify_error(format!(
-                r#"Can't get "{}" tile at /{}/{}/{}"#,
-                self.id, &xyz.z, &xyz.x, &xyz.z
-            )))?;
+            .map_err(|error| {
+                utils::prettify_error!(
+                    error,
+                    r#"Can't get "{}" tile at /{}/{}/{}"#,
+                    self.id,
+                    xyz.z,
+                    xyz.x,
+                    xyz.z
+                )
+            })?;
 
         Ok(tile)
     }
@@ -186,7 +192,7 @@ pub fn get_table_sources(
 
     let rows = conn
         .query(include_str!("scripts/get_table_sources.sql"), &[])
-        .map_err(utils::prettify_error("Can't get table sources".to_owned()))?;
+        .map_err(|e| utils::prettify_error!(e, "Can't get table sources"))?;
 
     for row in &rows {
         let schema: String = row.get("f_table_schema");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,9 +8,18 @@ use tilejson::Bounds;
 
 use crate::source::{Query, Xyz};
 
-pub fn prettify_error<E: std::fmt::Display>(message: String) -> impl Fn(E) -> std::io::Error {
-    move |error| std::io::Error::new(std::io::ErrorKind::Other, format!("{message}: {error}"))
+#[macro_export]
+macro_rules! prettify_error {
+    ($error:ident, $info:literal) => {
+        ::std::io::Error::new(::std::io::ErrorKind::Other, format!(concat!($info, ": {}"), $error))
+    };
+    ($error:ident, $($arg:tt)+) => {
+        ::std::io::Error::new(::std::io::ErrorKind::Other,
+            format!("{}: {}", format_args!($($arg)+), $error))
+    };
 }
+
+pub(crate) use prettify_error;
 
 // https://github.com/mapbox/postgis-vt-util/blob/master/src/TileBBox.sql
 pub fn tilebbox(xyz: &Xyz) -> String {


### PR DESCRIPTION
Resolves #348 
update prettify_error to one single macro
```rust
#[macro_export]
macro_rules! prettify_error {
    ($error:ident,$info:expr,$($arg:expr),+) => {
        {
            std::io::Error::new(std::io::ErrorKind::Other,format!("{}: {}",
            format!($info,$($arg),*),
            $error))
        }
    };
    ($error:ident,$info:literal) => {
        {
            std::io::Error::new(std::io::ErrorKind::Other,format!("{}: {}",$info,$error))
        }
    }
}

pub(crate) use prettify_error;
```
