### PR TITLE
Mostly noop code refactorings

### DIFF
--- a/benches/sources.rs
+++ b/benches/sources.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-
 use criterion::{criterion_group, criterion_main, Criterion};
-use martin::pg;
 use martin::pg::composite_source::CompositeSource;
+use martin::pg::dev::make_pool;
 use martin::pg::function_source::FunctionSource;
 use martin::pg::table_source::TableSource;
 use martin::source::{Source, Xyz};
+use std::collections::HashMap;
 
 fn mock_table_source(schema: &str, table: &str) -> TableSource {
     TableSource {
@@ -43,7 +42,7 @@ async fn get_table_source() {
 }
 
 async fn get_table_source_tile() {
-    let pool = pg::dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
 
     let source = mock_table_source("public", "table_source");
@@ -65,7 +64,7 @@ async fn get_composite_source() {
 }
 
 async fn get_composite_source_tile() {
-    let pool = pg::dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
 
     let points1 = mock_table_source("public", "points1");
@@ -86,7 +85,7 @@ async fn get_function_source() {
 }
 
 async fn get_function_source_tile() {
-    let pool = pg::dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
 
     let source = mock_function_source("public", "function_source");
@@ -103,14 +102,14 @@ fn table_source(c: &mut Criterion) {
 fn composite_source(c: &mut Criterion) {
     c.bench_function("get_composite_source", |b| b.iter(get_composite_source));
     c.bench_function("get_composite_source_tile", |b| {
-        b.iter(get_composite_source_tile)
+        b.iter(get_composite_source_tile);
     });
 }
 
 fn function_source(c: &mut Criterion) {
     c.bench_function("get_function_source", |b| b.iter(get_function_source));
     c.bench_function("get_function_source_tile", |b| {
-        b.iter(get_function_source_tile)
+        b.iter(get_function_source_tile);
     });
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use log::{error, info, warn};
 use martin::config::{read_config, ConfigBuilder};
 use martin::pg::config::{PgArgs, PgConfigBuilder};
-use martin::pg::db::configure_db_source;
+use martin::pg::db::configure_db_sources;
 use martin::srv::config::{SrvArgs, SrvConfigBuilder};
 use martin::srv::server;
 use std::{env, io};
@@ -59,7 +59,7 @@ async fn start(args: Args) -> io::Result<Server> {
         ConfigBuilder::from(args).finalize()?
     };
 
-    let pool = configure_db_source(&mut config).await?;
+    let pool = configure_db_sources(&mut config).await?;
     let listen_addresses = config.srv.listen_addresses.clone();
     let server = server::new(pool, config);
 

--- a/src/pg/composite_source.rs
+++ b/src/pg/composite_source.rs
@@ -1,7 +1,7 @@
 use crate::pg::db::Connection;
 use crate::pg::table_source::TableSource;
 use crate::pg::utils::{get_bounds_cte, get_srid_bounds, prettify_error};
-use crate::source::{Query, Source, Tile, Xyz};
+use crate::source::{Source, Tile, UrlQuery, Xyz};
 use async_trait::async_trait;
 use itertools::Itertools;
 use std::io;
@@ -99,7 +99,7 @@ impl Source for CompositeSource {
         &self,
         conn: &mut Connection,
         xyz: &Xyz,
-        _query: &Option<Query>,
+        _query: &Option<UrlQuery>,
     ) -> Result<Tile, io::Error> {
         let tile_query = self.build_tile_query(xyz);
 

--- a/src/pg/db.rs
+++ b/src/pg/db.rs
@@ -93,7 +93,7 @@ async fn validate_postgis_version(pool: &Pool) -> io::Result<()> {
     }
 }
 
-pub async fn configure_db_source(mut config: &mut Config) -> io::Result<Pool> {
+pub async fn configure_db_sources(mut config: &mut Config) -> io::Result<Pool> {
     info!("Connecting to database");
     let pool = setup_connection_pool(
         &config.pg.connection_string,

--- a/src/pg/dev.rs
+++ b/src/pg/dev.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 use std::env;
 use tilejson::Bounds;
 
-pub fn mock_table_sources(sources: Vec<TableSource>) -> TableSources {
+pub fn mock_table_sources(sources: &[TableSource]) -> TableSources {
     let mut table_sources: TableSources = HashMap::new();
     for source in sources {
-        table_sources.insert(source.id.clone(), Box::new(source));
+        table_sources.insert(source.id.clone(), Box::new(source.clone()));
     }
 
     table_sources
@@ -40,15 +40,9 @@ pub fn mock_default_table_sources() -> TableSources {
         table: "table_source_multiple_geom".to_owned(),
         id_column: None,
         geometry_column: "geom1".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        ..table_source
     };
 
     let table_source_multiple_geom2 = TableSource {
@@ -57,15 +51,9 @@ pub fn mock_default_table_sources() -> TableSources {
         table: "table_source_multiple_geom".to_owned(),
         id_column: None,
         geometry_column: "geom2".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        ..table_source
     };
 
     let table_source1 = TableSource {
@@ -74,15 +62,9 @@ pub fn mock_default_table_sources() -> TableSources {
         table: "points1".to_owned(),
         id_column: None,
         geometry_column: "geom".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        ..table_source
     };
 
     let table_source2 = TableSource {
@@ -91,15 +73,9 @@ pub fn mock_default_table_sources() -> TableSources {
         table: "points2".to_owned(),
         id_column: None,
         geometry_column: "geom".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        ..table_source
     };
 
     let table_source3857 = TableSource {
@@ -108,18 +84,13 @@ pub fn mock_default_table_sources() -> TableSources {
         table: "points3857".to_owned(),
         id_column: None,
         geometry_column: "geom".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
         srid: 3857,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        ..table_source
     };
 
-    mock_table_sources(vec![
+    mock_table_sources(&[
         table_source,
         table_source_multiple_geom1,
         table_source_multiple_geom2,
@@ -129,10 +100,10 @@ pub fn mock_default_table_sources() -> TableSources {
     ])
 }
 
-pub fn mock_function_sources(sources: Vec<FunctionSource>) -> FunctionSources {
+pub fn mock_function_sources(sources: &[FunctionSource]) -> FunctionSources {
     let mut function_sources: FunctionSources = HashMap::new();
     for source in sources {
-        function_sources.insert(source.id.clone(), Box::new(source));
+        function_sources.insert(source.id.clone(), Box::new(source.clone()));
     }
 
     function_sources
@@ -152,12 +123,10 @@ pub fn mock_default_function_sources() -> FunctionSources {
         id: "public.function_source_query_params".to_owned(),
         schema: "public".to_owned(),
         function: "function_source_query_params".to_owned(),
-        minzoom: Some(0),
-        maxzoom: Some(30),
-        bounds: Some(Bounds::MAX),
+        ..function_source
     };
 
-    mock_function_sources(vec![function_source, function_source_query_params])
+    mock_function_sources(&[function_source, function_source_query_params])
 }
 
 pub async fn make_pool() -> Pool {

--- a/src/pg/function_source.rs
+++ b/src/pg/function_source.rs
@@ -1,6 +1,6 @@
 use crate::pg::db::Connection;
 use crate::pg::utils::{prettify_error, query_to_json};
-use crate::source::{Query, Source, Tile, Xyz};
+use crate::source::{Source, Tile, UrlQuery, Xyz};
 use async_trait::async_trait;
 use postgres::types::Type;
 use postgres_protocol::escape::escape_identifier;
@@ -71,7 +71,7 @@ impl Source for FunctionSource {
         &self,
         conn: &mut Connection,
         xyz: &Xyz,
-        query: &Option<Query>,
+        query: &Option<UrlQuery>,
     ) -> Result<Tile, io::Error> {
         let empty_query = HashMap::new();
         let query = query.as_ref().unwrap_or(&empty_query);

--- a/src/pg/function_source.rs
+++ b/src/pg/function_source.rs
@@ -11,26 +11,26 @@ use tilejson::{tilejson, Bounds, TileJSON};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FunctionSource {
-    // Function source id
+    /// Function source id
     pub id: String,
-    // Schema name
+    /// Schema name
     pub schema: String,
 
-    // Function name
+    /// Function name
     pub function: String,
 
-    // An integer specifying the minimum zoom level
+    /// An integer specifying the minimum zoom level
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minzoom: Option<u8>,
 
-    // An integer specifying the maximum zoom level. MUST be >= minzoom
+    /// An integer specifying the maximum zoom level. MUST be >= minzoom
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maxzoom: Option<u8>,
 
-    // The maximum extent of available map tiles. Bounds MUST define an area
-    // covered by all zoom levels. The bounds are represented in WGS:84
-    // latitude and longitude values, in the order left, bottom, right, top.
-    // Values may be integers or floating point numbers.
+    /// The maximum extent of available map tiles. Bounds MUST define an area
+    /// covered by all zoom levels. The bounds are represented in WGS:84
+    /// latitude and longitude values, in the order left, bottom, right, top.
+    /// Values may be integers or floating point numbers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
 }
@@ -75,7 +75,6 @@ impl Source for FunctionSource {
     ) -> Result<Tile, io::Error> {
         let empty_query = HashMap::new();
         let query = query.as_ref().unwrap_or(&empty_query);
-
         let query_json = query_to_json(query);
 
         // Query preparation : the schema and function can't be part of a prepared query, so they

--- a/src/pg/table_source.rs
+++ b/src/pg/table_source.rs
@@ -258,12 +258,12 @@ pub async fn get_table_sources(
     }
 
     if !duplicate_source_ids.is_empty() {
-        let sources = duplicate_source_ids
+        let source_list = duplicate_source_ids
             .into_iter()
             .collect::<Vec<String>>()
             .join(", ");
 
-        warn!("These table sources have multiple geometry columns: {sources}");
+        warn!("These table sources have multiple geometry columns: {source_list}");
         warn!(
             r#"You can specify the geometry column in the table source name to access particular geometry in vector tile, eg. "schema_name.table_name.geometry_column""#,
         );

--- a/src/pg/table_source.rs
+++ b/src/pg/table_source.rs
@@ -3,7 +3,7 @@ use crate::pg::utils::{
     get_bounds_cte, get_source_bounds, get_srid_bounds, json_to_hashmap, polygon_to_bbox,
     prettify_error, tile_bbox,
 };
-use crate::source::{Query, Source, Tile, Xyz};
+use crate::source::{Source, Tile, UrlQuery, Xyz};
 use async_trait::async_trait;
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -160,7 +160,7 @@ impl Source for TableSource {
         &self,
         conn: &mut Connection,
         xyz: &Xyz,
-        _query: &Option<Query>,
+        _query: &Option<UrlQuery>,
     ) -> Result<Tile, io::Error> {
         let tile_query = self.build_tile_query(xyz);
 

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -1,6 +1,6 @@
 use crate::source::{Query, Xyz};
 use actix_http::header::HeaderValue;
-use actix_web::http;
+use actix_web::http::Uri;
 use postgis::{ewkb, LineString, Point, Polygon};
 use postgres::types::Json;
 use serde_json::Value;
@@ -88,7 +88,7 @@ pub fn get_source_bounds(id: &str, srid: u32, geometry_column: &str) -> String {
     )
 }
 
-pub fn polygon_to_bbox(polygon: ewkb::Polygon) -> Option<Bounds> {
+pub fn polygon_to_bbox(polygon: &ewkb::Polygon) -> Option<Bounds> {
     polygon.rings().next().and_then(|linestring| {
         let mut points = linestring.points();
         if let (Some(bottom_left), Some(top_right)) = (points.next(), points.nth(1)) {
@@ -108,6 +108,6 @@ pub fn parse_x_rewrite_url(header: &HeaderValue) -> Option<String> {
     header
         .to_str()
         .ok()
-        .and_then(|header| header.parse::<http::Uri>().ok())
+        .and_then(|header| header.parse::<Uri>().ok())
         .map(|uri| uri.path().trim_end_matches(".json").to_owned())
 }

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -1,4 +1,4 @@
-use crate::source::{Query, Xyz};
+use crate::source::{UrlQuery, Xyz};
 use actix_http::header::HeaderValue;
 use actix_web::http::Uri;
 use postgis::{ewkb, LineString, Point, Polygon};
@@ -52,7 +52,7 @@ pub fn json_to_hashmap(value: &serde_json::Value) -> HashMap<String, String> {
     hashmap
 }
 
-pub fn query_to_json(query: &Query) -> Json<HashMap<String, Value>> {
+pub fn query_to_json(query: &UrlQuery) -> Json<HashMap<String, Value>> {
     let mut query_as_json = HashMap::new();
     for (k, v) in query.iter() {
         let json_value: serde_json::Value =

--- a/src/source.rs
+++ b/src/source.rs
@@ -6,7 +6,7 @@ use std::io;
 use tilejson::TileJSON;
 
 pub type Tile = Vec<u8>;
-pub type Query = HashMap<String, String>;
+pub type UrlQuery = HashMap<String, String>;
 
 #[derive(Copy, Clone)]
 pub struct Xyz {
@@ -25,6 +25,6 @@ pub trait Source: Debug {
         &self,
         conn: &mut Connection,
         xyz: &Xyz,
-        query: &Option<Query>,
+        query: &Option<UrlQuery>,
     ) -> Result<Tile, io::Error>;
 }

--- a/tests/function_source_test.rs
+++ b/tests/function_source_test.rs
@@ -1,4 +1,5 @@
-use martin::pg::dev;
+use log::info;
+use martin::pg::dev::make_pool;
 use martin::pg::function_source::get_function_sources;
 use martin::source::{Source, Xyz};
 
@@ -7,14 +8,14 @@ fn init() {
 }
 
 #[actix_rt::test]
-async fn test_get_function_sources_ok() {
+async fn get_function_sources_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 
-    log::info!("function_sources = {function_sources:#?}");
+    info!("function_sources = {function_sources:#?}");
 
     assert!(!function_sources.is_empty());
     assert!(function_sources.contains_key("public.function_source"));
@@ -28,17 +29,17 @@ async fn test_get_function_sources_ok() {
 }
 
 #[actix_rt::test]
-async fn test_function_source_tilejson_ok() {
+async fn function_source_tilejson_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 
     let function_source = function_sources.get("public.function_source").unwrap();
     let tilejson = function_source.get_tilejson().await.unwrap();
 
-    log::info!("tilejson = {tilejson:#?}");
+    info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
     assert_eq!(tilejson.version, Some("1.0.0".to_owned()));
@@ -51,10 +52,10 @@ async fn test_function_source_tilejson_ok() {
 }
 
 #[actix_rt::test]
-async fn test_function_source_tile_ok() {
+async fn function_source_tile_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -1,53 +1,65 @@
-use std::collections::HashMap;
-
-use actix_web::web::Data;
-use actix_web::{http, test, App};
-use martin::pg::dev;
+use actix_http::Request;
+use actix_web::http::StatusCode;
+use actix_web::test::{call_and_read_body_json, call_service, read_body, TestRequest};
+use martin::pg::dev::{
+    mock_default_function_sources, mock_default_table_sources, mock_function_sources, mock_state,
+    mock_table_sources,
+};
 use martin::pg::function_source::{FunctionSource, FunctionSources};
 use martin::pg::table_source::{TableSource, TableSources};
-use martin::srv::server::router;
+use std::collections::HashMap;
 use tilejson::{Bounds, TileJSON};
 
 fn init() {
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
+macro_rules! create_app {
+    ($tables:expr, $functions:expr) => {{
+        init();
+        let state = mock_state($tables, $functions).await;
+        let data = ::actix_web::web::Data::new(state);
+        ::actix_web::test::init_service(
+            ::actix_web::App::new()
+                .app_data(data)
+                .configure(::martin::srv::server::router),
+        )
+        .await
+    }};
+}
+
+fn test_get(path: &str) -> Request {
+    TestRequest::get().uri(path).to_request()
+}
+
 #[actix_rt::test]
-async fn test_get_table_sources_ok() {
-    init();
+async fn get_table_sources_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get().uri("/index.json").to_request();
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/index.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let body = test::read_body(response).await;
+    let body = read_body(response).await;
     let table_sources: TableSources = serde_json::from_slice(&body).unwrap();
     assert!(table_sources.contains_key("public.table_source"));
 }
 
 #[actix_rt::test]
-async fn test_get_table_sources_watch_mode_ok() {
-    init();
+async fn get_table_sources_watch_mode_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get().uri("/index.json").to_request();
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/index.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let body = test::read_body(response).await;
+    let body = read_body(response).await;
     let table_sources: TableSources = serde_json::from_slice(&body).unwrap();
     assert!(table_sources.contains_key("public.table_source"));
 }
 
 #[actix_rt::test]
-async fn test_get_table_source_ok() {
-    init();
-
+async fn get_table_source_ok() {
     let table_source = TableSource {
         id: "public.table_source".to_owned(),
         schema: "public".to_owned(),
@@ -65,26 +77,20 @@ async fn test_get_table_source_ok() {
         properties: HashMap::new(),
     };
 
-    let state = dev::mock_state(Some(dev::mock_table_sources(vec![table_source])), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let app = create_app!(Some(mock_table_sources(&[table_source])), None);
 
-    let req = test::TestRequest::get()
-        .uri("/public.non_existant.json")
-        .to_request();
+    let req = test_get("/public.non_existent.json");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-
-    let req = test::TestRequest::get()
+    let req = TestRequest::get()
         .uri("/public.table_source.json?token=martin")
         .insert_header((
             "x-rewrite-url",
             "/tiles/public.table_source.json?token=martin",
         ))
         .to_request();
-
-    let result: TileJSON = test::call_and_read_body_json(&app, req).await;
-
+    let result: TileJSON = call_and_read_body_json(&app, req).await;
     assert_eq!(result.name, Some(String::from("public.table_source")));
     assert_eq!(
         result.tiles,
@@ -96,103 +102,34 @@ async fn test_get_table_source_ok() {
 }
 
 #[actix_rt::test]
-async fn test_get_table_source_tile_ok() {
-    init();
+async fn get_table_source_tile_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let req = test_get("/public.non_existent/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let req = test::TestRequest::get()
-        .uri("/public.non_existant/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-
-    let req = test::TestRequest::get()
-        .uri("/public.table_source/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.table_source/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_table_source_multiple_geom_tile_ok() {
-    init();
+async fn get_table_source_multiple_geom_tile_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get()
-        .uri("/public.table_source_multiple_geom.geom1/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.table_source_multiple_geom.geom1/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let req = test::TestRequest::get()
-        .uri("/public.table_source_multiple_geom.geom2/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.table_source_multiple_geom.geom2/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_table_source_tile_minmax_zoom_ok() {
+async fn get_table_source_tile_minmax_zoom_ok() {
     init();
-
-    let points1 = TableSource {
-        id: "public.points1".to_owned(),
-        schema: "public".to_owned(),
-        table: "points1".to_owned(),
-        id_column: None,
-        geometry_column: "geom".to_owned(),
-        bounds: Some(Bounds::MAX),
-        minzoom: Some(6),
-        maxzoom: Some(12),
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
-        geometry_type: None,
-        properties: HashMap::new(),
-    };
-
-    let points2 = TableSource {
-        id: "public.points2".to_owned(),
-        schema: "public".to_owned(),
-        table: "points2".to_owned(),
-        id_column: None,
-        geometry_column: "geom".to_owned(),
-        bounds: Some(Bounds::MAX),
-        minzoom: None,
-        maxzoom: None,
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
-        geometry_type: None,
-        properties: HashMap::new(),
-    };
-
-    let points3857 = TableSource {
-        id: "public.points3857".to_owned(),
-        schema: "public".to_owned(),
-        table: "points3857".to_owned(),
-        id_column: None,
-        geometry_column: "geom".to_owned(),
-        bounds: Some(Bounds::MAX),
-        minzoom: Some(6),
-        maxzoom: None,
-        srid: 4326,
-        extent: Some(4096),
-        buffer: Some(64),
-        clip_geom: Some(true),
-        geometry_type: None,
-        properties: HashMap::new(),
-    };
 
     let table_source = TableSource {
         id: "public.table_source".to_owned(),
@@ -211,162 +148,137 @@ async fn test_get_table_source_tile_minmax_zoom_ok() {
         properties: HashMap::new(),
     };
 
-    let state = dev::mock_state(
-        Some(dev::mock_table_sources(vec![
-            points1,
-            points2,
-            points3857,
-            table_source,
-        ])),
-        None,
-    )
-    .await;
+    let points1 = TableSource {
+        id: "public.points1".to_owned(),
+        schema: "public".to_owned(),
+        table: "points1".to_owned(),
+        id_column: None,
+        geometry_column: "geom".to_owned(),
+        minzoom: Some(6),
+        maxzoom: Some(12),
+        geometry_type: None,
+        properties: HashMap::new(),
+        ..table_source
+    };
 
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let points2 = TableSource {
+        id: "public.points2".to_owned(),
+        schema: "public".to_owned(),
+        table: "points2".to_owned(),
+        id_column: None,
+        geometry_column: "geom".to_owned(),
+        minzoom: None,
+        maxzoom: None,
+        geometry_type: None,
+        properties: HashMap::new(),
+        ..table_source
+    };
+
+    let points3857 = TableSource {
+        id: "public.points3857".to_owned(),
+        schema: "public".to_owned(),
+        table: "points3857".to_owned(),
+        id_column: None,
+        geometry_column: "geom".to_owned(),
+        minzoom: Some(6),
+        maxzoom: None,
+        geometry_type: None,
+        properties: HashMap::new(),
+        ..table_source
+    };
+
+    let tables = &[points1, points2, points3857, table_source];
+    let app = create_app!(Some(mock_table_sources(tables)), None);
 
     // zoom = 0 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.points1/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.points1/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // zoom = 6 (public.points1)
-    let req = test::TestRequest::get()
-        .uri("/public.points1/6/38/20.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1/6/38/20.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (public.points1)
-    let req = test::TestRequest::get()
-        .uri("/public.points1/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 13 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.points1/13/4952/2560.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.points1/13/4952/2560.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // zoom = 0 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points2/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points2/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 6 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points2/6/38/20.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points2/6/38/20.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points2/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points2/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 13 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points2/13/4952/2560.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points2/13/4952/2560.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 0 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.points3857/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.points3857/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // zoom = 12 (public.points3857)
-    let req = test::TestRequest::get()
-        .uri("/public.points3857/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points3857/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 0 (public.table_source)
-    let req = test::TestRequest::get()
-        .uri("/public.table_source/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.table_source/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.table_source/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.table_source/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[actix_rt::test]
-async fn test_get_composite_source_ok() {
-    init();
+async fn get_composite_source_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let req = test_get("/public.non_existent1,public.non_existent2.json");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let req = test::TestRequest::get()
-        .uri("/public.non_existant1,public.non_existant2.json")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2,public.points3857.json")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2,public.points3857.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_composite_source_tile_ok() {
-    init();
+async fn get_composite_source_tile_ok() {
+    let app = create_app!(Some(mock_default_table_sources()), None);
 
-    let state = dev::mock_state(Some(dev::mock_default_table_sources()), None).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let req = test_get("/public.non_existent1,public.non_existent2/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let req = test::TestRequest::get()
-        .uri("/public.non_existant1,public.non_existant2/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2,public.points3857/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2,public.points3857/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_composite_source_tile_minmax_zoom_ok() {
+async fn get_composite_source_tile_minmax_zoom_ok() {
     init();
 
     let public_points1 = TableSource {
@@ -403,136 +315,91 @@ async fn test_get_composite_source_tile_minmax_zoom_ok() {
         properties: HashMap::new(),
     };
 
-    let state = dev::mock_state(
-        Some(dev::mock_table_sources(vec![
-            public_points1,
-            public_points2,
-        ])),
-        None,
-    )
-    .await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let tables = &[public_points1, public_points2];
+    let app = create_app!(Some(mock_table_sources(tables)), None);
 
     // zoom = 0 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.points1,public.points2/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // zoom = 6 (public.points1)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/6/38/20.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2/6/38/20.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (public.points1)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 13 (public.points1, public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/13/4952/2560.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2/13/4952/2560.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 14 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/14/9904/5121.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2/14/9904/5121.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 20 (public.points2)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/20/633856/327787.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/public.points1,public.points2/20/633856/327787.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 21 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/public.points1,public.points2/21/1267712/655574.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/public.points1,public.points2/21/1267712/655574.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[actix_rt::test]
-async fn test_get_function_sources_ok() {
-    init();
+async fn get_function_sources_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get().uri("/rpc/index.json").to_request();
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/index.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let body = test::read_body(response).await;
+    let body = read_body(response).await;
     let function_sources: FunctionSources = serde_json::from_slice(&body).unwrap();
     assert!(function_sources.contains_key("public.function_source"));
 }
 
 #[actix_rt::test]
-async fn test_get_function_sources_watch_mode_ok() {
-    init();
+async fn get_function_sources_watch_mode_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get().uri("/rpc/index.json").to_request();
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/index.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let body = test::read_body(response).await;
+    let body = read_body(response).await;
     let function_sources: FunctionSources = serde_json::from_slice(&body).unwrap();
     assert!(function_sources.contains_key("public.function_source"));
 }
 
 #[actix_rt::test]
-async fn test_get_function_source_ok() {
-    init();
+async fn get_function_source_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let req = test_get("/rpc/public.non_existent.json");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.non_existant.json")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source.json")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source.json");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
-    let req = test::TestRequest::get()
+    let req = TestRequest::get()
         .uri("/rpc/public.function_source.json?token=martin")
         .insert_header((
             "x-rewrite-url",
             "/tiles/rpc/public.function_source.json?token=martin",
         ))
         .to_request();
-
-    let result: TileJSON = test::call_and_read_body_json(&app, req).await;
-
+    let result: TileJSON = call_and_read_body_json(&app, req).await;
     assert_eq!(
         result.tiles,
         vec!["http://localhost:8080/tiles/rpc/public.function_source/{z}/{x}/{y}.pbf?token=martin"]
@@ -540,24 +407,16 @@ async fn test_get_function_source_ok() {
 }
 
 #[actix_rt::test]
-async fn test_get_function_source_tile_ok() {
-    init();
+async fn get_function_source_tile_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_function_source_tile_minmax_zoom_ok() {
-    init();
-
+async fn get_function_source_tile_minmax_zoom_ok() {
     let function_source1 = FunctionSource {
         id: "public.function_source1".to_owned(),
         schema: "public".to_owned(),
@@ -576,113 +435,69 @@ async fn test_get_function_source_tile_minmax_zoom_ok() {
         bounds: Some(Bounds::MAX),
     };
 
-    let state = dev::mock_state(
-        None,
-        Some(dev::mock_function_sources(vec![
-            function_source1,
-            function_source2,
-        ])),
-    )
-    .await;
-
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
+    let funcs = &[function_source1, function_source2];
+    let app = create_app!(None, Some(mock_function_sources(funcs)));
 
     // zoom = 0 (public.function_source1)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source1/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source1/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 6 (public.function_source1)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source1/6/38/20.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source1/6/38/20.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (public.function_source1)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source1/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source1/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 13 (public.function_source1)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source1/13/4952/2560.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source1/13/4952/2560.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 0 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source2/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/rpc/public.function_source2/0/0/0.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // zoom = 6 (public.function_source2)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source2/6/38/20.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source2/6/38/20.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 12 (public.function_source2)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source2/12/2476/1280.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source2/12/2476/1280.pbf");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 
     // zoom = 13 (nothing)
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source2/13/4952/2560.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
-    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    let req = test_get("/rpc/public.function_source2/13/4952/2560.pbf");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[actix_rt::test]
-async fn test_get_function_source_query_params_ok() {
-    init();
+async fn get_function_source_query_params_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source_query_params/0/0/0.pbf")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source_query_params/0/0/0.pbf");
+    let response = call_service(&app, req).await;
     println!("response.status = {:?}", response.status());
     assert!(response.status().is_server_error());
 
-    let req = test::TestRequest::get()
-        .uri("/rpc/public.function_source_query_params/0/0/0.pbf?token=martin")
-        .to_request();
-
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/rpc/public.function_source_query_params/0/0/0.pbf?token=martin");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }
 
 #[actix_rt::test]
-async fn test_get_health_returns_ok() {
-    init();
+async fn get_health_returns_ok() {
+    let app = create_app!(None, Some(mock_default_function_sources()));
 
-    let state = dev::mock_state(None, Some(dev::mock_default_function_sources())).await;
-    let app = test::init_service(App::new().app_data(Data::new(state)).configure(router)).await;
-
-    let req = test::TestRequest::get().uri("/healthz").to_request();
-    let response = test::call_service(&app, req).await;
+    let req = test_get("/healthz");
+    let response = call_service(&app, req).await;
     assert!(response.status().is_success());
 }

--- a/tests/table_source_test.rs
+++ b/tests/table_source_test.rs
@@ -1,22 +1,22 @@
-use std::collections::HashMap;
-
-use martin::pg::dev;
+use log::info;
+use martin::pg::dev::make_pool;
 use martin::pg::table_source::get_table_sources;
 use martin::source::{Source, Xyz};
+use std::collections::HashMap;
 
 fn init() {
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
 #[actix_rt::test]
-async fn test_get_table_sources_ok() {
+async fn get_table_sources_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
-    log::info!("table_sources = {table_sources:#?}");
+    info!("table_sources = {table_sources:#?}");
 
     assert!(!table_sources.is_empty());
     assert!(table_sources.contains_key("public.table_source"));
@@ -41,17 +41,17 @@ async fn test_get_table_sources_ok() {
 }
 
 #[actix_rt::test]
-async fn test_table_source_tilejson_ok() {
+async fn table_source_tilejson_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
     let table_source = table_sources.get("public.table_source").unwrap();
     let tilejson = table_source.get_tilejson().await.unwrap();
 
-    log::info!("tilejson = {tilejson:#?}");
+    info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
     assert_eq!(tilejson.version, Some("1.0.0".to_owned()));
@@ -64,10 +64,10 @@ async fn test_table_source_tilejson_ok() {
 }
 
 #[actix_rt::test]
-async fn test_table_source_tile_ok() {
+async fn table_source_tile_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
@@ -81,12 +81,12 @@ async fn test_table_source_tile_ok() {
 }
 
 #[actix_rt::test]
-async fn test_table_source_srid_ok() {
+async fn table_source_srid_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
-    let table_sources = get_table_sources(&mut connection, Some(900913))
+    let table_sources = get_table_sources(&mut connection, Some(900_913))
         .await
         .unwrap();
 
@@ -104,14 +104,14 @@ async fn test_table_source_srid_ok() {
 
     assert!(table_sources.contains_key("public.points_empty_srid"));
     let points_empty_srid = table_sources.get("public.points_empty_srid").unwrap();
-    assert_eq!(points_empty_srid.srid, 900913);
+    assert_eq!(points_empty_srid.srid, 900_913);
 }
 
 #[actix_rt::test]
-async fn test_table_source_multiple_geom_ok() {
+async fn table_source_multiple_geom_ok() {
     init();
 
-    let pool = dev::make_pool().await;
+    let pool = make_pool().await;
     let mut connection = pool.get().await.unwrap();
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 


### PR DESCRIPTION
* remove most of the utils:: and dev:: namespace usage
* rename `configure_db_source` to `configure_db_sources`
* use defaults from other table info objects (using the `..obj` syntax)
* use doc comments vs regular comment in a few places
* refactor server_test.rs to make it more readable and much shorter
  * use a macro for identical code
  * use a test_get() for identical GET request
* rename fn test_foo() into fn foo() for simplicity