### PR TITLE
Vendor openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/lib.rs"
 name = "martin"
 path = "src/bin/main.rs"
 
+[features]
+vendored-openssl = ['openssl/vendored']
+
 [dependencies]
 actix = "0.13"
 actix-cors = "0.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM rust:alpine as builder
 
 RUN apk update
-RUN apk add --no-cache openssl-dev musl-dev
+RUN apk add --no-cache openssl-dev musl-dev perl build-base
 
 WORKDIR /usr/src/martin
 ADD . .
-RUN cargo build --release
+RUN cargo build --release --features=vendored-openssl
 
 
 FROM alpine:latest


### PR DESCRIPTION
Fixes #423 

The alpine packages `perl ` and `build-base` are needed to build openssl from source.