### PR TITLE
Strongly-type errors, fix bounds escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "tilejson",
 ]
 
@@ -1317,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
 
 [[package]]
 name = "percent-encoding"
@@ -1824,6 +1825,26 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tilejson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "martin"
 path = "src/bin/main.rs"
 
 [features]
+default = []
 ssl = ["openssl", "postgres-openssl"]
 vendored-openssl = ["ssl", "openssl/vendored"]
 
@@ -47,6 +48,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+thiserror = "1"
 tilejson = "0.3"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod pg;
 pub mod source;
 pub mod srv;
 pub mod utils;
+pub use crate::utils::Error;
+pub use crate::utils::Result;
 
 // Ensure README.md contains valid code
 #[cfg(doctest)]

--- a/src/pg/scripts/get_bounds.sql
+++ b/src/pg/scripts/get_bounds.sql
@@ -1,9 +1,0 @@
-WITH real_bounds AS (SELECT ST_SetSRID(ST_Extent({geometry_column}), {srid}) AS rb FROM {schema}.{table})
-SELECT ST_Transform(
-               CASE
-                   WHEN (SELECT ST_GeometryType(rb) FROM real_bounds LIMIT 1) = 'ST_Point'
-                       THEN ST_SetSRID(ST_Extent(ST_Expand({geometry_column}, 1)), {srid})
-                   ELSE (SELECT * FROM real_bounds)
-                   END
-           , 4326) AS bounds
-FROM {schema}.{table};

--- a/src/pg/scripts/get_postgis_version.sql
+++ b/src/pg/scripts/get_postgis_version.sql
@@ -1,1 +1,0 @@
-select (regexp_matches(postgis_lib_version(), '^(\d+\.\d+\.\d+)', 'g'))[1] as postgis_version;

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -1,26 +1,12 @@
-use crate::source::UrlQuery;
+use crate::source::{UrlQuery, Xyz};
 use crate::utils::InfoMap;
 use actix_http::header::HeaderValue;
 use actix_web::http::Uri;
 use postgis::{ewkb, LineString, Point, Polygon};
 use postgres::types::Json;
+use semver::Version;
 use std::collections::HashMap;
 use tilejson::{tilejson, Bounds, TileJSON, VectorLayer};
-
-#[macro_export]
-macro_rules! io_error {
-    ($format:literal $(, $arg:expr)* $(,)?) => {
-        ::std::io::Error::new(
-            ::std::io::ErrorKind::Other,
-            ::std::format!($format, $($arg,)*))
-    };
-    ($error:ident $(, $arg:expr)* $(,)?) => {
-        ::std::io::Error::new(
-            ::std::io::ErrorKind::Other,
-            ::std::format!("{}: {}", ::std::format_args!($($arg,)+), $error))
-    };
-}
-pub(crate) use io_error;
 
 pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
     let mut hashmap = HashMap::new();
