### PR TITLE
Enable clippy pedantic, fix lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: |
             cargo fmt --all -- --check
-            cargo clippy --all-targets --all-features -- -D warnings
+            cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
       - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: |
+            rustc --version
+            cargo --version
             cargo fmt --all -- --check
             cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
       - name: Install OpenSSL (Windows)

--- a/justfile
+++ b/justfile
@@ -99,6 +99,8 @@ git *ARGS: start-db
 
 # These steps automatically run before git push via a git hook
 git-pre-push: stop start-db
-    cargo clippy --all -- -D warnings -W clippy::pedantic
+    rustc --version
+    cargo --version
     cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
     just test

--- a/justfile
+++ b/justfile
@@ -69,6 +69,7 @@ test-int-legacy: (test-integration "db-legacy")
 # Run integration tests with the given docker compose target
 @test-integration name: (docker-up name) clean-test
     #!/usr/bin/env sh
+    export MARTIN_PORT=3111
     tests/test.sh
 # echo "** Skipping comparison with the expected values - not yet stable"
 # if ( ! diff --brief --recursive --new-file tests/output tests/expected ); then
@@ -98,9 +99,6 @@ git *ARGS: start-db
 
 # These steps automatically run before git push via a git hook
 git-pre-push: stop start-db
-    echo '+cargo clippy --all -- -D warnings'
-    cargo clippy --all -- -D warnings
-    echo '+cargo fmt --all -- --check'
+    cargo clippy --all -- -D warnings -W clippy::pedantic
     cargo fmt --all -- --check
-    echo 'Running all tests'
     just test

