### PR TITLE
Include full test into the coverage

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -46,7 +46,12 @@ jobs:
           override: true
 
       - name: Run tests
-        run: cargo test
+        run: |
+          cargo test
+          cargo test --all-targets
+          cargo test --all-targets --all-features
+          cargo test --doc
+          # tests/test.sh
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'


### PR DESCRIPTION
This is a test to see if multiple runs in the grcov github workflow would increase the coverage.  So far seems like only the last one is used