### PR TITLE
Configuration cleanup: step 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1061,7 @@ dependencies = [
  "clap 4.0.4",
  "criterion",
  "env_logger",
+ "indoc",
  "itertools",
  "log",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.8"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
 dependencies = [
  "atty",
  "bitflags",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.8"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
+checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1058,7 +1058,7 @@ dependencies = [
  "bb8",
  "bb8-postgres",
  "cargo-husky",
- "clap 4.0.8",
+ "clap 4.0.9",
  "criterion",
  "env_logger",
  "indoc",
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
  "itoa",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.4"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
 dependencies = [
  "atty",
  "bitflags",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.1"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1058,7 +1058,7 @@ dependencies = [
  "bb8",
  "bb8-postgres",
  "cargo-husky",
- "clap 4.0.4",
+ "clap 4.0.8",
  "criterion",
  "env_logger",
  "indoc",
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ serde_json = "1"
 serde_yaml = "0.9"
 tilejson = "0.3"
 
+[dev-dependencies]
+indoc = "1"
+
 [dev-dependencies.criterion]
 version = "0.4.0"
 features = ["async_futures", "async_tokio", "html_reports"]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,9 +2,9 @@ use actix_web::dev::Server;
 use clap::Parser;
 use log::{error, info, warn};
 use martin::config::{read_config, ConfigBuilder};
-use martin::pg::config as pg_config;
+use martin::pg::config::{PgArgs, PgConfigBuilder};
 use martin::pg::db::configure_db_source;
-use martin::srv::config as srv_config;
+use martin::srv::config::{SrvArgs, SrvConfigBuilder};
 use martin::srv::server;
 use std::{env, io};
 
@@ -22,9 +22,9 @@ pub struct Args {
     #[arg(short, long, hide = true)]
     pub watch: bool,
     #[command(flatten)]
-    srv: srv_config::WebServerArgs,
+    srv: SrvArgs,
     #[command(flatten)]
-    pg: pg_config::PostgreSqlArgs,
+    pg: PgArgs,
 }
 
 impl From<Args> for ConfigBuilder {
@@ -39,8 +39,8 @@ impl From<Args> for ConfigBuilder {
         }
 
         ConfigBuilder {
-            srv: srv_config::ConfigBuilder::from(args.srv),
-            pg: pg_config::ConfigBuilder::from((args.pg, args.connection)),
+            srv: SrvConfigBuilder::from(args.srv),
+            pg: PgConfigBuilder::from((args.pg, args.connection)),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,25 @@
-use crate::{pg, prettify_error, srv};
+use crate::pg::config::{PgConfig, PgConfigBuilder};
+use crate::prettify_error;
+use crate::srv::config::{SrvConfig, SrvConfigBuilder};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct Config {
     #[serde(flatten)]
-    pub srv: srv::config::Config,
+    pub srv: SrvConfig,
     #[serde(flatten)]
-    pub pg: pg::config::Config,
+    pub pg: PgConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConfigBuilder {
     #[serde(flatten)]
-    pub srv: srv::config::ConfigBuilder,
+    pub srv: SrvConfigBuilder,
     #[serde(flatten)]
-    pub pg: pg::config::ConfigBuilder,
+    pub pg: PgConfigBuilder,
 }
 
 /// Update empty option in place with a non-empty value from the second option.
@@ -52,4 +54,114 @@ pub fn read_config(file_name: &str) -> io::Result<ConfigBuilder> {
         .map_err(|e| prettify_error!(e, "Unable to read config file '{}'", file_name))?;
     serde_yaml::from_str(contents.as_str())
         .map_err(|e| prettify_error!(e, "Error parsing config file '{}'", file_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pg::function_source::FunctionSource;
+    use crate::pg::table_source::TableSource;
+    use indoc::indoc;
+    use std::collections::HashMap;
+    use tilejson::Bounds;
+
+    #[test]
+    fn parse_config() {
+        let yaml = indoc! {"
+            ---
+            connection_string: 'postgres://postgres@localhost:5432/db'
+            danger_accept_invalid_certs: false
+            default_srid: 4326
+            keep_alive: 75
+            listen_addresses: '0.0.0.0:3000'
+            pool_size: 20
+            worker_processes: 8
+
+            table_sources:
+              public.table_source:
+                id: public.table_source
+                schema: public
+                table: table_source
+                srid: 4326
+                geometry_column: geom
+                id_column: ~
+                minzoom: 0
+                maxzoom: 30
+                bounds: [-180.0, -90.0, 180.0, 90.0]
+                extent: 4096
+                buffer: 64
+                clip_geom: true
+                geometry_type: GEOMETRY
+                properties:
+                  gid: int4
+
+            function_sources:
+              public.function_source:
+                id: public.function_source
+                schema: public
+                function: function_source
+                minzoom: 0
+                maxzoom: 30
+                bounds: [-180.0, -90.0, 180.0, 90.0]
+        "};
+
+        let config: ConfigBuilder = serde_yaml::from_str(yaml).expect("parse yaml");
+        let config = config.finalize().expect("finalize");
+        let expected = Config {
+            srv: SrvConfig {
+                keep_alive: 75,
+                listen_addresses: "0.0.0.0:3000".to_string(),
+                worker_processes: 8,
+            },
+            pg: PgConfig {
+                connection_string: "postgres://postgres@localhost:5432/db".to_string(),
+                ca_root_file: None,
+                danger_accept_invalid_certs: false,
+                default_srid: Some(4326),
+                pool_size: 20,
+                use_dynamic_sources: false,
+                table_sources: HashMap::from([(
+                    "public.table_source".to_string(),
+                    Box::new(TableSource {
+                        id: "public.table_source".to_string(),
+                        schema: "public".to_string(),
+                        table: "table_source".to_string(),
+                        srid: 4326,
+                        geometry_column: "geom".to_string(),
+                        id_column: None,
+                        minzoom: Some(0),
+                        maxzoom: Some(30),
+                        bounds: Some(Bounds {
+                            left: -180.0,
+                            bottom: -90.0,
+                            right: 180.0,
+                            top: 90.0,
+                        }),
+                        extent: Some(4096),
+                        buffer: Some(64),
+                        clip_geom: Some(true),
+                        geometry_type: Some("GEOMETRY".to_string()),
+                        properties: HashMap::from([("gid".to_string(), "int4".to_string())]),
+                    }),
+                )]),
+                function_sources: HashMap::from([(
+                    "public.function_source".to_string(),
+                    Box::new(FunctionSource {
+                        id: "public.function_source".to_string(),
+                        schema: "public".to_string(),
+                        function: "function_source".to_string(),
+                        minzoom: Some(0),
+                        maxzoom: Some(30),
+                        bounds: Some(Bounds {
+                            left: -180.0,
+                            bottom: -90.0,
+                            right: 180.0,
+                            top: 90.0,
+                        }),
+                    }),
+                )]),
+            },
+        };
+        assert_eq!(config, expected);
+    }
 }

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -30,8 +30,8 @@ pub struct Config {
     pub default_srid: Option<i32>,
     pub pool_size: u32,
     pub use_dynamic_sources: bool,
-    pub table_sources: Option<TableSources>,
-    pub function_sources: Option<FunctionSources>,
+    pub table_sources: TableSources,
+    pub function_sources: FunctionSources,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -75,8 +75,8 @@ impl ConfigBuilder {
             default_srid: self.default_srid,
             pool_size: self.pool_size.unwrap_or(POOL_SIZE_DEFAULT),
             use_dynamic_sources: self.table_sources.is_none() && self.function_sources.is_none(),
-            table_sources: self.table_sources,
-            function_sources: self.function_sources,
+            table_sources: self.table_sources.unwrap_or_default(),
+            function_sources: self.function_sources.unwrap_or_default(),
         })
     }
 }

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -8,7 +8,7 @@ pub const POOL_SIZE_DEFAULT: u32 = 20;
 
 #[derive(clap::Args, Debug)]
 #[command(about, version)]
-pub struct PostgreSqlArgs {
+pub struct PgArgs {
     /// Loads trusted root certificates from a file. The file should contain a sequence of PEM-formatted CA certificates.
     #[arg(long)]
     pub ca_root_file: Option<String>,
@@ -22,8 +22,8 @@ pub struct PostgreSqlArgs {
     pub pool_size: Option<u32>,
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct Config {
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct PgConfig {
     pub connection_string: String,
     pub ca_root_file: Option<String>,
     pub danger_accept_invalid_certs: bool,
@@ -35,7 +35,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConfigBuilder {
+pub struct PgConfigBuilder {
     pub connection_string: Option<String>,
     pub ca_root_file: Option<String>,
     pub danger_accept_invalid_certs: Option<bool>,
@@ -45,8 +45,8 @@ pub struct ConfigBuilder {
     pub function_sources: Option<FunctionSources>,
 }
 
-impl ConfigBuilder {
-    pub fn merge(&mut self, other: ConfigBuilder) -> &mut Self {
+impl PgConfigBuilder {
+    pub fn merge(&mut self, other: PgConfigBuilder) -> &mut Self {
         set_option(&mut self.connection_string, other.connection_string);
         set_option(&mut self.ca_root_file, other.ca_root_file);
         set_option(
@@ -61,14 +61,14 @@ impl ConfigBuilder {
     }
 
     /// Apply defaults to the config, and validate if there is a connection string
-    pub fn finalize(self) -> io::Result<Config> {
+    pub fn finalize(self) -> io::Result<PgConfig> {
         let connection_string = self.connection_string.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::Other,
                 "Database connection string is not set",
             )
         })?;
-        Ok(Config {
+        Ok(PgConfig {
             connection_string,
             ca_root_file: self.ca_root_file,
             danger_accept_invalid_certs: self.danger_accept_invalid_certs.unwrap_or_default(),
@@ -81,9 +81,9 @@ impl ConfigBuilder {
     }
 }
 
-impl From<(PostgreSqlArgs, Option<String>)> for ConfigBuilder {
-    fn from((args, connection): (PostgreSqlArgs, Option<String>)) -> Self {
-        ConfigBuilder {
+impl From<(PgArgs, Option<String>)> for PgConfigBuilder {
+    fn from((args, connection): (PgArgs, Option<String>)) -> Self {
+        PgConfigBuilder {
             connection_string: connection.or_else(|| {
                 env::var_os("DATABASE_URL").and_then(|connection| connection.into_string().ok())
             }),

--- a/src/pg/db.rs
+++ b/src/pg/db.rs
@@ -113,14 +113,14 @@ pub async fn configure_db_source(mut config: &mut Config) -> io::Result<Pool> {
         if sources.is_empty() {
             info!("No table sources found");
         } else {
-            config.pg.table_sources = Some(sources);
+            config.pg.table_sources = sources;
         }
 
         let sources = get_function_sources(&mut connection).await?;
         if sources.is_empty() {
             info!("No function sources found");
         } else {
-            config.pg.function_sources = Some(sources);
+            config.pg.function_sources = sources;
         }
 
         "Found"
@@ -128,21 +128,17 @@ pub async fn configure_db_source(mut config: &mut Config) -> io::Result<Pool> {
         "Loaded"
     };
 
-    if let Some(table_sources) = &config.pg.table_sources {
-        for table_source in table_sources.values() {
-            info!(
-                r#"{info_prefix} "{}" table source with "{}" column ({}, SRID={})"#,
-                table_source.id,
-                table_source.geometry_column,
-                table_source.geometry_type.as_deref().unwrap_or("null"),
-                table_source.srid
-            );
-        }
+    for table_source in config.pg.table_sources.values() {
+        info!(
+            r#"{info_prefix} "{}" table source with "{}" column ({}, SRID={})"#,
+            table_source.id,
+            table_source.geometry_column,
+            table_source.geometry_type.as_deref().unwrap_or("null"),
+            table_source.srid
+        );
     }
-    if let Some(function_sources) = &config.pg.function_sources {
-        for function_source in function_sources.values() {
-            info!("{info_prefix} {} function source", function_source.id);
-        }
+    for function_source in config.pg.function_sources.values() {
+        info!("{info_prefix} {} function source", function_source.id);
     }
     Ok(pool)
 }

--- a/src/pg/dev.rs
+++ b/src/pg/dev.rs
@@ -175,7 +175,6 @@ pub async fn make_pool() -> Pool {
 pub async fn mock_state(
     table_sources: Option<TableSources>,
     function_sources: Option<FunctionSources>,
-    default_srid: Option<i32>,
 ) -> AppState {
     let pool = make_pool().await;
 
@@ -183,6 +182,5 @@ pub async fn mock_state(
         pool,
         table_sources,
         function_sources,
-        default_srid,
     }
 }

--- a/src/pg/dev.rs
+++ b/src/pg/dev.rs
@@ -180,7 +180,7 @@ pub async fn mock_state(
 
     AppState {
         pool,
-        table_sources,
-        function_sources,
+        table_sources: table_sources.unwrap_or_default(),
+        function_sources: function_sources.unwrap_or_default(),
     }
 }

--- a/src/pg/function_source.rs
+++ b/src/pg/function_source.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io;
 use tilejson::{tilejson, Bounds, TileJSON};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FunctionSource {
     // Function source id
     pub id: String,

--- a/src/pg/table_source.rs
+++ b/src/pg/table_source.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::io;
 use tilejson::{tilejson, Bounds, TileJSON};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TableSource {
     // Table source id
     pub id: String,

--- a/src/srv/config.rs
+++ b/src/srv/config.rs
@@ -7,7 +7,7 @@ pub const LISTEN_ADDRESSES_DEFAULT: &str = "0.0.0.0:3000";
 
 #[derive(clap::Args, Debug)]
 #[command(about, version)]
-pub struct WebServerArgs {
+pub struct SrvArgs {
     #[arg(help = format!("Connection keep alive timeout. [DEFAULT: {}]", KEEP_ALIVE_DEFAULT), short, long)]
     pub keep_alive: Option<usize>,
     #[arg(help = format!("The socket address to bind. [DEFAULT: {}]", LISTEN_ADDRESSES_DEFAULT), short, long)]
@@ -17,22 +17,22 @@ pub struct WebServerArgs {
     pub workers: Option<usize>,
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct Config {
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SrvConfig {
     pub keep_alive: usize,
     pub listen_addresses: String,
     pub worker_processes: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ConfigBuilder {
+pub struct SrvConfigBuilder {
     pub keep_alive: Option<usize>,
     pub listen_addresses: Option<String>,
     pub worker_processes: Option<usize>,
 }
 
-impl ConfigBuilder {
-    pub fn merge(&mut self, other: ConfigBuilder) -> &mut Self {
+impl SrvConfigBuilder {
+    pub fn merge(&mut self, other: SrvConfigBuilder) -> &mut Self {
         set_option(&mut self.keep_alive, other.keep_alive);
         set_option(&mut self.listen_addresses, other.listen_addresses);
         set_option(&mut self.worker_processes, other.worker_processes);
@@ -40,8 +40,8 @@ impl ConfigBuilder {
     }
 
     /// Apply defaults to the config, and validate if there is a connection string
-    pub fn finalize(self) -> io::Result<Config> {
-        Ok(Config {
+    pub fn finalize(self) -> io::Result<SrvConfig> {
+        Ok(SrvConfig {
             keep_alive: self.keep_alive.unwrap_or(KEEP_ALIVE_DEFAULT),
             listen_addresses: self
                 .listen_addresses
@@ -51,9 +51,9 @@ impl ConfigBuilder {
     }
 }
 
-impl From<WebServerArgs> for ConfigBuilder {
-    fn from(args: WebServerArgs) -> Self {
-        ConfigBuilder {
+impl From<SrvArgs> for SrvConfigBuilder {
+    fn from(args: SrvArgs) -> Self {
+        SrvConfigBuilder {
             keep_alive: args.keep_alive,
             listen_addresses: args.listen_addresses,
             worker_processes: args.workers,

--- a/src/srv/server.rs
+++ b/src/srv/server.rs
@@ -264,7 +264,7 @@ async fn get_tile(
     match tile.len() {
         0 => Ok(HttpResponse::NoContent()
             .content_type("application/x-protobuf")
-            .body(tile)),
+            .finish()),
         _ => Ok(HttpResponse::Ok()
             .content_type("application/x-protobuf")
             .body(tile)),

--- a/src/srv/server.rs
+++ b/src/srv/server.rs
@@ -23,7 +23,6 @@ pub struct AppState {
     pub pool: Pool,
     pub table_sources: Option<TableSources>,
     pub function_sources: Option<FunctionSources>,
-    pub default_srid: Option<i32>,
 }
 
 #[derive(Deserialize)]
@@ -290,7 +289,6 @@ fn create_state(pool: Pool, config: Config) -> AppState {
         pool,
         table_sources: config.pg.table_sources,
         function_sources: config.pg.function_sources,
-        default_srid: config.pg.default_srid,
     }
 }
 

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -16,7 +16,7 @@ fn init() {
 async fn test_get_table_sources_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get().uri("/index.json").to_request();
@@ -32,7 +32,7 @@ async fn test_get_table_sources_ok() {
 async fn test_get_table_sources_watch_mode_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get().uri("/index.json").to_request();
@@ -65,12 +65,7 @@ async fn test_get_table_source_ok() {
         properties: HashMap::new(),
     };
 
-    let state = dev::mock_state(
-        Some(dev::mock_table_sources(vec![table_source])),
-        None,
-        None,
-    )
-    .await;
+    let state = dev::mock_state(Some(dev::mock_table_sources(vec![table_source])), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -104,7 +99,7 @@ async fn test_get_table_source_ok() {
 async fn test_get_table_source_tile_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -126,7 +121,7 @@ async fn test_get_table_source_tile_ok() {
 async fn test_get_table_source_multiple_geom_tile_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -223,7 +218,6 @@ async fn test_get_table_source_tile_minmax_zoom_ok() {
             points3857,
             table_source,
         ])),
-        None,
         None,
     )
     .await;
@@ -331,7 +325,7 @@ async fn test_get_table_source_tile_minmax_zoom_ok() {
 async fn test_get_composite_source_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -353,7 +347,7 @@ async fn test_get_composite_source_ok() {
 async fn test_get_composite_source_tile_ok() {
     init();
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None, None).await;
+    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -414,7 +408,6 @@ async fn test_get_composite_source_tile_minmax_zoom_ok() {
             public_points1,
             public_points2,
         ])),
-        None,
         None,
     )
     .await;
@@ -481,7 +474,7 @@ async fn test_get_composite_source_tile_minmax_zoom_ok() {
 async fn test_get_function_sources_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get().uri("/rpc/index.json").to_request();
@@ -497,7 +490,7 @@ async fn test_get_function_sources_ok() {
 async fn test_get_function_sources_watch_mode_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get().uri("/rpc/index.json").to_request();
@@ -513,7 +506,7 @@ async fn test_get_function_sources_watch_mode_ok() {
 async fn test_get_function_source_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -550,7 +543,7 @@ async fn test_get_function_source_ok() {
 async fn test_get_function_source_tile_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -589,7 +582,6 @@ async fn test_get_function_source_tile_minmax_zoom_ok() {
             function_source1,
             function_source2,
         ])),
-        None,
     )
     .await;
 
@@ -664,7 +656,7 @@ async fn test_get_function_source_tile_minmax_zoom_ok() {
 async fn test_get_function_source_query_params_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get()
@@ -687,7 +679,7 @@ async fn test_get_function_source_query_params_ok() {
 async fn test_get_health_returns_ok() {
     init();
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources()), None).await;
+    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
     let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
 
     let req = test::TestRequest::get().uri("/healthz").to_request();


### PR DESCRIPTION
A few minor simplifications in the config and appstate:

* default srid seems to be unused.
* simplify Config struct to have non-optional table and function sources. Ok to be empty.
* add a parsing unit test
* rename configs to distinct names for simplicity

I am making this as a separate PR to keep things easier -- the big upcoming PR will use a dynamic dispatch system for all types of sources