### PR TITLE
Migrate tests to use maplibre-gl

### DIFF
--- a/tests/composite_source.html
+++ b/tests/composite_source.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <title>Martin Debug Page</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
-    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
 
     <style>
       body {
@@ -26,18 +26,9 @@
     <div id="map"></div>
 
     <script>
-      let accessToken = localStorage.getItem('accessToken');
-
-      if (!accessToken) {
-        accessToken = window.prompt('Mapbox accessToken');
-        localStorage.setItem('accessToken', accessToken);
-      }
-
-      mapboxgl.accessToken = accessToken;
-
-      const map = new mapboxgl.Map({
+      const map = new maplibregl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/light-v9',
+        style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
         zoom: 0,
         center: [0, 0]
       });

--- a/tests/debug-deckgl.html
+++ b/tests/debug-deckgl.html
@@ -8,8 +8,8 @@
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
     <script src="https://unpkg.com/deck.gl@^8.4.0/dist.min.js"></script>
-    <script src="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.js"></script>
-    <link href="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
 
     <style>
       body {
@@ -30,6 +30,7 @@
     <script>
       const deckgl = new deck.DeckGL({
         container: 'map',
+        map: maplibregl,
         mapStyle: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
         initialViewState: {
           latitude: 0,

--- a/tests/debug.html
+++ b/tests/debug.html
@@ -7,11 +7,8 @@
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
-    <link
-      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
-      rel="stylesheet"
-    />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
 
     <style>
       body {
@@ -79,18 +76,9 @@
     <div id="map"></div>
 
     <script>
-      let accessToken = localStorage.getItem('accessToken');
-
-      if (!accessToken) {
-        accessToken = window.prompt('Mapbox accessToken');
-        localStorage.setItem('accessToken', accessToken);
-      }
-
-      mapboxgl.accessToken = accessToken;
-
-      const map = new mapboxgl.Map({
+      const map = new maplibregl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/light-v9',
+        style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
         zoom: 0,
         center: [0, 0],
         hash: true


### PR DESCRIPTION
Migrates the HTML test files to use `maplibre-gl` instead of `mapbox-gl`. I kept the same version as in `tests/debug-maplibre.html` and used the Carto Positron style on `tests/debug.html` because it was the closet to Mapbox's light style.

Closes #406. Happy to make any changes to this, thanks!