### PR TITLE
Catch errors in tests, minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ justfile
 /target/
 **/*.rs.bk
 .idea/
+test_log*
 
 pg_data/
 config.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
           password: test
           database: test
           rights: --superuser
+      - name: Log DATABASE_URL string
+        shell: bash
+        run: |
+          echo "DATABASE_URL=$DATABASE_URL"
+          echo "And in base64 to bypass Github's obfuscation:"
+          echo "$DATABASE_URL" | base64
+        env:
+          DATABASE_URL: ${{ steps.pg.outputs.connection-uri }}
       - name: Init database
         if: matrix.target != 'aarch64-apple-darwin'
         shell: bash
@@ -126,7 +134,7 @@ jobs:
           name: test-output
           path: tests/output/*
           retention-days: 5
-      - name: Test
+      - name: Integration Tests
         if: matrix.target != 'aarch64-apple-darwin'
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /target/
 **/*.rs.bk
 .idea/
+test_log*
 
 pg_data/
 config.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,11 +1542,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1641,18 +1640,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -464,9 +464,6 @@ You can find an example of a configuration file [here](https://github.com/maplib
 # Database connection string
 connection_string: 'postgres://postgres@localhost:5432/db'
 
-# Trust invalid certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
-danger_accept_invalid_certs: false
-
 # If a spatial table has SRID 0, then this SRID will be used as a fallback
 default_srid: 4326
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ You can find an example of a configuration file [here](https://github.com/maplib
 # Database connection string
 connection_string: 'postgres://postgres@localhost:5432/db'
 
+# Trust invalid certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+danger_accept_invalid_certs: false
+
 # If a spatial table has SRID 0, then this SRID will be used as a fallback
 default_srid: 4326
 

--- a/src/pg/pool.rs
+++ b/src/pg/pool.rs
@@ -56,10 +56,10 @@ impl Pool {
                 builder.set_verify(SslVerifyMode::NONE);
             }
 
-            if let Some(ca_root_file) = &config.ca_root_file {
-                info!("Using {ca_root_file} as trusted root certificate");
-                builder.set_ca_file(ca_root_file).map_err(|e| {
-                    io_error!(e, "Can't set trusted root certificate {ca_root_file}")
+            if let Some(file) = &config.ca_root_file {
+                info!("Using {} as trusted root certificate", file.display());
+                builder.set_ca_file(file).map_err(|e| {
+                    io_error!(e, "Can't set trusted root certificate {}", file.display())
                 })?;
             }
             PostgresConnectionManager::new(pg_cfg, MakeTlsConnector::new(builder.build()))

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -4,7 +4,6 @@ use actix_http::header::HeaderValue;
 use actix_web::http::Uri;
 use postgis::{ewkb, LineString, Point, Polygon};
 use postgres::types::Json;
-use serde_json::Value;
 use std::collections::HashMap;
 use tilejson::{tilejson, Bounds, TileJSON, VectorLayer};
 
@@ -35,7 +34,7 @@ pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
     hashmap
 }
 
-pub fn query_to_json(query: &UrlQuery) -> Json<InfoMap<Value>> {
+pub fn query_to_json(query: &UrlQuery) -> Json<InfoMap<serde_json::Value>> {
     let mut query_as_json = HashMap::new();
     for (k, v) in query.iter() {
         let json_value: serde_json::Value =
@@ -96,4 +95,11 @@ pub fn create_tilejson(
 pub fn is_valid_zoom(zoom: i32, minzoom: Option<u8>, maxzoom: Option<u8>) -> bool {
     minzoom.map_or(true, |minzoom| zoom >= minzoom.into())
         && maxzoom.map_or(true, |maxzoom| zoom <= maxzoom.into())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    pub fn some_str(s: &str) -> Option<String> {
+        Some(s.to_string())
+    }
 }

--- a/src/srv/config.rs
+++ b/src/srv/config.rs
@@ -2,14 +2,14 @@ use crate::config::set_option;
 use serde::{Deserialize, Serialize};
 use std::io;
 
-pub const KEEP_ALIVE_DEFAULT: usize = 75;
+pub const KEEP_ALIVE_DEFAULT: u64 = 75;
 pub const LISTEN_ADDRESSES_DEFAULT: &str = "0.0.0.0:3000";
 
 #[derive(clap::Args, Debug)]
 #[command(about, version)]
 pub struct SrvArgs {
     #[arg(help = format!("Connection keep alive timeout. [DEFAULT: {}]", KEEP_ALIVE_DEFAULT), short, long)]
-    pub keep_alive: Option<usize>,
+    pub keep_alive: Option<u64>,
     #[arg(help = format!("The socket address to bind. [DEFAULT: {}]", LISTEN_ADDRESSES_DEFAULT), short, long)]
     pub listen_addresses: Option<String>,
     /// Number of web server workers
@@ -19,7 +19,7 @@ pub struct SrvArgs {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct SrvConfig {
-    pub keep_alive: usize,
+    pub keep_alive: u64,
     pub listen_addresses: String,
     pub worker_processes: usize,
 }
@@ -27,7 +27,7 @@ pub struct SrvConfig {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct SrvConfigBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub keep_alive: Option<usize>,
+    pub keep_alive: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub listen_addresses: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/srv/server.rs
+++ b/src/srv/server.rs
@@ -296,7 +296,7 @@ pub fn new(config: SrvConfig, sources: Sources) -> Server {
     })
     .bind(listen_addresses.clone())
     .unwrap_or_else(|_| panic!("Can't bind to {listen_addresses}"))
-    .keep_alive(Duration::from_secs(keep_alive as u64))
+    .keep_alive(Duration::from_secs(keep_alive))
     .shutdown_timeout(0)
     .workers(worker_processes)
     .run()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use itertools::Itertools;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::env;
+use std::env::VarError;
 
 pub type InfoMap<T> = HashMap<String, T>;
 
@@ -85,6 +87,18 @@ impl Schemas {
                     Vec::new()
                 }
             }
+        }
+    }
+}
+
+pub fn get_env_str(name: &str) -> Option<String> {
+    match env::var(name) {
+        Ok(v) => Some(v),
+        Err(VarError::NotPresent) => None,
+        Err(VarError::NotUnicode(v)) => {
+            let v = v.to_string_lossy();
+            warn!("Environment variable {name} has invalid unicode. Lossy representation: {v}");
+            None
         }
     }
 }

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,24 +1,21 @@
 ---
-# Database connection string
-connection_string: 'postgres://postgres@localhost:5432/db'
-
-# Trust invalid certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
-danger_accept_invalid_certs: false
-
-# If a spatial table has SRID 0, then this SRID will be used as a fallback
-default_srid: 4326
-
 # Connection keep alive timeout [default: 75]
 keep_alive: 75
 
 # The socket address to bind [default: 0.0.0.0:3000]
-listen_addresses: 0.0.0.0:3000
-
-# Maximum connections pool size [default: 20]
-pool_size: 20
+listen_addresses: '0.0.0.0:3000'
 
 # Number of web server workers
 worker_processes: 8
+
+# Database connection string
+connection_string: 'postgresql://postgres@localhost:5432/db'
+
+# If a spatial table has SRID 0, then this SRID will be used as a fallback
+default_srid: 4326
+
+# Maximum connections pool size [default: 20]
+pool_size: 20
 
 # Associative arrays of table sources
 tables:

--- a/tests/function_source_test.rs
+++ b/tests/function_source_test.rs
@@ -40,9 +40,9 @@ async fn function_source_tilejson() {
     info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
-    assert_eq!(tilejson.version, Some("1.0.0".to_owned()));
-    assert_eq!(tilejson.name, Some("public.function_zxy_query".to_owned()));
-    assert_eq!(tilejson.scheme, Some("xyz".to_owned()));
+    assert_eq!(tilejson.version, some_str("1.0.0"));
+    assert_eq!(tilejson.name, some_str("public.function_zxy_query"));
+    assert_eq!(tilejson.scheme, some_str("xyz"));
     assert_eq!(tilejson.minzoom, Some(0));
     assert_eq!(tilejson.maxzoom, Some(30));
     assert!(tilejson.bounds.is_some());

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -465,12 +465,12 @@ async fn tables_feature_id() {
         ..default.clone()
     };
     let id_only = TableInfo {
-        id_column: Some("giD".to_string()),
+        id_column: some_str("giD"),
         properties: props(&[("TABLE", "text")]),
         ..default.clone()
     };
     let id_and_prop = TableInfo {
-        id_column: Some("giD".to_string()),
+        id_column: some_str("giD"),
         properties: props(&[("giD", "int4"), ("TABLE", "text")]),
         ..default.clone()
     };
@@ -498,11 +498,11 @@ async fn tables_feature_id() {
     // });
 
     let src = table(&mock, "id_only");
-    assert_eq!(src.id_column, Some("giD".to_string()));
+    assert_eq!(src.id_column, some_str("giD"));
     assert_eq!(src.properties.len(), 1);
 
     let src = table(&mock, "id_and_prop");
-    assert_eq!(src.id_column, Some("giD".to_string()));
+    assert_eq!(src.id_column, some_str("giD"));
     assert_eq!(src.properties.len(), 2);
 
     let src = table(&mock, "prop_only");

--- a/tests/table_source_test.rs
+++ b/tests/table_source_test.rs
@@ -31,7 +31,7 @@ async fn table_source() {
     assert_eq!(source.extent, Some(4096));
     assert_eq!(source.buffer, Some(64));
     assert_eq!(source.clip_geom, Some(true));
-    assert_eq!(source.geometry_type, Some("GEOMETRY".to_owned()));
+    assert_eq!(source.geometry_type, some_str("GEOMETRY"));
 
     let mut properties = HashMap::new();
     properties.insert("gid".to_owned(), "int4".to_owned());
@@ -46,9 +46,9 @@ async fn tables_tilejson_ok() {
     info!("tilejson = {tilejson:#?}");
 
     assert_eq!(tilejson.tilejson, "2.2.0");
-    assert_eq!(tilejson.version, Some("1.0.0".to_owned()));
-    assert_eq!(tilejson.name, Some("public.table_source.geom".to_owned()));
-    assert_eq!(tilejson.scheme, Some("xyz".to_owned()));
+    assert_eq!(tilejson.version, some_str("1.0.0"));
+    assert_eq!(tilejson.name, some_str("public.table_source.geom"));
+    assert_eq!(tilejson.scheme, some_str("xyz"));
     assert_eq!(tilejson.minzoom, Some(0));
     assert_eq!(tilejson.maxzoom, Some(30));
     assert!(tilejson.bounds.is_some());

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -187,7 +187,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "public".to_string(),
                 table: "points1".to_string(),
                 geometry_column: "geom".to_string(),
-                geometry_type: Some("POINT".to_string()),
+                geometry_type: some_str("POINT"),
                 properties: props(&[("gid", "int4")]),
                 ..default.clone()
             },
@@ -198,7 +198,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "public".to_string(),
                 table: "points2".to_string(),
                 geometry_column: "geom".to_string(),
-                geometry_type: Some("POINT".to_string()),
+                geometry_type: some_str("POINT"),
                 properties: props(&[("gid", "int4")]),
                 ..default.clone()
             },
@@ -210,8 +210,8 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "MIXEDCASE".to_string(),
                 table: "mixPoints".to_string(),
                 geometry_column: "geoM".to_string(),
-                geometry_type: Some("POINT".to_string()),
-                id_column: Some("giD".to_string()),
+                geometry_type: some_str("POINT"),
+                id_column: some_str("giD"),
                 properties: props(&[("tAble", "text")]),
                 ..default.clone()
             },
@@ -223,7 +223,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 table: "points3857".to_string(),
                 srid: 3857,
                 geometry_column: "geom".to_string(),
-                geometry_type: Some("POINT".to_string()),
+                geometry_type: some_str("POINT"),
                 properties: props(&[("gid", "int4")]),
                 ..default.clone()
             },
@@ -235,7 +235,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 table: "points_empty_srid".to_string(),
                 srid: 900973,
                 geometry_column: "geom".to_string(),
-                geometry_type: Some("GEOMETRY".to_string()),
+                geometry_type: some_str("GEOMETRY"),
                 properties: props(&[("gid", "int4")]),
                 ..default.clone()
             },
@@ -246,7 +246,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "public".to_string(),
                 table: "table_source".to_string(),
                 geometry_column: "geom".to_string(),
-                geometry_type: Some("GEOMETRY".to_string()),
+                geometry_type: some_str("GEOMETRY"),
                 properties: props(&[("gid", "int4")]),
                 ..default.clone()
             },
@@ -257,7 +257,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "public".to_string(),
                 table: "table_source_multiple_geom".to_string(),
                 geometry_column: "geom1".to_string(),
-                geometry_type: Some("POINT".to_string()),
+                geometry_type: some_str("POINT"),
                 properties: props(&[("geom2", "geometry"), ("gid", "int4")]),
                 ..default.clone()
             },
@@ -268,7 +268,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
                 schema: "public".to_string(),
                 table: "table_source_multiple_geom".to_string(),
                 geometry_column: "geom2".to_string(),
-                geometry_type: Some("POINT".to_string()),
+                geometry_type: some_str("POINT"),
                 properties: props(&[("gid", "int4"), ("geom1", "geometry")]),
                 ..default.clone()
             },
@@ -295,4 +295,9 @@ pub fn table<'a>(mock: &'a MockSource, name: &str) -> &'a TableInfo {
 pub fn source<'a>(mock: &'a MockSource, name: &str) -> &'a dyn Source {
     let (sources, _) = mock;
     sources.get(name).unwrap().as_ref()
+}
+
+#[allow(dead_code)]
+pub fn some_str(s: &str) -> Option<String> {
+    Some(s.to_string())
 }


### PR DESCRIPTION
This extracts some of the code from #511 but without breaking changes

* Use `PathBuf` instead of `String` where dealing with files
* Parse keep_alive as u64
* More config tests to crash if martin output contains warnings or errors