### PR TITLE
Fix handling for null-returning PG queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,9 +1072,9 @@ checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "local-channel"

--- a/src/pg/pg_source.rs
+++ b/src/pg/pg_source.rs
@@ -73,19 +73,22 @@ impl Source for PgSource {
             let json = query_to_json(url_query);
             debug!("SQL: {query} [{xyz}, {json:?}]");
             let params: &[&(dyn ToSql + Sync)] = &[&xyz.z, &xyz.x, &xyz.y, &json];
-            conn.query_one(&prep_query, params).await
+            conn.query_opt(&prep_query, params).await
         } else {
             debug!("SQL: {query} [{xyz}]");
-            conn.query_one(&prep_query, &[&xyz.z, &xyz.x, &xyz.y]).await
+            conn.query_opt(&prep_query, &[&xyz.z, &xyz.x, &xyz.y]).await
         };
 
-        let tile = tile.map(|row| row.get(0)).map_err(|e| {
-            if self.info.has_query_params {
-                GetTileWithQueryError(e, self.id.to_string(), *xyz, url_query.clone())
-            } else {
-                GetTileError(e, self.id.to_string(), *xyz)
-            }
-        })?;
+        let tile = tile
+            .map(|row| row.map_or(Default::default(), |r| r.get::<_, Option<Tile>>(0)))
+            .map_err(|e| {
+                if self.info.has_query_params {
+                    GetTileWithQueryError(e, self.id.to_string(), *xyz, url_query.clone())
+                } else {
+                    GetTileError(e, self.id.to_string(), *xyz)
+                }
+            })?
+            .unwrap_or_default();
 
         Ok(tile)
     }

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -134,10 +134,10 @@ pub enum PgError {
         String,
     ),
 
-    #[error(r#"Unable to get tile {1}/{2:#}: {0}"#)]
+    #[error(r#"Unable to get tile {2:#} from {1}: {0}"#)]
     GetTileError(#[source] bb8_postgres::tokio_postgres::Error, String, Xyz),
 
-    #[error(r#"Unable to get tile {1}/{2:#} with {:?} params: {0}"#, query_to_json(.3))]
+    #[error(r#"Unable to get tile {2:#} with {:?} params from {1}: {0}"#, query_to_json(.3))]
     GetTileWithQueryError(
         #[source] bb8_postgres::tokio_postgres::Error,
         String,

--- a/tests/fixtures/functions/function_null.sql
+++ b/tests/fixtures/functions/function_null.sql
@@ -1,0 +1,7 @@
+DROP FUNCTION IF EXISTS public.function_null;
+
+CREATE OR REPLACE FUNCTION public.function_null(z integer, x integer, y integer) RETURNS bytea AS $$
+BEGIN
+    RETURN null;
+END
+$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;

--- a/tests/fixtures/functions/function_null_row.sql
+++ b/tests/fixtures/functions/function_null_row.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION IF EXISTS public.function_null_row;
+
+CREATE OR REPLACE FUNCTION public.function_null_row(z integer, x integer, y integer)
+RETURNS TABLE(mvt bytea, key text) AS $$
+  SELECT NULL::bytea, NULL::text
+$$ LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;

--- a/tests/fixtures/functions/function_null_row2.sql
+++ b/tests/fixtures/functions/function_null_row2.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION IF EXISTS public.function_null_row2;
+
+CREATE OR REPLACE FUNCTION public.function_null_row2(z integer, x integer, y integer)
+RETURNS TABLE(mvt bytea, key text) AS $$
+  SELECT NULL::bytea, NULL::text WHERE FALSE;
+$$ LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE;

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -317,6 +317,23 @@ async fn get_composite_source_tile_minmax_zoom_ok() {
 }
 
 #[actix_rt::test]
+async fn null_functions() {
+    let app = create_app!(mock_empty_config());
+
+    let req = test_get("/function_null/0/0/0");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let req = test_get("/function_null_row/0/0/0");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let req = test_get("/function_null_row2/0/0/0");
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[actix_rt::test]
 async fn get_function_source_ok() {
     let app = create_app!(mock_empty_config());
 


### PR DESCRIPTION
Handle cases when a query returns a NULL or a table with no rows, or a single row  with a null value in it.

This fully fixes #519 in the main branch