### PR TITLE
typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ map.addLayer({
 
 ## Using with MapLibre
 [MapLibre](https://maplibre.org/projects/maplibre-gl-js/) is an Open-source JavaScript library for publishing maps on your websites. Originated as an open-source fork of [mapbox-gl-js](https://www.mapbox.com/mapbox-gljs), [MapLibre](https://maplibre.org/projects/maplibre-gl-js/) is intended to be a drop-in replacement for the Mapbox’s version with additional functionality.
-Generally There is no big difference between MapLibre and [mapbox-gl-js](https://www.mapbox.com/mapbox-gljs) when coperating with Martin.
+Generally There is no big difference between MapLibre and [mapbox-gl-js](https://www.mapbox.com/mapbox-gljs) when cooperating with Martin.
 
 ```js
 map.addSource('rpc', {


### PR DESCRIPTION
This is just a quick PR that corrects `coperating` to `cooperating`.