### PR TITLE
Make SSL support optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             # compile without debug symbols
             RUSTFLAGS='-C link-arg=-s' cargo build --release --target ${{ matrix.target }} --features=vendored-openssl
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --release --target ${{ matrix.target }} --features=ssl
           fi
           mkdir target_releases
           if [[ "${{ runner.os }}" == "Windows" ]]; then
@@ -109,7 +109,8 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: |
-          cargo test --all
+          cargo test --all-targets --all-features
+          cargo test --doc
           rm -rf target
         env:
           DATABASE_URL: ${{ steps.pg.outputs.connection-uri }}

--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -46,7 +46,7 @@ jobs:
           override: true
 
       - name: Run tests
-        run: cargo test --all
+        run: cargo test
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ name = "martin"
 path = "src/bin/main.rs"
 
 [features]
-vendored-openssl = ['openssl/vendored']
+ssl = ["openssl", "postgres-openssl"]
+vendored-openssl = ["ssl", "openssl/vendored"]
 
 [dependencies]
 actix = "0.13"
@@ -32,10 +33,10 @@ env_logger = "0.9"
 itertools = "0.10"
 log = "0.4"
 num_cpus = "1"
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 postgis = "0.9"
 postgres = { version = "0.19", features = ["with-time-0_3", "with-uuid-1", "with-serde_json-1"] }
-postgres-openssl = "0.5"
+postgres-openssl = { version = "0.5", optional = true }
 postgres-protocol = "0.6"
 semver = "1"
 serde = { version = "1", features = ["derive"] }

--- a/benches/sources.rs
+++ b/benches/sources.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use martin::pg::composite_source::CompositeSource;
-use martin::pg::dev::make_pool;
+use martin::pg::dev::{get_conn, make_pool};
 use martin::pg::function_source::FunctionSource;
 use martin::pg::table_source::TableSource;
 use martin::source::{Source, Xyz};
@@ -45,7 +45,7 @@ async fn get_table_source() {
 
 async fn get_table_source_tile() {
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
 
     let source = mock_table_source("public", "table_source");
     let xyz = Xyz { z: 0, x: 0, y: 0 };
@@ -67,7 +67,7 @@ async fn get_composite_source() {
 
 async fn get_composite_source_tile() {
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
 
     let points1 = mock_table_source("public", "points1");
     let points2 = mock_table_source("public", "points2");
@@ -88,7 +88,7 @@ async fn get_function_source() {
 
 async fn get_function_source_tile() {
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
 
     let source = mock_function_source("public", "function_source");
     let xyz = Xyz { z: 0, x: 0, y: 0 };

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,9 @@ mod tests {
             },
             pg: PgConfig {
                 connection_string: "postgres://postgres@localhost:5432/db".to_string(),
+                #[cfg(feature = "ssl")]
                 ca_root_file: None,
+                #[cfg(feature = "ssl")]
                 danger_accept_invalid_certs: false,
                 default_srid: Some(4326),
                 pool_size: 20,

--- a/tests/function_source_test.rs
+++ b/tests/function_source_test.rs
@@ -1,5 +1,5 @@
 use log::info;
-use martin::pg::dev::make_pool;
+use martin::pg::dev::{get_conn, make_pool};
 use martin::pg::function_source::get_function_sources;
 use martin::source::{Source, Xyz};
 
@@ -12,7 +12,7 @@ async fn get_function_sources_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 
     info!("function_sources = {function_sources:#?}");
@@ -33,7 +33,7 @@ async fn function_source_tilejson_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 
     let function_source = function_sources.get("public.function_source").unwrap();
@@ -56,7 +56,7 @@ async fn function_source_tile_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let function_sources = get_function_sources(&mut connection).await.unwrap();
 
     let function_source = function_sources.get("public.function_source").unwrap();

--- a/tests/table_source_test.rs
+++ b/tests/table_source_test.rs
@@ -1,5 +1,5 @@
 use log::info;
-use martin::pg::dev::make_pool;
+use martin::pg::dev::{get_conn, make_pool};
 use martin::pg::table_source::get_table_sources;
 use martin::source::{Source, Xyz};
 use std::collections::HashMap;
@@ -13,7 +13,7 @@ async fn get_table_sources_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
     info!("table_sources = {table_sources:#?}");
@@ -45,7 +45,7 @@ async fn table_source_tilejson_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
     let table_source = table_sources.get("public.table_source").unwrap();
@@ -68,7 +68,7 @@ async fn table_source_tile_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
     let table_source = table_sources.get("public.table_source").unwrap();
@@ -85,7 +85,7 @@ async fn table_source_srid_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let table_sources = get_table_sources(&mut connection, Some(900_913))
         .await
         .unwrap();
@@ -112,7 +112,7 @@ async fn table_source_multiple_geom_ok() {
     init();
 
     let pool = make_pool().await;
-    let mut connection = pool.get().await.unwrap();
+    let mut connection = get_conn(&pool).await;
     let table_sources = get_table_sources(&mut connection, None).await.unwrap();
 
     assert!(table_sources.contains_key("public.table_source_multiple_geom"));


### PR DESCRIPTION
By default, Martin is now compiled without openssl, simplifying debugging and simple case usage, whereas the docker build and CI publishing would still use openssl