### PR TITLE
Warn on unknown cfg, CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,91 +100,91 @@ jobs:
 
       - name: Test server response for table source
         run: |
-          curl "localhost:3000/index.json" | jq -e
-          curl "localhost:3000/public.table_source/0/0/0.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/6/38/20.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/12/2476/1280.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/13/4952/2560.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/14/9904/5121.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/20/633856/327787.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.table_source/21/1267712/655574.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
+          curl -sS "localhost:3000/index.json" | jq -e
+          curl -sS "localhost:3000/public.table_source/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/6/38/20.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/12/2476/1280.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/13/4952/2560.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/14/9904/5121.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/20/633856/327787.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source/21/1267712/655574.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
       - name: Test server response for composite source
         run: |
-          curl "localhost:3000/public.table_source,public.points1,public.points2/0/0/0.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/6/38/20.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/12/2476/1280.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/13/4952/2560.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/14/9904/5121.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/20/633856/327787.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/public.table_source,public.points1,public.points2/21/1267712/655574.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/6/38/20.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/12/2476/1280.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/13/4952/2560.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/14/9904/5121.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/20/633856/327787.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.table_source,public.points1,public.points2/21/1267712/655574.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
       - name: Test server response for function source
         run: |
-          curl "localhost:3000/rpc/public.function_source/0/0/0.pbf" > function_source0.pbf
-          ./tests/vtzero-check function_source0.pbf
-          ./tests/vtzero-show function_source0.pbf
-          curl "localhost:3000/rpc/public.function_source/6/38/20.pbf" > function_source6.pbf
-          ./tests/vtzero-check function_source6.pbf
-          ./tests/vtzero-show function_source6.pbf
-          curl "localhost:3000/rpc/public.function_source/12/2476/1280.pbf" > function_source12.pbf
-          ./tests/vtzero-check function_source12.pbf
-          ./tests/vtzero-show function_source12.pbf
-          curl "localhost:3000/rpc/public.function_source/13/4952/2560.pbf" > function_source13.pbf
-          ./tests/vtzero-check function_source13.pbf
-          ./tests/vtzero-show function_source13.pbf
-          curl "localhost:3000/rpc/public.function_source/14/9904/5121.pbf" > function_source14.pbf
-          ./tests/vtzero-check function_source14.pbf
-          ./tests/vtzero-show function_source14.pbf
-          curl "localhost:3000/rpc/public.function_source/20/633856/327787.pbf" > function_source20.pbf
-          ./tests/vtzero-check function_source20.pbf
-          ./tests/vtzero-show function_source20.pbf
-          curl "localhost:3000/rpc/public.function_source/21/1267712/655574.pbf" > function_source21.pbf
-          ./tests/vtzero-check function_source21.pbf
-          ./tests/vtzero-show function_source21.pbf
-          curl "localhost:3000/rpc/public.function_source_query_params/0/0/0.pbf?token=martin" > function_source_query_params.pbf
-          ./tests/vtzero-check function_source_query_params.pbf
-          ./tests/vtzero-show function_source_query_params.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/6/38/20.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/12/2476/1280.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/13/4952/2560.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/14/9904/5121.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/20/633856/327787.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/21/1267712/655574.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source_query_params/0/0/0.pbf?token=martin" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
       - name: Test server response for table source with different SRID
         run: |
-          curl "localhost:3000/public.points3857/0/0/0.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
+          curl -sS "localhost:3000/public.points3857/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
       - name: Test server response for table source with empty SRID
         run: |
-          curl "localhost:3000/public.points_empty_srid/0/0/0.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
+          curl -sS "localhost:3000/public.points_empty_srid/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
       - name: Prepare config
         run: sed -i 's/5432/${{ job.services.postgres.ports[5432] }}/g' ./tests/config.yaml
@@ -194,19 +194,19 @@ jobs:
 
       - name: Test server response
         run: |
