### PR TITLE
Remove automated docker builds for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Build and push the Docker image
         uses: docker/build-push-action@v3
         with:
-          push: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
+          push: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 


### PR DESCRIPTION
Closes #443. Adds a conditional to the `docker` job that won't run any of the Docker build steps if triggered by a PR. Based on the docker/metadata-action docs, this should stop any of the `pr-*` images from being built