### PR TITLE
Feat: max_feature_count query limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Options:
           If a spatial table has SRID 0, then this default SRID will be used as a fallback
   -p, --pool-size <POOL_SIZE>
           Maximum connections pool size [DEFAULT: 20]
+  -m, --max-feature-count <MAX_FEATURE_COUNT>
+          Limit the number of features in a tile from a PG table source
   -h, --help
           Print help
   -V, --version
@@ -526,6 +528,9 @@ postgres:
   
   # Maximum connections pool size [default: 20]
   pool_size: 20
+
+  # Limit the number of table geo features included in a tile. Unlimited by default.
+  max_feature_count: 1000
 
   # Control the automatic generation of bounds for spatial tables [default: false]
   # If enabled, it will spend some time on startup to compute geometry bounds.

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -44,6 +44,8 @@ pub struct PgConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_bounds: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_feature_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pool_size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_publish: Option<BoolOrObject<PgCfgPublish>>,
@@ -168,6 +170,7 @@ mod tests {
               connection_string: 'postgres://postgres@localhost:5432/db'
               default_srid: 4326
               pool_size: 20
+              max_feature_count: 100
 
               tables:
                 table_source:
@@ -199,6 +202,7 @@ mod tests {
                     connection_string: some("postgres://postgres@localhost:5432/db"),
                     default_srid: Some(4326),
                     pool_size: Some(20),
+                    max_feature_count: Some(100),
                     tables: Some(HashMap::from([(
                         "table_source".to_string(),
                         TableInfo {

--- a/src/pg/configurator.rs
+++ b/src/pg/configurator.rs
@@ -39,10 +39,12 @@ impl PgBuilderPublish {
     }
 }
 
+#[derive(Debug)]
 pub struct PgBuilder {
     pool: PgPool,
     default_srid: Option<i32>,
     disable_bounds: bool,
+    max_feature_count: Option<usize>,
     auto_functions: Option<PgBuilderPublish>,
     auto_tables: Option<PgBuilderPublish>,
     id_resolver: IdResolver,
@@ -58,6 +60,7 @@ impl PgBuilder {
             pool,
             default_srid: config.default_srid,
             disable_bounds: config.disable_bounds.unwrap_or_default(),
+            max_feature_count: config.max_feature_count,
             id_resolver,
             tables: config.tables.clone().unwrap_or_default(),
             functions: config.functions.clone().unwrap_or_default(),
@@ -96,6 +99,7 @@ impl PgBuilder {
                 cfg_inf,
                 self.pool.clone(),
                 self.disable_bounds,
+                self.max_feature_count,
             ));
         }
 
@@ -128,6 +132,7 @@ impl PgBuilder {
                             src_inf,
                             self.pool.clone(),
                             self.disable_bounds,
+                            self.max_feature_count,
                         ));
                     }
                 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -51,7 +51,7 @@ impl Clone for Box<dyn Source> {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct IdResolver {
     /// name -> unique name
     names: Arc<Mutex<HashMap<String, String>>>,

--- a/tests/expected/given_config.yaml
+++ b/tests/expected/given_config.yaml
@@ -3,6 +3,7 @@ listen_addresses: localhost:3111
 worker_processes: 1
 postgres:
   default_srid: 4326
+  max_feature_count: 1000
   pool_size: 20
   tables:
     MixPoints:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -228,7 +228,7 @@ echo "Test pre-configured Martin"
 TEST_OUT_DIR="$(dirname "$0")/output/configured"
 mkdir -p "$TEST_OUT_DIR"
 
-ARG=(--config tests/config.yaml --save-config "$(dirname "$0")/output/given_config.yaml" -W 1)
+ARG=(--config tests/config.yaml --max-feature-count 1000 --save-config "$(dirname "$0")/output/given_config.yaml" -W 1)
 set -x
 $MARTIN_BIN "${ARG[@]}" 2>&1 | tee test_log_2.txt &
 PROCESS_ID=`jobs -p`


### PR DESCRIPTION
Implements #384 - ability to limit the number of features included in a tile from a Postgres table/view.

This allows zoomed-out view of a table with a reasonable speed because each tile could be limited in size, rather than include millions of features.

If set on a CLI, overrides whatever is set in the config file (if given).

Any naming suggestions?