-          curl "localhost:3000/index.json" | jq -e
-          curl "localhost:3000/public.table_source/0/0/0.pbf" > table_source.pbf
-          ./tests/vtzero-check table_source.pbf
-          ./tests/vtzero-show table_source.pbf
-          curl "localhost:3000/public.points1,public.points2/0/0/0.pbf" > composite_source.pbf
-          ./tests/vtzero-check composite_source.pbf
-          ./tests/vtzero-show composite_source.pbf
-          curl "localhost:3000/rpc/public.function_source/0/0/0.pbf" > function_source.pbf
-          ./tests/vtzero-check function_source.pbf
-          ./tests/vtzero-show function_source.pbf
-          curl "localhost:3000/rpc/public.function_source_query_params/0/0/0.pbf?token=martin" > function_source_query_params.pbf
-          ./tests/vtzero-check function_source_query_params.pbf
-          ./tests/vtzero-show function_source_query_params.pbf
+          curl -sS "localhost:3000/index.json" | jq -e
+          curl -sS "localhost:3000/public.table_source/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/public.points1,public.points2/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source/0/0/0.pbf" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
+          curl -sS "localhost:3000/rpc/public.function_source_query_params/0/0/0.pbf?token=martin" > tmp.pbf
+          ./tests/vtzero-check tmp.pbf
+          ./tests/vtzero-show tmp.pbf
 
   build:
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,15 @@ jobs:
       - name: Setup database
         run: |
           sudo apt-get install postgresql-client
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/TileBBox.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/table_source.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/table_source_multiple_geom.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/function_source.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/function_source_query_params.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/points1_source.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/points2_source.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/points3857_source.sql
-          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -f tests/fixtures/points_empty_srid_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/TileBBox.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/table_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/table_source_multiple_geom.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/function_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/function_source_query_params.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/points1_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/points2_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/points3857_source.sql
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -d db -v ON_ERROR_STOP=1 -f tests/fixtures/points_empty_srid_source.sql
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/benches/sources.rs
+++ b/benches/sources.rs
@@ -22,6 +22,7 @@ fn mock_table_source(schema: &str, table: &str) -> TableSource {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     }
 }
 
@@ -33,6 +34,7 @@ fn mock_function_source(schema: &str, function: &str) -> FunctionSource {
         minzoom: None,
         maxzoom: None,
         bounds: None,
+        unrecognized: HashMap::new(),
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,6 +6,7 @@ use martin::pg::config::{PgArgs, PgConfigBuilder};
 use martin::pg::db::configure_db_sources;
 use martin::srv::config::{SrvArgs, SrvConfigBuilder};
 use martin::srv::server;
+use std::collections::HashMap;
 use std::{env, io};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -41,6 +42,7 @@ impl From<Args> for ConfigBuilder {
         ConfigBuilder {
             srv: SrvConfigBuilder::from(args.srv),
             pg: PgConfigBuilder::from((args.pg, args.connection)),
+            unrecognized: HashMap::new(),
         }
     }
 }

