### PR TITLE
Improve SSL support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,25 +189,43 @@ jobs:
         include:
           # These must match the versions of postgres used in the docker-compose.yml
           - image: postgis/postgis:11-3.0-alpine
+            args: postgres
+            sslmode: disable
           - image: postgis/postgis:14-3.3-alpine
+            args: postgres
+            sslmode: disable
+          # alpine images don't support SSL, so for this we use the debian images
+          - image: postgis/postgis:15-3.3
+            args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+            sslmode: require
     env:
       # PG_* variables are used by psql
       PGDATABASE: test
       PGHOST: localhost
       PGUSER: postgres
+      PGPASSWORD: postgres
     services:
       postgres:
         image: ${{ matrix.image }}
-        env:
-          # POSTGRES_* variables are used by the postgis/postgres image
-          POSTGRES_DB: ${{ env.PGDATABASE }}
-          POSTGRES_USER: ${{ env.PGUSER }}
-          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           # will assign a random free host port
           - 5432/tcp
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        # Sadly there is currently no way to pass arguments to the service image other than this hack
+        # See also https://stackoverflow.com/a/62720566/177275
+        options: >-
+          -e POSTGRES_DB=test
+          -e POSTGRES_USER=postgres
+          -e POSTGRES_PASSWORD=postgres
+          -e PGDATABASE=test
+          -e PGUSER=postgres
+          -e PGPASSWORD=postgres
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --entrypoint sh
+          ${{ matrix.image }}
+          -c "exec docker-entrypoint.sh ${{ matrix.args }}"
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -220,12 +238,18 @@ jobs:
     - name: Unit Tests (Linux)
       shell: bash
       run: |
-        cargo test --all-targets
+        echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"
+        echo "Same but as base64 to prevent GitHub obfuscation (this is not a secret):"
+        echo "$DATABASE_URL" | base64
+        if [[ "${{ matrix.sslmode }}" == "disable" ]]; then
+          # This only works if SSL is not required
+          cargo test --all-targets
+        fi
         cargo test --all-targets --all-features
         cargo test --doc
         rm -rf target
       env:
-        DATABASE_URL: postgres://${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
+        DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
     - name: Save test output on failure
       if: failure()
       uses: actions/upload-artifact@v3
@@ -242,6 +266,6 @@ jobs:
         chmod +x target/martin
         tests/test.sh
       env:
-        DATABASE_URL: postgres://${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
+        DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
         MARTIN_BUILD: "-"
         MARTIN_BIN: target/martin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "postgres",
  "postgres-openssl",
  "postgres-protocol",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ postgis = "0.9"
 postgres = { version = "0.19", features = ["with-time-0_3", "with-uuid-1", "with-serde_json-1"] }
 postgres-openssl = { version = "0.5", optional = true }
 postgres-protocol = "0.6"
