### PR TITLE
tests, report unknown cfg, rm catalog vector flds

### DIFF
--- a/src/srv/server.rs
+++ b/src/srv/server.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use log::{debug, error};
 use martin_tile_utils::DataFormat;
 use serde::{Deserialize, Serialize};
-use tilejson::{TileJSON, VectorLayer};
+use tilejson::TileJSON;
 
 use crate::source::{Source, Sources, UrlQuery, Xyz};
 use crate::srv::config::{SrvConfig, KEEP_ALIVE_DEFAULT, LISTEN_ADDRESSES_DEFAULT};
@@ -106,8 +106,6 @@ pub struct IndexEntry {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribution: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vector_layer: Option<Vec<VectorLayer>>,
 }
 
 impl PartialOrd<Self> for IndexEntry {
@@ -159,7 +157,6 @@ async fn get_catalog(state: Data<AppState>) -> impl Responder {
                 name: tilejson.name,
                 description: tilejson.description,
                 attribution: tilejson.attribution,
-                vector_layer: tilejson.vector_layers,
             }
         })
         .sorted()

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -126,17 +126,6 @@
     "content_type": "application/x-protobuf",
     "description": "Major cities from Natural Earth data",
     "id": "world_cities",
-    "name": "Major cities from Natural Earth data",
-    "vector_layer": [
-      {
-        "description": "",
-        "fields": {
-          "name": "String"
-        },
-        "id": "cities",
-        "maxzoom": 6,
-        "minzoom": 0
-      }
-    ]
+    "name": "Major cities from Natural Earth data"
   }
 ]

--- a/tests/pg_function_source_test.rs
+++ b/tests/pg_function_source_test.rs
@@ -1,7 +1,6 @@
 use ctor::ctor;
 use indoc::indoc;
 use itertools::Itertools;
-use martin::pg::get_function_sources;
 use martin::Xyz;
 
 pub mod utils;
@@ -10,26 +9,6 @@ pub use utils::*;
 #[ctor]
 fn init() {
     let _ = env_logger::builder().is_test(true).try_init();
-}
-
-#[actix_rt::test]
-async fn get_function_sources_ok() {
-    let pool = mock_pool().await;
-    let sources = get_function_sources(&pool).await.unwrap();
-
-    assert!(!sources.is_empty());
-
-    let funcs = sources.get("public").unwrap();
-    let source = funcs.get("function_zxy_query").unwrap();
-    assert_eq!(source.1.schema, "public");
-    assert_eq!(source.1.function, "function_zxy_query");
-    assert_eq!(source.1.minzoom, None);
-    assert_eq!(source.1.maxzoom, None);
-    assert_eq!(source.1.bounds, None);
-
-    let source = funcs.get("function_zxy_query_jsonb").unwrap();
-    assert_eq!(source.1.schema, "public");
-    assert_eq!(source.1.function, "function_zxy_query_jsonb");
 }
 
 #[actix_rt::test]

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -25,6 +25,7 @@ pub fn mock_cfg(yaml: &str) -> Config {
     };
     let env = FauxEnv(vec![("DATABASE_URL", db_url.into())].into_iter().collect());
     let mut cfg: Config = subst::yaml::from_str(yaml, &env).unwrap();
-    cfg.finalize().unwrap();
+    let res = cfg.finalize().unwrap();
+    assert!(res.is_empty(), "unrecognized config: {res:?}");
     cfg
 }


### PR DESCRIPTION
* clean up reporting of the un-used config params - instead of printing, collect them and print in one place if needed (allows testing too)
* remove `vector_layer` in catalog - too verbose, not needed - can be received via tilejson for individual source
* clean up tests so that they all use the same config yaml