### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Martin requires at least one PostgreSQL [connection string](#postgresql-connecti
 martin postgresql://postgres@localhost/db
 ```
 
-Martin provides [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint for each [geospatial-enabled](https://postgis.net/docs/postgis_usage.html#geometry_columns) table in your database.
+Martin provides [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint for each [geospatial-enabled](https://postgis.net/docs/using_postgis_dbmanagement.html#geometry_columns) table in your database.
 
 # API
 


### PR DESCRIPTION
I was going through the README when I stumbled upon a dead link. I _think_ this is the new URL.