### PR TITLE
Clean up error wrapping

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
+use crate::io_error;
 use crate::pg::config::{PgConfig, PgConfigBuilder};
-use crate::prettify_error;
 use crate::srv::config::{SrvConfig, SrvConfigBuilder};
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -61,12 +61,12 @@ pub fn report_unrecognized_config(prefix: &str, unrecognized: &HashMap<String, V
 /// Read config from a file
 pub fn read_config(file_name: &str) -> io::Result<ConfigBuilder> {
     let mut file = File::open(file_name)
-        .map_err(|e| prettify_error!(e, "Unable to open config file '{}'", file_name))?;
+        .map_err(|e| io_error!(e, "Unable to open config file '{file_name}'"))?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)
-        .map_err(|e| prettify_error!(e, "Unable to read config file '{}'", file_name))?;
+        .map_err(|e| io_error!(e, "Unable to read config file '{file_name}'"))?;
     serde_yaml::from_str(contents.as_str())
-        .map_err(|e| prettify_error!(e, "Error parsing config file '{}'", file_name))
+        .map_err(|e| io_error!(e, "Error parsing config file '{file_name}'"))
 }
 
 #[cfg(test)]

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -8,20 +8,15 @@ use std::collections::HashMap;
 use tilejson::{tilejson, Bounds, TileJSON, VectorLayer};
 
 #[macro_export]
-macro_rules! prettify_error {
-    ($error:ident, $info:literal) => {
+macro_rules! io_error {
+    ($error:ident $(, $arg:expr)* $(,)?) => {
         ::std::io::Error::new(
             ::std::io::ErrorKind::Other,
-            ::std::format!(::std::concat!($info, ": {}"), $error))
-    };
-    ($error:ident, $($arg:tt)+) => {
-        ::std::io::Error::new(
-            ::std::io::ErrorKind::Other,
-            ::std::format!("{}: {}", ::std::format_args!($($arg)+), $error))
+            ::std::format!("{}: {}", ::std::format_args!($($arg,)+), $error))
     };
 }
 
-pub(crate) use prettify_error;
+pub(crate) use io_error;
 
 // https://github.com/mapbox/postgis-vt-util/blob/master/src/TileBBox.sql
 pub fn tile_bbox(xyz: &Xyz) -> String {

--- a/src/source.rs
+++ b/src/source.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use martin_tile_utils::DataFormat;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 use std::fmt::Write;
+use std::fmt::{Debug, Display, Formatter};
 use std::io;
 use std::sync::{Arc, Mutex};
 use tilejson::TileJSON;
@@ -13,6 +13,12 @@ pub struct Xyz {
     pub z: i32,
     pub x: i32,
     pub y: i32,
+}
+
+impl Display for Xyz {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}/{}", self.z, self.x, self.y)
+    }
 }
 
 pub type Tile = Vec<u8>;


### PR DESCRIPTION
* Fix incorrect printing of the xyz value - implements Display trait instead to keep it simpler
* Remove the possibly-incorrect macro capture of a simple string - in case the string contains inline vars
* Handle optional extra comma properly
* Rename it to a shorter name
* Inline vars where possible