### PR TITLE
sort use-statements during fmt

### DIFF
--- a/benches/sources.rs
+++ b/benches/sources.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 
-use criterion::Criterion;
-use criterion::{criterion_group, criterion_main};
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use martin::composite_source::CompositeSource;
 use martin::dev::make_pool;
 use martin::function_source::FunctionSource;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+## These should be enabled in the future, but for now its a manual step to simplify usage.
+## Use cargo nightly for these:    cargo +nightly fmt
+#imports_granularity = "Module"
+#group_imports = "StdExternalCrate"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,13 +2,12 @@ use std::{env, io};
 
 use docopt::Docopt;
 use log::{error, info, warn};
-use serde::Deserialize;
-
 use martin::config::{read_config, Config, ConfigBuilder};
 use martin::db::{check_postgis_version, get_connection, setup_connection_pool, Pool};
 use martin::function_source::get_function_sources;
 use martin::table_source::get_table_sources;
 use martin::{prettify_error, server};
+use serde::Deserialize;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const REQUIRED_POSTGIS_VERSION: &str = ">= 2.4.0";

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,8 +6,7 @@ use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
 use r2d2::PooledConnection;
 use r2d2_postgres::PostgresConnectionManager;
-use semver::Version;
-use semver::VersionReq;
+use semver::{Version, VersionReq};
 
 use crate::utils::prettify_error;
 

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 
 use actix_web::{http, test, App};
-use tilejson::{Bounds, TileJSON};
-
 use martin::dev;
 use martin::function_source::{FunctionSource, FunctionSources};
 use martin::server::router;
 use martin::table_source::{TableSource, TableSources};
+use tilejson::{Bounds, TileJSON};
 
 fn init() {
     let _ = env_logger::builder().is_test(true).try_init();


### PR DESCRIPTION
This does not force automatic use statement sorting,
but it sorts all them now, and we can manually keep them ordered until
the fmt features becomes stable.