--- a/src/pg/dev.rs
+++ b/src/pg/dev.rs
@@ -32,6 +32,7 @@ pub fn mock_default_table_sources() -> TableSources {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     };
 
     let table_source_multiple_geom1 = TableSource {
@@ -42,6 +43,7 @@ pub fn mock_default_table_sources() -> TableSources {
         geometry_column: "geom1".to_owned(),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -53,6 +55,7 @@ pub fn mock_default_table_sources() -> TableSources {
         geometry_column: "geom2".to_owned(),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -64,6 +67,7 @@ pub fn mock_default_table_sources() -> TableSources {
         geometry_column: "geom".to_owned(),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -75,6 +79,7 @@ pub fn mock_default_table_sources() -> TableSources {
         geometry_column: "geom".to_owned(),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -87,6 +92,7 @@ pub fn mock_default_table_sources() -> TableSources {
         srid: 3857,
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -117,12 +123,14 @@ pub fn mock_default_function_sources() -> FunctionSources {
         minzoom: Some(0),
         maxzoom: Some(30),
         bounds: Some(Bounds::MAX),
+        unrecognized: HashMap::new(),
     };
 
     let function_source_query_params = FunctionSource {
         id: "public.function_source_query_params".to_owned(),
         schema: "public".to_owned(),
         function: "function_source_query_params".to_owned(),
+        unrecognized: HashMap::new(),
         ..function_source
     };
 

--- a/src/pg/table_source.rs
+++ b/src/pg/table_source.rs
@@ -7,6 +7,7 @@ use crate::source::{Source, Tile, UrlQuery, Xyz};
 use async_trait::async_trait;
 use log::warn;
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::collections::{HashMap, HashSet};
 use std::io;
 use tilejson::{tilejson, Bounds, TileJSON};
@@ -65,6 +66,9 @@ pub struct TableSource {
 
     /// List of columns, that should be encoded as tile properties
     pub properties: HashMap<String, String>,
+
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: HashMap<String, Value>,
 }
 
 pub type TableSources = HashMap<String, Box<TableSource>>;
@@ -248,6 +252,7 @@ pub async fn get_table_sources(
             clip_geom: Some(DEFAULT_CLIP_GEOM),
             geometry_type: row.get("type"),
             properties: json_to_hashmap(&row.get("properties")),
+            unrecognized: HashMap::new(),
         };
 
         let mut explicit_source = source.clone();

--- a/src/srv/config.rs
+++ b/src/srv/config.rs
@@ -26,8 +26,11 @@ pub struct SrvConfig {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SrvConfigBuilder {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_alive: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub listen_addresses: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_processes: Option<usize>,
 }
 

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -75,6 +75,7 @@ async fn get_table_source_ok() {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     };
 
     let app = create_app!(Some(mock_table_sources(&[table_source])), None);
@@ -146,6 +147,7 @@ async fn get_table_source_tile_minmax_zoom_ok() {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     };
 
     let points1 = TableSource {
@@ -158,6 +160,7 @@ async fn get_table_source_tile_minmax_zoom_ok() {
         maxzoom: Some(12),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -171,6 +174,7 @@ async fn get_table_source_tile_minmax_zoom_ok() {
         maxzoom: None,
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -184,6 +188,7 @@ async fn get_table_source_tile_minmax_zoom_ok() {
         maxzoom: None,
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
         ..table_source
     };
 
@@ -296,6 +301,7 @@ async fn get_composite_source_tile_minmax_zoom_ok() {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     };
 
     let public_points2 = TableSource {
@@ -313,6 +319,7 @@ async fn get_composite_source_tile_minmax_zoom_ok() {
         clip_geom: Some(true),
         geometry_type: None,
         properties: HashMap::new(),
+        unrecognized: HashMap::new(),
     };
 
     let tables = &[public_points1, public_points2];
@@ -424,6 +431,7 @@ async fn get_function_source_tile_minmax_zoom_ok() {
         minzoom: None,
         maxzoom: None,
         bounds: Some(Bounds::MAX),
+        unrecognized: HashMap::new(),
     };
 
     let function_source2 = FunctionSource {
@@ -433,6 +441,7 @@ async fn get_function_source_tile_minmax_zoom_ok() {
         minzoom: Some(6),
         maxzoom: Some(12),
         bounds: Some(Bounds::MAX),
+        unrecognized: HashMap::new(),
     };
 
     let funcs = &[function_source1, function_source2];


### PR DESCRIPTION
* Detect all unrecognized config file values, and report them.  Ideally we want to use `serde-ignored` crate, but it doesn't work with flattened structs (yet). So using a bad workaround.
* CI test has been using all sorts of somewhat duplicated temporary pbf files - cleaned up to `tmp.pbf`, and made sure curl only shows errors, not download stats.
* In CI, crash psql instead of silently ignoring errors
* Don't serialize optional config values as nulls
* Tiny error message cleanup