+regex = "1"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README-main.md
+++ b/README-main.md
@@ -1,11 +1,11 @@
-# WARNING
+<h1>WARNING</h1>
 This documentation is for the unreleased main branch.
 
 The documentation for the latest release v0.6 is available [here](https://github.com/maplibre/martin/tree/v0.6#readme).
 
 ----
 
-# Martin
+<h1>Martin</h1>
 
 [![CI](https://github.com/maplibre/martin/workflows/CI/badge.svg)](https://github.com/maplibre/martin/actions)
 ![Security audit](https://github.com/maplibre/martin/workflows/Security%20audit/badge.svg)
@@ -15,43 +15,49 @@ Martin is a tile server able to generate [vector tiles](https://github.com/mapbo
 
 ![Martin](https://raw.githubusercontent.com/maplibre/martin/main/logo.png)
 
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Usage](#usage)
-- [API](#api)
-- [Using with MapLibre GL JS](#using-with-maplibre)
-- [Using with Leaflet](#using-with-leaflet)
-- [Using with deck.gl](#using-with-deckgl)
-- [Sources List](#source-list)
-- [Composite Sources](#composite-sources)
-  - [Composite Source TileJSON](#composite-source-tilejson)
-  - [Composite Source Tiles](#composite-source-tiles)
-- [Table Sources](#table-sources)
-  - [Table Source TileJSON](#table-source-tilejson)
-  - [Table Source Tiles](#table-source-tiles)
-- [Function Sources](#function-sources)
-  - [Function Source TileJSON](#function-source-tilejson)
-  - [Function Source Tiles](#function-source-tiles)
-- [Command-line Interface](#command-line-interface)
-- [Environment Variables](#environment-variables)
-- [Configuration File](#configuration-file)
-- [Using with Docker](#using-with-docker)
-- [Using with Docker Compose](#using-with-docker-compose)
-- [Using with Nginx](#using-with-nginx)
-  - [Rewriting URLs](#rewriting-urls)
-  - [Caching tiles](#caching-tiles)
-- [Building from Source](#building-from-source)
-- [Debugging](#debugging)
-- [Development](#development)
-- [Recipes](#recipes)
-  - [Using with DigitalOcean PostgreSQL](#using-with-digitalocean-postgresql)
-  - [Using with Heroku PostgreSQL](#using-with-heroku-postgresql)
+<!-- TOC -->
+* [Requirements](#requirements)
+* [Installation](#installation)
+* [Usage](#usage)
+* [API](#api)
+* [Using with MapLibre](#using-with-maplibre)
+* [Using with Leaflet](#using-with-leaflet)
+* [Using with deck.gl](#using-with-deckgl)
+* [Using with Mapbox](#using-with-mapbox)
+* [Source List](#source-list)
+* [Composite Sources](#composite-sources)
+  * [Composite Source TileJSON](#composite-source-tilejson)
+  * [Composite Source Tiles](#composite-source-tiles)
+* [Table Sources](#table-sources)
+  * [Table Source TileJSON](#table-source-tilejson)
+  * [Table Source Tiles](#table-source-tiles)
+* [Function Sources](#function-sources)
+  * [Function Source TileJSON](#function-source-tilejson)
+  * [Function Source Tiles](#function-source-tiles)
+* [MBTile and PMTile Sources](#mbtile-and-pmtile-sources)
+* [Command-line Interface](#command-line-interface)
+* [Environment Variables](#environment-variables)
+* [Configuration File](#configuration-file)
+* [PostgreSQL SSL Connections](#postgresql-ssl-connections)
+* [Using with Docker](#using-with-docker)
+* [Using with Docker Compose](#using-with-docker-compose)
+* [Using with Nginx](#using-with-nginx)
+  * [Rewriting URLs](#rewriting-urls)
+  * [Caching tiles](#caching-tiles)
+* [Building from Source](#building-from-source)
+* [Debugging](#debugging)
+* [Development](#development)
+  * [Other useful commands](#other-useful-commands)
+* [Recipes](#recipes)
+  * [Using with DigitalOcean PostgreSQL](#using-with-digitalocean-postgresql)
+  * [Using with Heroku PostgreSQL](#using-with-heroku-postgresql)
+<!-- TOC -->
 
-## Requirements
+# Requirements
 
-Martin requires PostGIS >= 3.0.0
+Martin requires PostGIS 3.0+.  PostGIS 3.1+ is recommended.
 
-## Installation
+# Installation
 
 You can download martin from [GitHub releases page](https://github.com/maplibre/martin/releases).
 
@@ -79,7 +85,7 @@ export PGPASSWORD=postgres  # secret!
 docker run -p 3000:3000 -e PGPASSWORD -e DATABASE_URL=postgresql://postgres@localhost/db maplibre/martin
 ```
 
-## Usage
+# Usage
 
 Martin requires a database connection string. It can be passed as a command-line argument or as a `DATABASE_URL` environment variable.
 
@@ -89,7 +95,7 @@ martin postgresql://postgres@localhost/db
 
 Martin provides [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint for each [geospatial-enabled](https://postgis.net/docs/postgis_usage.html#geometry_columns) table in your database.
 
-## API
+# API
 
 When started, martin will go through all spatial tables and functions with an appropriate signature in the database. These tables and functions will be available as the HTTP endpoints, which you can use to query Mapbox vector tiles.
 
@@ -103,7 +109,7 @@ When started, martin will go through all spatial tables and functions with an ap
 | `GET`  | `/{name1},...,{nameN}/{z}/{x}/{y}` | [Composite Source Tiles](#composite-source-tiles)       |
 | `GET`  | `/health`                          | Martin server health check: returns 200 `OK`            |
 
-## Using with MapLibre
+# Using with MapLibre
 [MapLibre](https://maplibre.org/projects/maplibre-gl-js/) is an Open-source JavaScript library for showing maps on a website. MapLibre can accept [MVT vector tiles](https://github.com/mapbox/vector-tile-spec) generated by Martin, and applies [a style](https://maplibre.org/maplibre-gl-js-docs/style-spec/) to them to draw a map using Web GL.
 
 You can add a layer to the map and specify Martin [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint as a vector source URL. You should also specify a `source-layer` property. For [Table Sources](#table-sources) it is `{table_name}` by default.
@@ -169,7 +175,7 @@ map.addLayer({
 });
 ```
 
-## Using with Leaflet
+# Using with Leaflet
 
 [Leaflet](https://github.com/Leaflet/Leaflet) is the leading open-source JavaScript library for mobile-friendly interactive maps.
 
@@ -188,7 +194,7 @@ L.vectorGrid
   .addTo(map);
 ```
 
-## Using with deck.gl
+# Using with deck.gl
 
 [deck.gl](https://deck.gl/) is a WebGL-powered framework for visual exploratory data analysis of large datasets.
 
@@ -218,7 +224,7 @@ const deckgl = new DeckGL({
 });
 ```
 
-## Using with Mapbox
+# Using with Mapbox
 
 [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) is a JavaScript library for interactive, customizable vector maps on the web. Mapbox GL JS v1.x was open source, and it was forked as MapLibre (see [above](#using-with-maplibre)), so using Martin with Mapbox is similar to MapLibre. Mapbox GL JS can accept [MVT vector tiles](https://github.com/mapbox/vector-tile-spec) generated by Martin, and applies [a style](https://docs.mapbox.com/mapbox-gl-js/style-spec/) to them to draw a map using Web GL.
 
@@ -239,7 +245,7 @@ map.addLayer({
 });
 ```
 
-## Source List
+# Source List
 
 A list of all available sources is available in a catalogue:
 
@@ -261,13 +267,13 @@ curl localhost:3000/catalog | jq
 ]
 ```
 
-## Composite Sources
+# Composite Sources
 
 Composite Sources allows combining multiple sources into one. Composite Source consists of multiple sources separated by comma `{source1},...,{sourceN}`
 
 Each source in a composite source can be accessed with its `{source_name}` as a `source-layer` property.
 
-### Composite Source TileJSON
+## Composite Source TileJSON
 
 Composite Source [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint is available at `/{source1},...,{sourceN}`.
 
@@ -277,7 +283,7 @@ For example, composite source combining `points` and `lines` sources will be ava
 curl localhost:3000/points,lines | jq
 ```
 
-### Composite Source Tiles
+## Composite Source Tiles
 
 Composite Source tiles endpoint is available at `/{source1},...,{sourceN}/{z}/{x}/{y}`
 
@@ -287,11 +293,11 @@ For example, composite source combining `points` and `lines` sources will be ava
 curl localhost:3000/points,lines/0/0/0
 ```
 
-## Table Sources
+# Table Sources
 
 Table Source is a database table which can be used to query [vector tiles](https://github.com/mapbox/vector-tile-spec). When started, martin will go through all spatial tables in the database and build a list of table sources. A table should have at least one geometry column with non-zero SRID. All other table columns will be represented as properties of a vector tile feature.
 
-### Table Source TileJSON
+## Table Source TileJSON
 
 Table Source [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint is available at `/{table_name}`.
 
@@ -301,7 +307,7 @@ For example, `points` table will be available at `/points`, unless there is anot
 curl localhost:3000/points | jq
 ```
 
-### Table Source Tiles
+## Table Source Tiles
 
 Table Source tiles endpoint is available at `/{table_name}/{z}/{x}/{y}`
 
@@ -317,7 +323,7 @@ In case if you have multiple geometry columns in that table and want to access a
 curl localhost:3000/points.geom/0/0/0
 ```
 
-## Function Sources
+# Function Sources
 
 Function Source is a database function which can be used to query [vector tiles](https://github.com/mapbox/vector-tile-spec). When started, martin will look for the functions with a suitable signature. A function that takes `z integer` (or `zoom integer`), `x integer`, `y integer`, and an optional `query json` and returns `bytea`, can be used as a Function Source. Alternatively the function could return a record with a single `bytea` field, or a record with two fields of types `bytea` and `text`, where the `text` field is an etag key (i.e. md5 hash).  
 
@@ -394,7 +400,7 @@ You can access this params using [json operators](https://www.postgresql.org/doc
 ...WHERE answer = (query_params->'objectParam'->>'answer')::int;
 ```
 
-### Function Source TileJSON
+## Function Source TileJSON
 
 Function Source [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint is available at `/{function_name}`
 
@@ -404,7 +410,7 @@ For example, `points` function will be available at `/points`
 curl localhost:3000/points | jq
 ```
 
-### Function Source Tiles
+## Function Source Tiles
 
 Function Source tiles endpoint is available at `/{function_name}/{z}/{x}/{y}`
 
@@ -414,7 +420,7 @@ For example, `points` function will be available at `/points/{z}/{x}/{y}`
 curl localhost:3000/points/0/0/0
 ```
 
-## MBTile and PMTile Sources
+# MBTile and PMTile Sources
 
 Martin can serve any type of tiles from [PMTile](https://protomaps.com/blog/pmtiles-v3-whats-new) and [MBTile](https://github.com/mapbox/mbtiles-spec) files.  To serve a file from CLI, simply put the path to the file or the directory with `*.mbtiles` or `*.pmtiles` files. For example:
 
@@ -425,25 +431,29 @@ martin  /path/to/mbtiles/file.mbtiles  /path/to/directory
 You may also want to generate a [config file](#configuration-file) using the `--save-config my-config.yaml`, and later edit it and use it with `--config my-config.yaml` option.
 
 
-## Command-line Interface
+# Command-line Interface
 
 You can configure martin using command-line interface. See `martin --help` or `cargo run -- --help` for more information.
 
 ```shell
-Usage: martin [OPTIONS] [CONNECTION]
+Usage: martin [OPTIONS] [CONNECTION]...
 
 Arguments:
-  [CONNECTION]  Database connection string
+  [CONNECTION]...  Connection strings, e.g. postgres://... or /path/to/files
 
 Options:
   -c, --config <CONFIG>
-          Path to config file
+          Path to config file. If set, no tile source-related parameters are allowed
+      --save-config <SAVE_CONFIG>
+          Save resulting config to a file or use "-" to print to stdout. By default, only print if sources are auto-detected
   -k, --keep-alive <KEEP_ALIVE>
           Connection keep alive timeout. [DEFAULT: 75]
   -l, --listen-addresses <LISTEN_ADDRESSES>
           The socket address to bind. [DEFAULT: 0.0.0.0:3000]
   -W, --workers <WORKERS>
           Number of web server workers
+  -b, --disable-bounds
+          Disable the automatic generation of bounds for spatial tables
       --ca-root-file <CA_ROOT_FILE>
           Loads trusted root certificates from a file. The file should contain a sequence of PEM-formatted CA certificates
   -d, --default-srid <DEFAULT_SRID>
@@ -451,23 +461,24 @@ Options:
   -p, --pool-size <POOL_SIZE>
           Maximum connections pool size [DEFAULT: 20]
   -h, --help
-          Print help information
+          Print help
   -V, --version
-          Print version information
+          Print version
 ```
 
-## Environment Variables
+# Environment Variables
 
-You can also configure martin using environment variables, but only if the configuration file is not used. See [configuration section](#configuration-file) on how to use environment variables with config files.
+You can also configure martin using environment variables, but only if the configuration file is not used. See [configuration section](#configuration-file) on how to use environment variables with config files. See also [SSL configuration](#postgresql-ssl-connections) section below.
 
-| Environment variable          | Example                              | Description                                 |
-|-------------------------------|--------------------------------------|---------------------------------------------|
-| `DATABASE_URL`                | `postgresql://postgres@localhost/db` | Postgres database connection                |
-| `CA_ROOT_FILE`                | `./ca-certificate.crt`               | Loads trusted root certificates from a file |
-| `DEFAULT_SRID`                | `4326`                               | Fallback SRID                               |
-| `DANGER_ACCEPT_INVALID_CERTS` | `0`                                  | Trust invalid certificates (any value)      |
+| Environment var <br/> Config File key    | Example                              | Description                                                                                                                                                                                                                                                                                            |
+|------------------------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DATABASE_URL` <br/> `connection_string` | `postgresql://postgres@localhost/db` | Postgres database connection                                                                                                                                                                                                                                                                           |
+| `DEFAULT_SRID` <br/> `default_srid`      | `4326`                               | If a PostgreSQL table has a geometry column with SRID=0, use this value instead                                                                                                                                                                                                                        |
+| `PGSSLCERT` <br/> `ssl_cert`             | `./postgresql.crt`                   | A file with a client SSL certificate. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT)                                                                                                                                                                         |
+| `PGSSLKEY` <br/> `ssl_key`               | `./postgresql.key`                   | A file with the key for the client SSL certificate. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLKEY)                                                                                                                                                            |
+| `PGSSLROOTCERT` <br/> `ssl_root_cert`    | `./root.crt`                         | A file with trusted root certificate(s). The file should contain a sequence of PEM-formatted CA certificates. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT)<br/>This env var used to be called `CA_ROOT_FILE`, but support for it will be removed soon. |
 
-## Configuration File
+# Configuration File
 
 If you don't want to expose all of your tables and functions, you can list your sources in a configuration file. To start martin with a configuration file you need to pass a path to a file with a `--config` argument. Config files may contain environment variables, which will be expanded before parsing. For example, to use `MY_DATABASE_URL` in your config file: `connection_string: ${MY_DATABASE_URL}`, or with a default `connection_string: ${MY_DATABASE_URL:-postgresql://postgres@localhost/db}`
 
@@ -478,22 +489,29 @@ martin --config config.yaml
 You may wish to auto-generate a config file with `--save-config` argument. This will generate a config yaml file with all of your configuration, which you can edit to remove any sources you don't want to expose.
 
 ```yaml
-# Connection keep alive timeout [default: 75]
+ Connection keep alive timeout [default: 75]
 keep_alive: 75
 
-# The socket address to bind [default: 0.0.0.0:3000]
+ The socket address to bind [default: 0.0.0.0:3000]
 listen_addresses: '0.0.0.0:3000'
 
-# Number of web server workers
+ Number of web server workers
 worker_processes: 8
 
-# Database configuration. This can also be a list of PG configs.
+ Database configuration. This can also be a list of PG configs.
 postgres:
   # Database connection string. You can use env vars too, for example:
   #   $DATABASE_URL
   #   ${DATABASE_URL:-postgresql://postgres@localhost/db}
   connection_string: 'postgresql://postgres@localhost:5432/db'
-  
+
+  # Same as PGSSLCERT for psql
+  ssl_cert: './postgresql.crt'
+  # Same as PGSSLKEY for psql
+  ssl_key: './postgresql.key'
+  # Same as PGSSLROOTCERT for psql
+  ssl_root_cert: './root.crt'
+
   #  If a spatial table has SRID 0, then this SRID will be used as a fallback
   default_srid: 4326
   
@@ -589,7 +607,7 @@ postgres:
       # Values may be integers or floating point numbers.
       bounds: [-180.0, -90.0, 180.0, 90.0]
 
-# Publish PMTiles files
+ Publish PMTiles files
 pmtiles:
   paths:
     # scan this whole dir, matching all *.pmtiles files
@@ -600,7 +618,7 @@ pmtiles:
     # named source matching source name to a single file
     pm-src1: /path/to/pmtiles1.pmtiles
 
-# Publish MBTiles files
+ Publish MBTiles files
 mbtiles:
   paths:
     # scan this whole dir, matching all *.mbtiles files
@@ -612,7 +630,12 @@ mbtiles:
     mb-src1: /path/to/mbtiles1.mbtiles
 ```
 
-## Using with Docker
+# PostgreSQL SSL Connections
+Martin supports PostgreSQL `sslmode` including `disable`, `prefer`, `require`, `verify-ca` and `verify-full` modes as described in the [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-ssl.html).  Certificates can be provided in the configuration file, or can be set using the same env vars as used for `psql`. When set as env vars, they apply to all PostgreSQL connections.  See [environment vars](#environment-variables) section for more details.
+
+By default, `sslmode` is set to `prefer` which means that SSL is used if the server supports it, but the connection is not aborted if the server does not support it.  This is the default behavior of `psql` and is the most compatible option.  Use the `sslmode` param to set a different `sslmode`, e.g. `postgresql://user:password@host/db?sslmode=require`.
+
+# Using with Docker
 
 You can use official Docker image [`maplibre/martin`](https://hub.docker.com/r/maplibre/martin)
 
@@ -653,7 +676,7 @@ docker run \
   maplibre/martin
 ```
 
-## Using with Docker Compose
+# Using with Docker Compose
 
 You can use example [`docker-compose.yml`](https://raw.githubusercontent.com/maplibre/martin/main/docker-compose.yml) file as a reference
 
@@ -696,7 +719,7 @@ docker-compose up -d martin
 
 By default, martin will be available at [localhost:3000](http://localhost:3000/)
 
-## Using with Nginx
+# Using with Nginx
 
 You can run martin behind Nginx proxy, so you can cache frequently accessed tiles and reduce unnecessary pressure on the database.
 
@@ -736,7 +759,7 @@ services:
 
 You can find an example Nginx configuration file [here](https://github.com/maplibre/martin/blob/main/nginx.conf).
 
-### Rewriting URLs
+## Rewriting URLs
 
 If you are running martin behind Nginx proxy, you may want to rewrite the request URL to properly handle tile URLs in [TileJSON](#table-source-tilejson) [endpoints](#function-source-tilejson).
 
@@ -751,7 +774,7 @@ location ~ /tiles/(?<fwd_path>.*) {
 }
 ```
 
-### Caching tiles
+## Caching tiles
 
 You can also use Nginx to cache tiles. In the example, the maximum cache size is set to 10GB, and caching time is set to 1 hour for responses with codes 200, 204, and 302 and 1 minute for responses with code 404.
 
@@ -791,7 +814,7 @@ http {
 
 You can find an example Nginx configuration file [here](https://github.com/maplibre/martin/blob/main/nginx.conf).
 
-## Building from Source
+# Building from Source
 
 You can clone the repository and build martin using [cargo](https://doc.rust-lang.org/cargo) package manager.
 
@@ -808,7 +831,7 @@ cd ./target/release/
 ./martin postgresql://postgres@localhost/db
 ```
 
-## Debugging
+# Debugging
 
 Log levels are controlled on a per-module basis, and by default all logging is disabled except for errors. Logging is controlled via the `RUST_LOG` environment variable. The value of this environment variable is a comma-separated list of logging directives.
 
@@ -826,7 +849,7 @@ export RUST_LOG=actix_web=info,martin=debug,tokio_postgres=debug
 martin postgresql://postgres@localhost/db
 ```
 
-## Development
+# Development
 
 * Clone Martin
 * Install [docker](https://docs.docker.com/get-docker/), [docker-compose](https://docs.docker.com/compose/), and [Just](https://github.com/casey/just#readme) (improved makefile processor)
@@ -857,13 +880,13 @@ Available recipes:
     lint                   # Run cargo fmt and cargo clippy
 ```
 
-### Other useful commands
+## Other useful commands
 
 ```shell
-# Start db service
+ Start db service
 just debug-page
 
-# Run Martin server
+ Run Martin server
 DATABASE_URL=postgresql://postgres@localhost/db cargo run
 ```
 
@@ -883,10 +906,8 @@ DATABASE_URL=postgresql://postgres@localhost/db cargo bench
 
 An HTML report displaying the results of the benchmark will be generated under `target/criterion/report/index.html`
 
-## Recipes
-
-
-### Using with DigitalOcean PostgreSQL
+# Recipes
+## Using with DigitalOcean PostgreSQL
 
 You can use martin with [Managed PostgreSQL from DigitalOcean](https://www.digitalocean.com/products/managed-databases-postgresql/) with PostGIS extension
 
@@ -896,6 +917,26 @@ First, you need to download the CA certificate and get your cluster connection s
 martin --ca-root-file ./ca-certificate.crt postgresql://user:password@host:port/db?sslmode=require
 ```
 
-### SSL Security
-Note that Martin does not full support the `verify-ca` and `verify-full` ssl modes as described in the [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-ssl.html).  Martin
-will only verify the SSL certificate of the database server if the certificate is signed with a valid root cert authority.  If the cert is not signed, i.e. for Heroku, do not set the root certificate at all.  This is a known issue and will be fixed in the future.
+## Using with Heroku PostgreSQL
+
+You can use martin with [Managed PostgreSQL from Heroku](https://www.heroku.com/postgres) with PostGIS extension
+
+```shell
+heroku pg:psql -a APP_NAME -c 'create extension postgis'
+```
+
+Use the same environment variables as Heroku [suggests for psql](https://devcenter.heroku.com/articles/heroku-postgres-via-mtls#step-2-configure-environment-variables).
+
+```shell
+export DATABASE_URL=$(heroku config:get DATABASE_URL -a APP_NAME)
+export PGSSLCERT=DIRECTORY/PREFIXpostgresql.crt
+export PGSSLKEY=DIRECTORY/PREFIXpostgresql.key
+export PGSSLROOTCERT=DIRECTORY/PREFIXroot.crt
+
+martin
+```
+
+You may also be able to validate SSL certificate with an explicit sslmode, e.g.
+```shell
+export DATABASE_URL="$(heroku config:get DATABASE_URL -a APP_NAME)?sslmode=verify-ca"
+```

--- a/README-main.md
+++ b/README-main.md
@@ -75,7 +75,8 @@ brew install martin
 You can also use [official Docker image](https://hub.docker.com/r/maplibre/martin)
 
 ```shell
-docker run -p 3000:3000 -e DATABASE_URL=postgresql://postgres@localhost/db maplibre/martin
+export PGPASSWORD=postgres  # secret!
+docker run -p 3000:3000 -e PGPASSWORD -e DATABASE_URL=postgresql://postgres@localhost/db maplibre/martin
 ```
 
 ## Usage
@@ -445,8 +446,6 @@ Options:
           Number of web server workers
       --ca-root-file <CA_ROOT_FILE>
           Loads trusted root certificates from a file. The file should contain a sequence of PEM-formatted CA certificates
-      --danger-accept-invalid-certs
-          Trust invalid certificates. This introduces significant vulnerabilities, and should only be used as a last resort
   -d, --default-srid <DEFAULT_SRID>
           If a spatial table has SRID 0, then this default SRID will be used as a fallback
   -p, --pool-size <POOL_SIZE>
@@ -897,22 +896,6 @@ First, you need to download the CA certificate and get your cluster connection s
 martin --ca-root-file ./ca-certificate.crt postgresql://user:password@host:port/db?sslmode=require
 ```
 
-### Using with Heroku PostgreSQL
-
-You can use martin with [Managed PostgreSQL from Heroku](https://www.heroku.com/postgres) with PostGIS extension
-
-```shell
-heroku pg:psql -a APP_NAME -c 'create extension postgis'
-```
-
-In order to trust the Heroku certificate, you can disable certificate validation with either `DANGER_ACCEPT_INVALID_CERTS` environment variable
-
-```shell
-DATABASE_URL=$(heroku config:get DATABASE_URL -a APP_NAME) DANGER_ACCEPT_INVALID_CERTS=true martin
-```
-
-or `--danger-accept-invalid-certs` command-line argument
-
-```shell
-martin --danger-accept-invalid-certs $(heroku config:get DATABASE_URL -a APP_NAME)
-```
+### SSL Security
+Note that Martin does not full support the `verify-ca` and `verify-full` ssl modes as described in the [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-ssl.html).  Martin
+will only verify the SSL certificate of the database server if the certificate is signed with a valid root cert authority.  If the cert is not signed, i.e. for Heroku, do not set the root certificate at all.  This is a known issue and will be fixed in the future.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,25 +7,69 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - DATABASE_URL=postgres://postgres@db/db
+      - DATABASE_URL=postgres://postgres:postgres@db/db
       - RUST_LOG=actix_web=info,martin=debug,tokio_postgres=debug
     depends_on:
       - db
+
+  db-is-ready:
+    # This should match the version of postgres used in the CI workflow
+    image: postgis/postgis:14-3.3
+    network_mode: host
+    command:
+      - "sh"
+      - "-c"
+      - "until pg_isready -h localhost -p ${PGPORT:-5411} -U postgres; do sleep 1; done"
+    restart: "no"
+    environment:
+      - PGDATABASE=db
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
+      - PGHOST=localhost
+      - PGPORT=${PGPORT:-5411}
 
   db:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:14-3.3-alpine
     restart: unless-stopped
     ports:
-      - "5432:5432"
+      - "${PGPORT:-5411}:5432"
     environment:
       # POSTGRES_* variables are used by the postgis/postgres image
       # PG_* variables are used by psql
       - POSTGRES_DB=db
       - POSTGRES_USER=postgres
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_PASSWORD=postgres
       - PGDATABASE=db
       - PGUSER=postgres
+      - PGPASSWORD=postgres
+    volumes:
+      - ./tests/fixtures:/fixtures
+      - ./tests/fixtures/initdb-dc.sh:/docker-entrypoint-initdb.d/20_martin.sh
+
+  db-ssl:
+    # This should match the version of postgres used in the CI workflow
+    image: postgis/postgis:15-3.3
+    command:
+      - "postgres"
+      - "-c"
+      - "ssl=on"
+      - "-c"
+      - "ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem"
+      - "-c"
+      - "ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
+    restart: unless-stopped
+    ports:
+      - "${PGPORT:-5411}:5432"
+    environment:
+      # POSTGRES_* variables are used by the postgis/postgres image
+      # PG_* variables are used by psql
+      - POSTGRES_DB=db
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - PGDATABASE=db
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
     volumes:
       - ./tests/fixtures:/fixtures
       - ./tests/fixtures/initdb-dc.sh:/docker-entrypoint-initdb.d/20_martin.sh
@@ -35,13 +79,14 @@ services:
     image: postgis/postgis:11-3.0-alpine
     restart: unless-stopped
     ports:
-      - "5432:5432"
+      - "${PGPORT:-5411}:5432"
     environment:
       - POSTGRES_DB=db
       - POSTGRES_USER=postgres
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_PASSWORD=postgres
       - PGDATABASE=db
       - PGUSER=postgres
+      - PCPASSWORD=postgres
     volumes:
       - ./tests/fixtures:/fixtures
       - ./tests/fixtures/initdb-dc.sh:/docker-entrypoint-initdb.d/20_martin.sh

--- a/src/args/pg.rs
+++ b/src/args/pg.rs
@@ -3,7 +3,7 @@ use log::{info, warn};
 use crate::args::connections::Arguments;
 use crate::args::connections::State::{Ignore, Take};
 use crate::args::environment::Env;
-use crate::pg::{PgConfig, POOL_SIZE_DEFAULT};
+use crate::pg::{PgConfig, PgSslCerts, POOL_SIZE_DEFAULT};
 use crate::utils::OneOrMany;
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
@@ -31,15 +31,13 @@ impl PgArgs {
     ) -> Option<OneOrMany<PgConfig>> {
         let connections = Self::extract_conn_strings(cli_strings, env);
         let default_srid = self.get_default_srid(env);
-        #[cfg(feature = "ssl")]
-        let ca_root_file = self.get_ca_root_file(env);
+        let certs = self.get_certs(env);
 
         let results: Vec<_> = connections
             .into_iter()
             .map(|s| PgConfig {
                 connection_string: Some(s),
-                #[cfg(feature = "ssl")]
-                ca_root_file: ca_root_file.clone(),
+                ssl_certificates: certs.clone(),
                 default_srid,
                 pool_size: self.pool_size,
                 connection_timeout_ms: None,
@@ -74,16 +72,20 @@ impl PgArgs {
                 c.pool_size = self.pool_size;
             });
         }
+
         #[cfg(feature = "ssl")]
         if self.ca_root_file.is_some() {
             info!("Overriding root certificate file to {} on all Postgres connections because of a CLI parameter",
                 self.ca_root_file.as_ref().unwrap().display());
             pg_config.iter_mut().for_each(|c| {
-                c.ca_root_file = self.ca_root_file.clone();
+                c.ssl_certificates.ssl_root_cert = self.ca_root_file.clone();
             });
         }
 
         for v in &[
+            "PGSSLCERT",
+            "PGSSLKEY",
+            "PGSSLROOTCERT",
             "CA_ROOT_FILE",
             "DANGER_ACCEPT_INVALID_CERTS",
             "DATABASE_URL",
@@ -134,17 +136,42 @@ impl PgArgs {
             })
     }
 
+    #[cfg(not(feature = "ssl"))]
+    fn get_certs<'a>(&self, _env: &impl Env<'a>) -> PgSslCerts {
+        PgSslCerts {}
+    }
+
     #[cfg(feature = "ssl")]
-    fn get_ca_root_file<'a>(&self, env: &impl Env<'a>) -> Option<std::path::PathBuf> {
-        if self.ca_root_file.is_some() {
-            return self.ca_root_file.clone();
+    fn get_certs<'a>(&self, env: &impl Env<'a>) -> PgSslCerts {
+        let mut result = PgSslCerts {
+            ssl_cert: Self::parse_env_var(env, "PGSSLCERT", "ssl certificate"),
+            ssl_key: Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate"),
+            ssl_root_cert: self.ca_root_file.clone(),
+        };
+        if result.ssl_root_cert.is_none() {
+            result.ssl_root_cert = Self::parse_env_var(env, "PGSSLROOTCERT", "root certificate(s)");
         }
-        let path = env.var_os("CA_ROOT_FILE").map(std::path::PathBuf::from);
-        if let Some(path) = &path {
-            info!(
-                "Using env var CA_ROOT_FILE={} to load trusted root certificates",
-                path.display()
+        if result.ssl_root_cert.is_none() {
+            result.ssl_root_cert = Self::parse_env_var(
+                env,
+                "CA_ROOT_FILE",
+                "root certificate(s). This setting is obsolete, please use PGSSLROOTCERT instead",
             );
+        }
+
+        result
+    }
+
+    #[cfg(feature = "ssl")]
+    fn parse_env_var<'a>(
+        env: &impl Env<'a>,
+        env_var: &str,
+        info: &str,
+    ) -> Option<std::path::PathBuf> {
+        let path = env.var_os(env_var).map(std::path::PathBuf::from);
+        if let Some(p) = &path {
+            let p = p.display();
+            info!("Using env {env_var}={p} to load {info}");
         }
         path
     }
@@ -157,6 +184,9 @@ fn is_postgresql_string(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ssl")]
+    use std::path::PathBuf;
+
     use super::*;
     use crate::test_utils::{os, some, FauxEnv};
     use crate::Error;
@@ -223,7 +253,10 @@ mod tests {
                 connection_string: some("postgres://localhost:5432"),
                 default_srid: Some(10),
                 #[cfg(feature = "ssl")]
-                ca_root_file: Some(std::path::PathBuf::from("file")),
+                ssl_certificates: PgSslCerts {
+                    ssl_root_cert: Some(PathBuf::from("file")),
+                    ..Default::default()
+                },
                 ..Default::default()
             }))
         );
@@ -237,14 +270,14 @@ mod tests {
             vec![
                 ("DATABASE_URL", os("postgres://localhost:5432")),
                 ("DEFAULT_SRID", os("10")),
-                ("CA_ROOT_FILE", os("file")),
+                ("PGSSLCERT", os("cert")),
+                ("PGSSLKEY", os("key")),
+                ("PGSSLROOTCERT", os("root")),
             ]
             .into_iter()
             .collect(),
         );
         let pg_args = PgArgs {
-            #[cfg(feature = "ssl")]
-            ca_root_file: Some(std::path::PathBuf::from("file2")),
             default_srid: Some(20),
             ..Default::default()
         };
@@ -255,7 +288,11 @@ mod tests {
                 connection_string: some("postgres://localhost:5432"),
                 default_srid: Some(20),
                 #[cfg(feature = "ssl")]
-                ca_root_file: Some(std::path::PathBuf::from("file2")),
+                ssl_certificates: PgSslCerts {
+                    ssl_cert: Some(PathBuf::from("cert")),
+                    ssl_key: Some(PathBuf::from("key")),
+                    ssl_root_cert: Some(PathBuf::from("root")),
+                },
                 ..Default::default()
             }))
         );

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -21,15 +21,14 @@ pub struct PgConfig {
     #[cfg(feature = "ssl")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_root_file: Option<std::path::PathBuf>,
-    #[cfg(feature = "ssl")]
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub danger_accept_invalid_certs: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_srid: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_bounds: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pool_size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_timeout_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_publish: Option<BoolOrObject<PgCfgPublish>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -221,11 +220,4 @@ mod tests {
             },
         );
     }
-}
-
-/// Helper to skip serialization if the value is `false`
-#[allow(clippy::trivially_copy_pass_by_ref)]
-#[cfg(feature = "ssl")]
-pub fn is_false(value: &bool) -> bool {
-    !*value
 }

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -16,11 +16,29 @@ pub trait PgInfo {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct PgConfig {
-    pub connection_string: Option<String>,
+pub struct PgSslCerts {
+    /// Same as PGSSLCERT
+    /// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT
     #[cfg(feature = "ssl")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ca_root_file: Option<std::path::PathBuf>,
+    pub ssl_cert: Option<std::path::PathBuf>,
+    /// Same as PGSSLKEY
+    /// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLKEY
+    #[cfg(feature = "ssl")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssl_key: Option<std::path::PathBuf>,
+    /// Same as PGSSLROOTCERT
+    /// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
+    #[cfg(feature = "ssl")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssl_root_cert: Option<std::path::PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PgConfig {
+    pub connection_string: Option<String>,
+    #[serde(flatten)]
+    pub ssl_certificates: PgSslCerts,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_srid: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -6,6 +6,7 @@ mod function_source;
 mod pg_source;
 mod pool;
 mod table_source;
+mod tls;
 mod utils;
 
 pub use config::{PgCfgPublish, PgCfgPublishType, PgConfig};

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -9,7 +9,7 @@ mod table_source;
 mod tls;
 mod utils;
 
-pub use config::{PgCfgPublish, PgCfgPublishType, PgConfig};
+pub use config::{PgCfgPublish, PgCfgPublishType, PgConfig, PgSslCerts};
 pub use config_function::FunctionInfo;
 pub use config_table::TableInfo;
 pub use function_source::get_function_sources;

--- a/src/pg/pool.rs
+++ b/src/pg/pool.rs
@@ -1,22 +1,20 @@
 use std::str::FromStr;
+use std::time::Duration;
 
 use bb8::PooledConnection;
-use bb8_postgres::{tokio_postgres as pg, PostgresConnectionManager};
+use bb8_postgres::tokio_postgres as pg;
 use log::{info, warn};
 use semver::Version;
 
 use crate::pg::config::PgConfig;
+use crate::pg::tls::{make_connector, ConnectionManager, PgErrorSink};
 use crate::pg::utils::PgError::{
     BadConnectionString, BadPostgisVersion, PostgisTooOld, PostgresError, PostgresPoolConnError,
 };
 use crate::pg::utils::Result;
 
-#[cfg(feature = "ssl")]
-pub type ConnectionManager = PostgresConnectionManager<postgres_openssl::MakeTlsConnector>;
-#[cfg(not(feature = "ssl"))]
-pub type ConnectionManager = PostgresConnectionManager<postgres::NoTls>;
-
 pub const POOL_SIZE_DEFAULT: u32 = 20;
+pub const CONNECTION_TIMEOUT_MS: u64 = 5 * 1000; // seconds
 
 pub type InternalPool = bb8::Pool<ConnectionManager>;
 pub type Connection<'a> = PooledConnection<'a, ConnectionManager>;
@@ -47,45 +45,21 @@ impl Pool {
             ToString::to_string,
         );
 
-        #[cfg(not(feature = "ssl"))]
-        let manager = ConnectionManager::new(pg_cfg, postgres::NoTls);
-
-        #[cfg(feature = "ssl")]
-        let manager = {
-            use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-
-            use crate::pg::utils::PgError::{BadTrustedRootCertError, BuildSslConnectorError};
-
-            let tls = SslMethod::tls();
-            let mut builder = SslConnector::builder(tls).map_err(BuildSslConnectorError)?;
-
-            if config.danger_accept_invalid_certs {
-                builder.set_verify(SslVerifyMode::NONE);
-            }
-
-            if let Some(file) = &config.ca_root_file {
-                builder
-                    .set_ca_file(file)
-                    .map_err(|e| BadTrustedRootCertError(e, file.clone()))?;
-                info!("Using {} as trusted root certificate", file.display());
-            }
-
-            PostgresConnectionManager::new(
-                pg_cfg,
-                postgres_openssl::MakeTlsConnector::new(builder.build()),
-            )
-        };
+        let timeout_ms = config
+            .connection_timeout_ms
+            .unwrap_or(CONNECTION_TIMEOUT_MS);
 
         let pool = InternalPool::builder()
             .max_size(config.pool_size.unwrap_or(POOL_SIZE_DEFAULT))
-            .build(manager)
+            .test_on_check_out(false)
+            .connection_timeout(Duration::from_millis(timeout_ms))
+            .error_sink(Box::new(PgErrorSink))
+            .build(ConnectionManager::new(pg_cfg, make_connector(config)?))
             .await
             .map_err(|e| PostgresError(e, "building connection pool"))?;
 
-        let version = pool
-            .get()
-            .await
-            .map_err(|e| PostgresPoolConnError(e, id.clone()))?
+        let version = get_conn(&pool, id.as_str())
+            .await?
             .query_one(
                 r#"
 SELECT
@@ -114,10 +88,7 @@ SELECT
     }
 
     pub async fn get(&self) -> Result<Connection<'_>> {
-        self.pool
-            .get()
-            .await
-            .map_err(|e| PostgresPoolConnError(e, self.id.clone()))
+        get_conn(&self.pool, self.id.as_str()).await
     }
 
     #[must_use]
@@ -129,4 +100,10 @@ SELECT
     pub fn supports_tile_margin(&self) -> bool {
         self.margin
     }
+}
+
+async fn get_conn<'a>(pool: &'a InternalPool, id: &str) -> Result<Connection<'a>> {
+    pool.get()
+        .await
+        .map_err(|e| PostgresPoolConnError(e, id.to_string()))
 }

--- a/src/pg/tls.rs
+++ b/src/pg/tls.rs
@@ -1,0 +1,64 @@
+use crate::pg::{utils, PgConfig};
+use bb8::ErrorSink;
+use bb8_postgres::PostgresConnectionManager;
+use log::error;
+
+#[cfg(feature = "ssl")]
+use crate::pg::utils::PgError::{BadTrustedRootCertError, BuildSslConnectorError};
+#[cfg(feature = "ssl")]
+use log::info;
+#[cfg(feature = "ssl")]
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+
+#[cfg(feature = "ssl")]
+pub type ConnectionManager = PostgresConnectionManager<postgres_openssl::MakeTlsConnector>;
+#[cfg(not(feature = "ssl"))]
+pub type ConnectionManager = PostgresConnectionManager<postgres::NoTls>;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PgErrorSink;
+
+type PgConnError = <ConnectionManager as bb8::ManageConnection>::Error;
+
+impl ErrorSink<PgConnError> for PgErrorSink {
+    fn sink(&self, e: PgConnError) {
+        error!("{e}");
+    }
+
+    fn boxed_clone(&self) -> Box<dyn ErrorSink<PgConnError>> {
+        Box::new(*self)
+    }
+}
+
+#[cfg(not(feature = "ssl"))]
+pub fn make_connector(_config: &PgConfig) -> utils::Result<postgres::NoTls> {
+    Ok(postgres::NoTls)
+}
+
+#[cfg(feature = "ssl")]
+pub fn make_connector(config: &PgConfig) -> utils::Result<postgres_openssl::MakeTlsConnector> {
+    let tls = SslMethod::tls();
+    let mut builder = SslConnector::builder(tls).map_err(BuildSslConnectorError)?;
+
+    if let Some(file) = &config.ca_root_file {
+        builder
+            .set_ca_file(file)
+            .map_err(|e| BadTrustedRootCertError(e, file.clone()))?;
+        info!("Using {} as trusted root certificate", file.display());
+    } else {
+        // TODO: Once https://github.com/sfackler/rust-postgres/pull/988 is merged,
+        // we can only set this to None if ssl mode is Required, but not verify*
+        builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    let mut connector = postgres_openssl::MakeTlsConnector::new(builder.build());
+
+    // TODO: Once https://github.com/sfackler/rust-postgres/pull/988 is merged,
+    // we can only only do this if ssl mode is Required, but not verifyFull
+    connector.set_callback(|cfg, _domain| {
+        cfg.set_verify_hostname(false);
+        Ok(())
+    });
+
+    Ok(connector)
+}

--- a/src/pg/utils.rs
+++ b/src/pg/utils.rs
@@ -63,6 +63,18 @@ pub enum PgError {
     #[error("Can't set trusted root certificate {}: {0}", .1.display())]
     BadTrustedRootCertError(#[source] openssl::error::ErrorStack, std::path::PathBuf),
 
+    #[cfg(feature = "ssl")]
+    #[error("Can't set client certificate {}: {0}", .1.display())]
+    BadClientCertError(#[source] openssl::error::ErrorStack, std::path::PathBuf),
+
+    #[cfg(feature = "ssl")]
+    #[error("Can't set client certificate key {}: {0}", .1.display())]
+    BadClientKeyError(#[source] openssl::error::ErrorStack, std::path::PathBuf),
+
+    #[cfg(feature = "ssl")]
+    #[error("Unknown SSL mode: {0:?}")]
+    UnknownSslMode(postgres::config::SslMode),
+
     #[error("Postgres error while {1}: {0}")]
     PostgresError(#[source] bb8_postgres::tokio_postgres::Error, &'static str),
 


### PR DESCRIPTION
This is a partial fix for #496

* BREAKING: Now Martin behaves the same way as `psql` -- by default, if SSL is available on the server, it will be used, even though it will not verify that the server has a valid SSL certificate
* Martin now understands `PGSSLCERT`, `PGSSLKEY`, and `PGSSLROOTCERT` env vars (and corresponding config keys) - same as psql.
* Martin can now process `?sslmode=verify-ca` and `verify-full` (just like psql). The verify modes require root and/or client cert & key.
* remove `danger_accept_invalid_certs` -- turns out that behavior is expected by default unless ssl mode is set to verify - which upstream lib [does not support](https://github.com/sfackler/rust-postgres/issues/768) - PR [submitted](https://github.com/sfackler/rust-postgres/pull/988).
* added connection_timeout_ms option for postgres and set it to 5 seconds by default. This way it will fail out earlier.
* added error reporting to bb8 - but it is currently [broken upstream](https://github.com/djc/bb8/issues/151) - not sure we can fix it easily, so may need to switch to deadpool later.
* added docker-based TLS test (horray!) - wasn't trivial at all, despite ending up fairly simple.
