### PR TITLE
Fix workflow trigger on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   release:
-    branches: [main]
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   release:
-    branches: [main]
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Need to limit releases to the published events,
otherwise it gets re-triggered on every release notes editing.