@@ -102,4 +88,60 @@ pub(crate) mod tests {
     pub fn some_str(s: &str) -> Option<String> {
         Some(s.to_string())
     }
+}
+
+pub type Result<T> = std::result::Result<T, PgError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PgError {
+    #[cfg(feature = "ssl")]
+    #[error("Can't build TLS connection: {0}")]
+    BuildSslConnectorError(#[from] openssl::error::ErrorStack),
+
+    #[cfg(feature = "ssl")]
+    #[error("Can't set trusted root certificate {}: {0}", .1.display())]
+    BadTrustedRootCertError(#[source] openssl::error::ErrorStack, std::path::PathBuf),
+
+    #[error("Postgres error while {1}: {0}")]
+    PostgresError(#[source] bb8_postgres::tokio_postgres::Error, &'static str),
+
+    #[error("Unable to get a Postgres connection from the pool {1}: {0}")]
+    PostgresPoolConnError(
+        #[source] bb8::RunError<bb8_postgres::tokio_postgres::Error>,
+        String,
+    ),
+
+    #[error("Unable to parse connection string {1}: {0}")]
+    BadConnectionString(#[source] postgres::Error, String),
+
+    #[error("Unable to parse PostGIS version {1}: {0}")]
+    BadPostgisVersion(#[source] semver::Error, String),
+
+    #[error("PostGIS version {0} is too old, minimum required is {1}")]
+    PostgisTooOld(Version, Version),
+
+    #[error("Database connection string is not set")]
+    NoConnectionString,
+
+    #[error("Invalid extent setting in source {0} for table {1}: extent=0")]
+    InvalidTableExtent(String, String),
+
+    #[error("Error preparing a query for the tile '{1}' ({2}): {3} {0}")]
+    PrepareQueryError(
+        #[source] bb8_postgres::tokio_postgres::Error,
+        String,
+        String,
+        String,
+    ),
+
+    #[error(r#"Unable to get tile {1}/{2:#}: {0}"#)]
+    GetTileError(#[source] bb8_postgres::tokio_postgres::Error, String, Xyz),
+
+    #[error(r#"Unable to get tile {1}/{2:#} with {:?} params: {0}"#, query_to_json(.3))]
+    GetTileWithQueryError(
+        #[source] bb8_postgres::tokio_postgres::Error,
+        String,
+        Xyz,
+        UrlQuery,
+    ),
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,10 +1,10 @@
+use crate::utils::Result;
 use async_trait::async_trait;
 use martin_tile_utils::DataFormat;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::fmt::{Debug, Display, Formatter};
-use std::io;
 use std::sync::{Arc, Mutex};
 use tilejson::TileJSON;
 
@@ -38,7 +38,7 @@ pub trait Source: Send + Debug {
 
     fn is_valid_zoom(&self, zoom: i32) -> bool;
 
-    async fn get_tile(&self, xyz: &Xyz, query: &Option<UrlQuery>) -> Result<Tile, io::Error>;
+    async fn get_tile(&self, xyz: &Xyz, query: &Option<UrlQuery>) -> Result<Tile>;
 }
 
 impl Clone for Box<dyn Source> {

--- a/src/srv/config.rs
+++ b/src/srv/config.rs
@@ -1,6 +1,6 @@
 use crate::config::set_option;
+use crate::utils::Result;
 use serde::{Deserialize, Serialize};
-use std::io;
 
 pub const KEEP_ALIVE_DEFAULT: u64 = 75;
 pub const LISTEN_ADDRESSES_DEFAULT: &str = "0.0.0.0:3000";
@@ -43,7 +43,7 @@ impl SrvConfigBuilder {
     }
 
     /// Apply defaults to the config, and validate if there is a connection string
-    pub fn finalize(self) -> io::Result<SrvConfig> {
+    pub fn finalize(self) -> Result<SrvConfig> {
         Ok(SrvConfig {
             keep_alive: self.keep_alive.unwrap_or(KEEP_ALIVE_DEFAULT),
             listen_addresses: self

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,30 @@
+use crate::pg::utils::PgError;
 use itertools::Itertools;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::env;
 use std::env::VarError;
+use std::path::PathBuf;
+use std::{env, io};
 
 pub type InfoMap<T> = HashMap<String, T>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Unable to load config file {}: {0}", .1.display())]
+    ConfigLoadError(io::Error, PathBuf),
+
+    #[error("Unable to parse config file {}: {0}", .1.display())]
+    ConfigParseError(serde_yaml::Error, PathBuf),
+
+    #[error("Unable to write config file {}: {0}", .1.display())]
+    ConfigWriteError(io::Error, PathBuf),
+
+    #[error("{0}")]
+    PostgresError(#[from] PgError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub fn normalize_key<'a, T>(
     map: &'a InfoMap<T>,


### PR DESCRIPTION
* Since this is a library, all errors should have a strongly typed enum.
* table bounds computing function was not escaping identifiers
* table bounds computation was also silently ignoring all errors