--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -17,20 +17,21 @@ pub enum DataFormat {
 }
 
 impl DataFormat {
+    #[must_use]
     pub fn new(format: &str) -> Self {
         match format {
             "png" => DataFormat::Png,
             "jpg" | "jpeg" => DataFormat::Jpeg,
             "webp" => DataFormat::Webp,
             "json" => DataFormat::Json,
-            "pbf" => DataFormat::Mvt,
-            "mvt" => DataFormat::Mvt,
+            "pbf" | "mvt" => DataFormat::Mvt,
             "gzip" => DataFormat::Gzip,
             "zlib" => DataFormat::Zlib,
             _ => DataFormat::Unknown,
         }
     }
 
+    #[must_use]
     pub fn detect(data: &[u8]) -> Self {
         match data {
             v if &v[0..2] == b"\x1f\x8b" => DataFormat::Gzip,
@@ -42,6 +43,7 @@ impl DataFormat {
         }
     }
 
+    #[must_use]
     pub fn format(&self) -> &str {
         match *self {
             DataFormat::Png => "png",
@@ -49,12 +51,11 @@ impl DataFormat {
             DataFormat::Webp => "webp",
             DataFormat::Json => "json",
             DataFormat::Mvt => "mvt",
-            DataFormat::Gzip => "",
-            DataFormat::Zlib => "",
-            DataFormat::Unknown => "",
+            DataFormat::Gzip | DataFormat::Zlib | DataFormat::Unknown => "",
         }
     }
 
+    #[must_use]
     pub fn content_type(&self) -> &str {
         match *self {
             DataFormat::Png => "image/png",
@@ -62,9 +63,7 @@ impl DataFormat {
             DataFormat::Webp => "image/webp",
             DataFormat::Json => "application/json",
             DataFormat::Mvt => "application/x-protobuf",
-            DataFormat::Gzip => "",
-            DataFormat::Zlib => "",
-            DataFormat::Unknown => "",
+            DataFormat::Gzip | DataFormat::Zlib | DataFormat::Unknown => "",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 // Bounds struct derives PartialEq, but not Eq,
 // so all containing types must also derive PartialEq without Eq
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::implicit_hasher)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::module_name_repetitions)]
 
 pub mod config;
 pub mod pg;

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -138,6 +138,7 @@ pub struct FunctionInfo {
 }
 
 impl FunctionInfo {
+    #[must_use]
     pub fn new(schema: String, function: String) -> Self {
         Self {
             schema,
@@ -146,6 +147,7 @@ impl FunctionInfo {
         }
     }
 
+    #[must_use]
     pub fn new_extended(
         schema: String,
         function: String,
@@ -229,12 +231,12 @@ impl PgConfig {
     pub fn finalize(self) -> Result<PgConfig> {
         if let Some(ref ts) = self.tables {
             for (k, v) in ts {
-                report_unrecognized_config(&format!("tables.{}.", k), &v.unrecognized);
+                report_unrecognized_config(&format!("tables.{k}."), &v.unrecognized);
             }
         }
         if let Some(ref fs) = self.functions {
             for (k, v) in fs {
-                report_unrecognized_config(&format!("functions.{}.", k), &v.unrecognized);
+                report_unrecognized_config(&format!("functions.{k}."), &v.unrecognized);
             }
         }
         let connection_string = self.connection_string.ok_or(NoConnectionString)?;

--- a/src/pg/pg_source.rs
+++ b/src/pg/pg_source.rs
@@ -20,12 +20,13 @@ pub struct PgSource {
 }
 
 impl PgSource {
+    #[must_use]
     pub fn new(id: String, info: PgSqlInfo, tilejson: TileJSON, pool: Pool) -> Self {
         Self {
-            tilejson,
             id,
             info,
             pool,
+            tilejson,
         }
     }
 }
@@ -84,7 +85,7 @@ impl Source for PgSource {
         };
 
         let tile = tile
-            .map(|row| row.map_or(Default::default(), |r| r.get::<_, Option<Tile>>(0)))
+            .map(|row| row.and_then(|r| r.get::<_, Option<Tile>>(0)))
             .map_err(|e| {
                 if self.support_url_query() {
                     GetTileWithQueryError(e, self.id.to_string(), *xyz, url_query.clone())
@@ -106,6 +107,7 @@ pub struct PgSqlInfo {
 }
 
 impl PgSqlInfo {
+    #[must_use]
     pub fn new(query: String, has_query_params: bool, signature: String) -> Self {
         Self {
             query,

--- a/src/pg/pool.rs
+++ b/src/pg/pool.rs
@@ -38,9 +38,10 @@ impl Pool {
         let pg_cfg = pg::config::Config::from_str(conn_str)
             .map_err(|e| BadConnectionString(e, conn_str.to_string()))?;
 
-        let id = pg_cfg
-            .get_dbname()
-            .map_or_else(|| format!("{:?}", pg_cfg.get_hosts()[0]), |v| v.to_string());
+        let id = pg_cfg.get_dbname().map_or_else(
+            || format!("{:?}", pg_cfg.get_hosts()[0]),
+            ToString::to_string,
+        );
 
         #[cfg(not(feature = "ssl"))]
         let manager = ConnectionManager::new(pg_cfg, postgres::NoTls);
@@ -60,7 +61,7 @@ impl Pool {
             if let Some(file) = &config.ca_root_file {
                 builder
                     .set_ca_file(file)
-                    .map_err(|e| BadTrustedRootCertError(e, file.to_path_buf()))?;
+                    .map_err(|e| BadTrustedRootCertError(e, file.clone()))?;
                 info!("Using {} as trusted root certificate", file.display());
             }
 
@@ -114,10 +115,12 @@ SELECT
             .map_err(|e| PostgresPoolConnError(e, self.id.clone()))
     }
 
+    #[must_use]
     pub fn get_id(&self) -> &str {
         self.id.as_str()
     }
 
+    #[must_use]
     pub fn supports_tile_margin(&self) -> bool {
         self.margin
     }

--- a/src/pg/table_source.rs
+++ b/src/pg/table_source.rs
@@ -59,14 +59,14 @@ pub async fn get_table_sources(pool: &Pool) -> Result<SqlTableInfoMapMapMap> {
 
 fn escape_with_alias(mapping: &HashMap<String, String>, field: &str) -> String {
     let column = mapping.get(field).map_or(field, |v| v.as_str());
-    if field != column {
+    if field == column {
+        format!(", {}", escape_identifier(column))
+    } else {
         format!(
             ", {} AS {}",
             escape_identifier(column),
             escape_identifier(field),
         )
-    } else {
-        format!(", {}", escape_identifier(column))
     }
 }
 
@@ -127,7 +127,7 @@ FROM {schema}.{table};
     let bbox_search = if buffer == 0 {
         "ST_TileEnvelope($1::integer, $2::integer, $3::integer)".to_string()
     } else if pool.supports_tile_margin() {
-        let margin = buffer as f64 / extent as f64;
+        let margin = f64::from(buffer) / f64::from(extent);
         format!("ST_TileEnvelope($1::integer, $2::integer, $3::integer, margin => {margin})")
     } else {
         // TODO: we should use ST_Expand here, but it may require a bit more math work,
@@ -166,6 +166,7 @@ FROM (
     Ok((id, PgSqlInfo::new(query, false, info.format_id()), info))
 }
 
+#[must_use]
 pub fn merge_table_info(
     default_srid: Option<i32>,
     new_id: &String,
@@ -204,6 +205,7 @@ pub fn merge_table_info(
     Some(inf)
 }
 
+#[must_use]
 pub fn calc_srid(
     table_id: &str,
     new_id: &str,

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -8,6 +8,7 @@ use semver::Version;
 use std::collections::HashMap;
 use tilejson::{tilejson, Bounds, TileJSON, VectorLayer};
 
+#[must_use]
 pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
     let mut hashmap = HashMap::new();
 
@@ -20,6 +21,7 @@ pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
     hashmap
 }
 
+#[must_use]
 pub fn query_to_json(query: &UrlQuery) -> Json<InfoMap<serde_json::Value>> {
     let mut query_as_json = HashMap::new();
     for (k, v) in query.iter() {
@@ -32,6 +34,7 @@ pub fn query_to_json(query: &UrlQuery) -> Json<InfoMap<serde_json::Value>> {
     Json(query_as_json)
 }
 
+#[must_use]
 pub fn polygon_to_bbox(polygon: &ewkb::Polygon) -> Option<Bounds> {
     polygon.rings().next().and_then(|linestring| {
         let mut points = linestring.points();
@@ -56,6 +59,7 @@ pub fn parse_x_rewrite_url(header: &HeaderValue) -> Option<String> {
         .map(|uri| uri.path().to_owned())
 }
 
+#[must_use]
 pub fn create_tilejson(
     name: String,
     minzoom: Option<u8>,
@@ -78,6 +82,7 @@ pub fn create_tilejson(
     tilejson
 }
 
+#[must_use]
 pub fn is_valid_zoom(zoom: i32, minzoom: Option<u8>, maxzoom: Option<u8>) -> bool {
     minzoom.map_or(true, |minzoom| zoom >= minzoom.into())
         && maxzoom.map_or(true, |maxzoom| zoom <= maxzoom.into())
@@ -85,6 +90,7 @@ pub fn is_valid_zoom(zoom: i32, minzoom: Option<u8>, maxzoom: Option<u8>) -> boo
 
 #[cfg(test)]
 pub(crate) mod tests {
+    #[allow(clippy::unnecessary_wraps)]
     pub fn some_str(s: &str) -> Option<String> {
         Some(s.to_string())
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -58,6 +58,7 @@ pub struct IdResolver {
 }
 
 impl IdResolver {
+    #[must_use]
     pub fn new(reserved_keywords: &[&'static str]) -> Self {
         Self {
             names: Arc::new(Mutex::new(HashMap::new())),
@@ -68,6 +69,7 @@ impl IdResolver {
     /// If source name already exists in the self.names structure,
     /// try appending it with ".1", ".2", etc. until the name is unique.
     /// Only alphanumeric characters plus dashes/dots/underscores are allowed.
+    #[must_use]
     pub fn resolve(&self, mut name: String, unique_name: String) -> String {
         // Ensure name has no prohibited characters like spaces, commas, slashes, or non-unicode etc.
         // Underscores, dashes, and dots are OK. All other characters will be replaced with dashes.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,6 +41,7 @@ pub fn find_info<'a, T>(map: &'a InfoMap<T>, key: &'a str, info: &str, id: &str)
     find_info_kv(map, key, info, id).map(|(_, v)| v)
 }
 
+#[must_use]
 pub fn find_info_kv<'a, T>(
     map: &'a InfoMap<T>,
     key: &'a str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,6 +26,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[must_use]
 pub fn normalize_key<'a, T>(
     map: &'a InfoMap<T>,
     key: &str,
@@ -35,6 +36,7 @@ pub fn normalize_key<'a, T>(
     find_info_kv(map, key, info, id).map(|(k, _)| k.to_string())
 }
 
+#[must_use]
 pub fn find_info<'a, T>(map: &'a InfoMap<T>, key: &'a str, info: &str, id: &str) -> Option<&'a T> {
     find_info_kv(map, key, info, id).map(|(_, v)| v)
 }
@@ -71,7 +73,7 @@ pub fn find_info_kv<'a, T>(
             Some((result.as_str(), map.get(result)?))
         } else {
             warn!("Unable to configure source {id} because {info} '{key}' was not found.  Possible values are: {}",
-                map.keys().map(|k| k.as_str()).collect::<Vec<_>>().join(", "));
+                map.keys().map(String::as_str).collect::<Vec<_>>().join(", "));
             None
         }
     } else {
@@ -110,6 +112,7 @@ impl Schemas {
     }
 }
 
+#[must_use]
 pub fn get_env_str(name: &str) -> Option<String> {
     match env::var(name) {
         Ok(v) => Some(v),

--- a/tests/function_source_test.rs
+++ b/tests/function_source_test.rs
@@ -7,6 +7,7 @@ use martin::utils::Schemas;
 
 #[path = "utils.rs"]
 mod utils;
+#[allow(clippy::wildcard_imports)]
 use utils::*;
 
 #[ctor]

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -8,6 +8,7 @@ use tilejson::{Bounds, TileJSON};
 
 #[path = "utils.rs"]
 mod utils;
+#[allow(clippy::wildcard_imports)]
 use utils::*;
 
 #[ctor]
@@ -529,7 +530,7 @@ async fn tables_feature_id() {
     // --------------------------------------------
 
     let app = create_app!(mock_config(None, Some(tables.clone()), None));
-    for (name, _) in tables.iter() {
+    for (name, _) in &tables {
         let req = test_get(format!("/{name}/0/0/0").as_str());
         let response = call_service(&app, req).await;
         assert!(response.status().is_success());

--- a/tests/table_source_test.rs
+++ b/tests/table_source_test.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 #[path = "utils.rs"]
 mod utils;
+#[allow(clippy::wildcard_imports)]
 use utils::*;
 
 #[ctor]
@@ -69,7 +70,7 @@ async fn tables_tile_ok() {
 
 #[actix_rt::test]
 async fn tables_srid_ok() {
-    let mock = mock_unconfigured_srid(Some(900913)).await;
+    let mock = mock_unconfigured_srid(Some(900_913)).await;
 
     let source = table(&mock, "points1");
     assert_eq!(source.srid, 4326);
@@ -81,7 +82,7 @@ async fn tables_srid_ok() {
     assert_eq!(source.srid, 3857);
 
     let source = table(&mock, "points_empty_srid");
-    assert_eq!(source.srid, 900913);
+    assert_eq!(source.srid, 900_913);
 }
 
 #[actix_rt::test]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,17 +5,19 @@ set -euo pipefail
 CURL=${CURL:-curl -sSf}
 DATABASE_URL="${DATABASE_URL:-postgres://postgres@localhost/db}"
 MARTIN_BUILD="${MARTIN_BUILD:-cargo build}"
-MARTIN_BIN="${MARTIN_BIN:-cargo run --}"
+MARTIN_PORT="${MARTIN_PORT:-3000}"
+MARTIN_URL="http://localhost:${MARTIN_PORT}"
+MARTIN_BIN="${MARTIN_BIN:-cargo run -- --listen-addresses localhost:${MARTIN_PORT}}"
 
 function wait_for_martin {
     # Seems the --retry-all-errors option is not available on older curl versions, but maybe in the future we can just use this:
-    # timeout -k 20s 20s curl --retry 10 --retry-all-errors --retry-delay 1 -sS http://localhost:3000/health
+    # timeout -k 20s 20s curl --retry 10 --retry-all-errors --retry-delay 1 -sS "$MARTIN_URL/health"
     PROCESS_ID=$1
     echo "Waiting for Martin ($PROCESS_ID) to start..."
     for i in {1..30}; do
-        if curl -sSf http://localhost:3000/health 2>/dev/null >/dev/null; then
+        if curl -sSf "$MARTIN_URL/health" 2>/dev/null >/dev/null; then
             echo "Martin is up!"
-            curl -s http://localhost:3000/health
+            curl -s "$MARTIN_URL/health"
             return
         fi
         if ps -p $PROCESS_ID > /dev/null ; then
@@ -55,7 +57,7 @@ function kill_process {
 test_pbf()
 {
   FILENAME="$TEST_OUT_DIR/$1.pbf"
-  URL=$2
+  URL="$MARTIN_URL/$2"
 
   echo "Testing $(basename "$FILENAME") from $URL"
   $CURL "$URL" > "$FILENAME"
@@ -91,51 +93,51 @@ TEST_OUT_DIR="$(dirname "$0")/output/auto"
 mkdir -p "$TEST_OUT_DIR"
 
 >&2 echo "Test catalog"
-$CURL http://localhost:3000/catalog | jq --sort-keys -e | tee "$TEST_OUT_DIR/catalog.json"
+$CURL "$MARTIN_URL/catalog" | jq --sort-keys -e | tee "$TEST_OUT_DIR/catalog.json"
 
 >&2 echo "Test server response for table source"
-test_pbf tbl_0_0_0              http://localhost:3000/table_source/0/0/0
-test_pbf tbl_6_38_20            http://localhost:3000/table_source/6/38/20
-test_pbf tbl_12_2476_1280       http://localhost:3000/table_source/12/2476/1280
-test_pbf tbl_13_4952_2560       http://localhost:3000/table_source/13/4952/2560
-test_pbf tbl_14_9904_5121       http://localhost:3000/table_source/14/9904/5121
-test_pbf tbl_20_633856_327787   http://localhost:3000/table_source/20/633856/327787
-test_pbf tbl_21_1267712_655574  http://localhost:3000/table_source/21/1267712/655574
+test_pbf tbl_0_0_0                table_source/0/0/0
+test_pbf tbl_6_38_20              table_source/6/38/20
+test_pbf tbl_12_2476_1280         table_source/12/2476/1280
+test_pbf tbl_13_4952_2560         table_source/13/4952/2560
+test_pbf tbl_14_9904_5121         table_source/14/9904/5121
+test_pbf tbl_20_633856_327787     table_source/20/633856/327787
+test_pbf tbl_21_1267712_655574    table_source/21/1267712/655574
 
 >&2 echo "Test server response for composite source"
-test_pbf cmp_0_0_0              http://localhost:3000/table_source,points1,points2/0/0/0
-test_pbf cmp_6_38_20            http://localhost:3000/table_source,points1,points2/6/38/20
-test_pbf cmp_12_2476_1280       http://localhost:3000/table_source,points1,points2/12/2476/1280
-test_pbf cmp_13_4952_2560       http://localhost:3000/table_source,points1,points2/13/4952/2560
-test_pbf cmp_14_9904_5121       http://localhost:3000/table_source,points1,points2/14/9904/5121
-test_pbf cmp_20_633856_327787   http://localhost:3000/table_source,points1,points2/20/633856/327787
-test_pbf cmp_21_1267712_655574  http://localhost:3000/table_source,points1,points2/21/1267712/655574
+test_pbf cmp_0_0_0                table_source,points1,points2/0/0/0
+test_pbf cmp_6_38_20              table_source,points1,points2/6/38/20
+test_pbf cmp_12_2476_1280         table_source,points1,points2/12/2476/1280
+test_pbf cmp_13_4952_2560         table_source,points1,points2/13/4952/2560
+test_pbf cmp_14_9904_5121         table_source,points1,points2/14/9904/5121
+test_pbf cmp_20_633856_327787     table_source,points1,points2/20/633856/327787
+test_pbf cmp_21_1267712_655574    table_source,points1,points2/21/1267712/655574
 
 >&2 echo "Test server response for function source"
-test_pbf fnc_0_0_0              http://localhost:3000/function_zxy_query/0/0/0
-test_pbf fnc_6_38_20            http://localhost:3000/function_zxy_query/6/38/20
-test_pbf fnc_12_2476_1280       http://localhost:3000/function_zxy_query/12/2476/1280
-test_pbf fnc_13_4952_2560       http://localhost:3000/function_zxy_query/13/4952/2560
-test_pbf fnc_14_9904_5121       http://localhost:3000/function_zxy_query/14/9904/5121
-test_pbf fnc_20_633856_327787   http://localhost:3000/function_zxy_query/20/633856/327787
-test_pbf fnc_21_1267712_655574  http://localhost:3000/function_zxy_query/21/1267712/655574
-test_pbf fnc_0_0_0_token        http://localhost:3000/function_zxy_query_test/0/0/0?token=martin
+test_pbf fnc_0_0_0                function_zxy_query/0/0/0
+test_pbf fnc_6_38_20              function_zxy_query/6/38/20
+test_pbf fnc_12_2476_1280         function_zxy_query/12/2476/1280
+test_pbf fnc_13_4952_2560         function_zxy_query/13/4952/2560
+test_pbf fnc_14_9904_5121         function_zxy_query/14/9904/5121
+test_pbf fnc_20_633856_327787     function_zxy_query/20/633856/327787
+test_pbf fnc_21_1267712_655574    function_zxy_query/21/1267712/655574
+test_pbf fnc_0_0_0_token          function_zxy_query_test/0/0/0?token=martin
 
 >&2 echo "Test server response for different function call types"
-test_pbf fnc_zoom_xy_6_38_20        http://localhost:3000/function_zoom_xy/6/38/20
-test_pbf fnc_zxy_6_38_20            http://localhost:3000/function_zxy/6/38/20
-test_pbf fnc_zxy2_6_38_20           http://localhost:3000/function_zxy2/6/38/20
-test_pbf fnc_zxy_query_6_38_20      http://localhost:3000/function_zxy_query/6/38/20
-test_pbf fnc_zxy_row_6_38_20        http://localhost:3000/function_zxy_row/6/38/20
-test_pbf fnc_zxy_row2_6_38_20       http://localhost:3000/function_Mixed_Name/6/38/20
-test_pbf fnc_zxy_row_key_6_38_20    http://localhost:3000/function_zxy_row_key/6/38/20
+test_pbf fnc_zoom_xy_6_38_20      function_zoom_xy/6/38/20
+test_pbf fnc_zxy_6_38_20          function_zxy/6/38/20
+test_pbf fnc_zxy2_6_38_20         function_zxy2/6/38/20
+test_pbf fnc_zxy_query_6_38_20    function_zxy_query/6/38/20
+test_pbf fnc_zxy_row_6_38_20      function_zxy_row/6/38/20
+test_pbf fnc_zxy_row2_6_38_20     function_Mixed_Name/6/38/20
+test_pbf fnc_zxy_row_key_6_38_20  function_zxy_row_key/6/38/20
 
 >&2 echo "Test server response for table source with different SRID"
-test_pbf points3857_srid_0_0_0  http://localhost:3000/points3857/0/0/0
+test_pbf points3857_srid_0_0_0    points3857/0/0/0
 
 >&2 echo "Test server response for table source with empty SRID"
 echo "IGNORING: This test is currently failing, and has been failing for a while"
-echo "IGNORING:   " test_pbf points_empty_srid_0_0_0  http://localhost:3000/points_empty_srid/0/0/0
+echo "IGNORING:   " test_pbf points_empty_srid_0_0_0  points_empty_srid/0/0/0
 
 kill_process $PROCESS_ID
 grep -e ' ERROR ' -e ' WARN ' test_log_1.txt && exit 1
@@ -156,12 +158,12 @@ TEST_OUT_DIR="$(dirname "$0")/output/configured"
 mkdir -p "$TEST_OUT_DIR"
 
 >&2 echo "Test catalog"
-$CURL http://localhost:3000/catalog | jq --sort-keys -e | tee "$TEST_OUT_DIR/catalog.json"
+$CURL "$MARTIN_URL/catalog" | jq --sort-keys -e | tee "$TEST_OUT_DIR/catalog.json"
 
-test_pbf tbl_0_0_0  http://localhost:3000/table_source/0/0/0
-test_pbf cmp_0_0_0  http://localhost:3000/points1,points2/0/0/0
-test_pbf fnc_0_0_0  http://localhost:3000/function_zxy_query/0/0/0
-test_pbf fnc2_0_0_0 http://localhost:3000/function_zxy_query_test/0/0/0?token=martin
+test_pbf tbl_0_0_0   table_source/0/0/0
+test_pbf cmp_0_0_0   points1,points2/0/0/0
+test_pbf fnc_0_0_0   function_zxy_query/0/0/0
+test_pbf fnc2_0_0_0  function_zxy_query_test/0/0/0?token=martin
 
 kill_process $PROCESS_ID
 grep -e ' ERROR ' -e ' WARN ' test_log_2.txt && exit 1

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,4 +1,6 @@
+#![allow(clippy::missing_panics_doc)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::unused_async)]
 
 use actix_web::web::Data;
 use log::info;
@@ -87,14 +89,19 @@ pub async fn mock_configured_tables(default_srid: Option<i32>) -> PgConfig {
     mock_config(None, mock_table_config(), default_srid).await
 }
 
+#[must_use]
+#[allow(clippy::unnecessary_wraps)]
 pub fn mock_func_config() -> Option<Vec<(&'static str, FunctionInfo)>> {
     Some(mock_func_config_map().into_iter().collect())
 }
 
+#[must_use]
+#[allow(clippy::unnecessary_wraps)]
 pub fn mock_table_config() -> Option<Vec<(&'static str, TableInfo)>> {
     Some(mock_table_config_map().into_iter().collect())
 }
 
+#[must_use]
 pub fn mock_func_config_map() -> HashMap<&'static str, FunctionInfo> {
     let default = FunctionInfo::default();
     [
@@ -168,6 +175,8 @@ pub fn mock_func_config_map() -> HashMap<&'static str, FunctionInfo> {
     .collect()
 }
 
+#[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
     let default = TableInfo {
         srid: 4326,
@@ -233,7 +242,7 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
             TableInfo {
                 schema: "public".to_string(),
                 table: "points_empty_srid".to_string(),
-                srid: 900973,
+                srid: 900_973,
                 geometry_column: "geom".to_string(),
                 geometry_type: some_str("GEOMETRY"),
                 properties: props(&[("gid", "int4")]),
@@ -278,26 +287,30 @@ pub fn mock_table_config_map() -> HashMap<&'static str, TableInfo> {
     .collect()
 }
 
+#[must_use]
 pub fn props(props: &[(&'static str, &'static str)]) -> HashMap<String, String> {
     props
         .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
         .collect()
 }
 
 #[allow(dead_code)]
+#[must_use]
 pub fn table<'a>(mock: &'a MockSource, name: &str) -> &'a TableInfo {
     let (_, PgConfig { tables, .. }) = mock;
     tables.as_ref().map(|v| v.get(name).unwrap()).unwrap()
 }
 
 #[allow(dead_code)]
+#[must_use]
 pub fn source<'a>(mock: &'a MockSource, name: &str) -> &'a dyn Source {
     let (sources, _) = mock;
     sources.get(name).unwrap().as_ref()
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::unnecessary_wraps)]
+#[must_use]
 pub fn some_str(s: &str) -> Option<String> {
     Some(s.to_string())
 }


### PR DESCRIPTION
Pedantic lints often offer some good insight into the code. It is usually easier to sprinkle a few "allow"-s around, than to miss some important life hack offered by clippy.

Also, make use a different martin port when running integration tests locally (make sure `git push` works even if martin is running).