### PR TITLE
[noop] Include readme code in the unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,16 @@ pub mod server;
 pub mod source;
 pub mod table_source;
 pub mod utils;
+
+// Ensure README.md contains valid code
+#[cfg(doctest)]
+mod test_readme {
+    macro_rules! external_doc_test {
+        ($x:expr) => {
+            #[doc = $x]
+            extern "C" {}
+        };
+    }
+
+    external_doc_test!(include_str!("../README.md"));
+}


### PR DESCRIPTION
This is a noop (we don't have any code in the readme at the moment), but it ensures that if any is added, it all will compile properly.