### PR TITLE
Configurable tile systems for projections other than web mercator

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,18 @@ postgres:
       id_format: 'table.{schema}.{table}.{column}'
       # Add more schemas to the ones listed above
       from_schemas: my_other_schema
+      # Optionally, publish tiles in more than one projection/tiling scheme
+      tile_systems:
+        # the default web mercator tiles, enabled by default 
+        - type: WebMercatorQuad
+        # an additional custom tiling scheme
+        - type: Custom
+          srid: 4326
+          # bounds of tile 0/0/0
+          bounds: [ -180.0, -90.0, 180.0, 90.0 ]
+          # name for the tiling scheme 
+          # auto published table will be given the name {source_id}:{tile_system.identifier}
+          identifier: WGS84Quad
     functions:
       id_format: '{schema}.{function}'
   
@@ -601,6 +613,15 @@ postgres:
       # List of columns, that should be encoded as tile properties (required)
       properties:
         gid: int4
+        
+      # Output tiles with a custom projection and tiling
+      tile_system:
+        # output srid
+        srid: 4326
+        # bounds of tile 0/0/0
+        bounds: [ -180.0, -90.0, 180.0, 90.0 ]
+        # name for the tiling scheme
+        identifier: WGS84Quad
   
   # Associative arrays of function sources
   functions:

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,6 @@ use crate::pg::PgConfig;
 use crate::pmtiles::PmtSource;
 use crate::source::{IdResolver, Sources};
 use crate::srv::SrvConfig;
-use crate::tilesystems::TileSystemsConfig;
 use crate::utils::{OneOrMany, Result};
 use crate::Error::{ConfigLoadError, ConfigParseError, NoSources};
 
@@ -33,9 +32,6 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mbtiles: Option<FileConfigEnum>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tile_systems: Option<TileSystemsConfig>,
 
     #[serde(flatten)]
     pub unrecognized: HashMap<String, Value>,
@@ -84,7 +80,7 @@ impl Config {
         let mut sources: Vec<Pin<Box<dyn Future<Output = Result<Sources>>>>> = Vec::new();
         if let Some(v) = self.postgres.as_mut() {
             for s in v.iter_mut() {
-                sources.push(Box::pin(s.resolve(idr.clone(), &self.tile_systems)));
+                sources.push(Box::pin(s.resolve(idr.clone())));
             }
         }
         if let Some(v) = self.pmtiles.as_mut() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use crate::pg::PgConfig;
 use crate::pmtiles::PmtSource;
 use crate::source::{IdResolver, Sources};
 use crate::srv::SrvConfig;
+use crate::tilesystems::TileSystemsConfig;
 use crate::utils::{OneOrMany, Result};
 use crate::Error::{ConfigLoadError, ConfigParseError, NoSources};
 
@@ -32,6 +33,9 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mbtiles: Option<FileConfigEnum>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile_systems: Option<TileSystemsConfig>,
 
     #[serde(flatten)]
     pub unrecognized: HashMap<String, Value>,
@@ -80,7 +84,7 @@ impl Config {
         let mut sources: Vec<Pin<Box<dyn Future<Output = Result<Sources>>>>> = Vec::new();
         if let Some(v) = self.postgres.as_mut() {
             for s in v.iter_mut() {
-                sources.push(Box::pin(s.resolve(idr.clone())));
+                sources.push(Box::pin(s.resolve(idr.clone(), &self.tile_systems)));
             }
         }
         if let Some(v) = self.pmtiles.as_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod pg;
 pub mod pmtiles;
 mod source;
 pub mod srv;
+mod tilesystems;
 mod utils;
 
 #[cfg(test)]

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -8,7 +8,7 @@ use crate::pg::config_table::TableInfoSources;
 use crate::pg::configurator::PgBuilder;
 use crate::pg::utils::Result;
 use crate::source::{IdResolver, Sources};
-use crate::tilesystems::TileSystemsConfig;
+use crate::tilesystems::TileSystem;
 use crate::utils::{sorted_opt_map, BoolOrObject, OneOrMany};
 
 pub trait PgInfo {
@@ -69,6 +69,7 @@ pub struct PgCfgPublish {
 pub struct PgCfgPublishType {
     pub from_schemas: Option<OneOrMany<String>>,
     pub id_format: Option<String>,
+    pub tile_systems: Option<Vec<TileSystem>>,
 }
 
 impl PgConfig {
@@ -92,17 +93,10 @@ impl PgConfig {
         Ok(res)
     }
 
-    pub async fn resolve(
-        &mut self,
-        id_resolver: IdResolver,
-        tile_systems: &Option<TileSystemsConfig>,
-    ) -> crate::Result<Sources> {
+    pub async fn resolve(&mut self, id_resolver: IdResolver) -> crate::Result<Sources> {
         let pg = PgBuilder::new(self, id_resolver).await?;
-        let ((mut tables, tbl_info), (funcs, func_info)) = try_join(
-            pg.instantiate_tables(tile_systems),
-            pg.instantiate_functions(),
-        )
-        .await?;
+        let ((mut tables, tbl_info), (funcs, func_info)) =
+            try_join(pg.instantiate_tables(), pg.instantiate_functions()).await?;
 
         self.tables = Some(tbl_info);
         self.functions = Some(func_info);
@@ -124,6 +118,7 @@ mod tests {
     use crate::pg::config_function::FunctionInfo;
     use crate::pg::config_table::TableInfo;
     use crate::test_utils::some;
+    use crate::tilesystems::TileSystemConfig;
     use crate::utils::OneOrMany::{Many, One};
 
     #[test]
@@ -196,6 +191,11 @@ mod tests {
                   geometry_type: GEOMETRY
                   properties:
                     gid: int4
+                  tile_system:
+                    identifier: WGS84Quad
+                    srid: 4326
+                    bounds: [-180, -90, 180, 90]
+
 
               functions:
                 function_zxy_query:
@@ -229,6 +229,11 @@ mod tests {
                                 "gid".to_string(),
                                 "int4".to_string(),
                             )])),
+                            tile_system: Some(TileSystemConfig {
+                                srid: 4326,
+                                bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0),
+                                identifier: "WGS84Quad".to_string(),
+                            }),
                             ..Default::default()
                         },
                     )])),

--- a/src/pg/config.rs
+++ b/src/pg/config.rs
@@ -8,6 +8,7 @@ use crate::pg::config_table::TableInfoSources;
 use crate::pg::configurator::PgBuilder;
 use crate::pg::utils::Result;
 use crate::source::{IdResolver, Sources};
+use crate::tilesystems::TileSystemsConfig;
 use crate::utils::{sorted_opt_map, BoolOrObject, OneOrMany};
 
 pub trait PgInfo {
@@ -91,10 +92,17 @@ impl PgConfig {
         Ok(res)
     }
 
-    pub async fn resolve(&mut self, id_resolver: IdResolver) -> crate::Result<Sources> {
+    pub async fn resolve(
+        &mut self,
+        id_resolver: IdResolver,
+        tile_systems: &Option<TileSystemsConfig>,
+    ) -> crate::Result<Sources> {
         let pg = PgBuilder::new(self, id_resolver).await?;
-        let ((mut tables, tbl_info), (funcs, func_info)) =
-            try_join(pg.instantiate_tables(), pg.instantiate_functions()).await?;
+        let ((mut tables, tbl_info), (funcs, func_info)) = try_join(
+            pg.instantiate_tables(tile_systems),
+            pg.instantiate_functions(),
+        )
+        .await?;
 
         self.tables = Some(tbl_info);
         self.functions = Some(func_info);

--- a/src/pg/config_table.rs
+++ b/src/pg/config_table.rs
@@ -5,6 +5,7 @@ use serde_yaml::Value;
 use tilejson::{Bounds, TileJSON, VectorLayer};
 
 use crate::pg::config::PgInfo;
+use crate::tilesystems::TileSystemConfig;
 use crate::utils::{sorted_opt_map, InfoMap};
 
 pub type TableInfoSources = InfoMap<TableInfo>;
@@ -77,6 +78,10 @@ pub struct TableInfo {
     /// Mapping of properties to the actual table columns
     #[serde(skip_deserializing, skip_serializing)]
     pub prop_mapping: HashMap<String, String>,
+
+    /// Alternative tiling to standard web-mercator
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile_system: Option<TileSystemConfig>,
 
     #[serde(flatten, skip_serializing)]
     pub unrecognized: HashMap<String, Value>,

--- a/src/pg/configurator.rs
+++ b/src/pg/configurator.rs
@@ -15,6 +15,7 @@ use crate::pg::table_source::{calc_srid, get_table_sources, merge_table_info, ta
 use crate::pg::utils::PgError::InvalidTableExtent;
 use crate::pg::utils::Result;
 use crate::source::{IdResolver, Sources};
+use crate::tilesystems::{TileSystemConfig, TileSystemsConfig};
 use crate::utils::{find_info, normalize_key, BoolOrObject, InfoMap, OneOrMany};
 
 pub type SqlFuncInfoMapMap = InfoMap<InfoMap<(PgSqlInfo, FunctionInfo)>>;
@@ -69,12 +70,25 @@ impl PgBuilder {
         })
     }
 
-    pub async fn instantiate_tables(&self) -> Result<(Sources, TableInfoSources)> {
+    pub async fn instantiate_tables(
+        &self,
+        tile_systems: &Option<TileSystemsConfig>,
+    ) -> Result<(Sources, TableInfoSources)> {
         let mut all_tables = get_table_sources(&self.pool).await?;
 
         // Match configured sources with the discovered ones and add them to the pending list.
         let mut used = HashSet::<(&str, &str, &str)>::new();
         let mut pending = Vec::new();
+        let mut all_tile_systems: Vec<Option<(&str, &TileSystemConfig)>> = vec![None];
+
+        all_tile_systems.extend(
+            tile_systems
+                .as_ref()
+                .iter()
+                .flat_map(|map| map.iter())
+                .map(|(id, ts)| Some((id.as_str(), ts))),
+        );
+
         for (id, cfg_inf) in &self.tables {
             // TODO: move this validation to serde somehow?
             if let Some(extent) = cfg_inf.extent {
@@ -90,17 +104,26 @@ impl PgBuilder {
             let dup = !used.insert((&cfg_inf.schema, &cfg_inf.table, &cfg_inf.geometry_column));
             let dup = if dup { "duplicate " } else { "" };
 
-            let id2 = self.resolve_id(id, cfg_inf);
-            let Some(cfg_inf) = merge_table_info(self.default_srid, &id2, cfg_inf, src_inf) else { continue };
-            warn_on_rename(id, &id2, "Table");
-            info!("Configured {dup}source {id2} from {}", summary(&cfg_inf));
-            pending.push(table_to_query(
-                id2,
-                cfg_inf,
-                self.pool.clone(),
-                self.disable_bounds,
-                self.max_feature_count,
-            ));
+            for tile_system in &all_tile_systems {
+                let mut id2 = self.resolve_id(id, cfg_inf);
+
+                if let Some((ts_id, _)) = tile_system {
+                    id2 += format!(":{ts_id}").as_str();
+                }
+
+                let Some(cfg_inf) = merge_table_info(self.default_srid, &id2, cfg_inf, src_inf) else { continue };
+                warn_on_rename(id, &id2, "Table");
+                info!("Configured {dup}source {id2} from {}", summary(&cfg_inf));
+
+                pending.push(table_to_query(
+                    id2,
+                    cfg_inf,
+                    self.pool.clone(),
+                    self.disable_bounds,
+                    self.max_feature_count,
+                    tile_system.map(|(_, ts)| ts),
+                ));
+            }
         }
 
         // Sort the discovered sources by schema, table and geometry column to ensure a consistent behavior
@@ -123,17 +146,27 @@ impl PgBuilder {
                             .replace("{schema}", &schema)
                             .replace("{table}", &table)
                             .replace("{column}", &column);
-                        let id2 = self.resolve_id(&source_id, &src_inf);
-                        let Some(srid) = calc_srid(&src_inf.format_id(), &id2, src_inf.srid, 0, self.default_srid) else { continue };
-                        src_inf.srid = srid;
-                        info!("Discovered source {id2} from {}", summary(&src_inf));
-                        pending.push(table_to_query(
-                            id2,
-                            src_inf,
-                            self.pool.clone(),
-                            self.disable_bounds,
-                            self.max_feature_count,
-                        ));
+
+                        for tile_system in &all_tile_systems {
+                            let mut id2 = self.resolve_id(&source_id, &src_inf);
+
+                            if let Some((ts_id, _)) = tile_system {
+                                id2 += format!(":{ts_id}").as_str();
+                            }
+
+                            let Some(srid) = calc_srid(&src_inf.format_id(), &id2, src_inf.srid, 0, self.default_srid) else { continue };
+                            src_inf.srid = srid;
+                            info!("Discovered source {id2} from {}", summary(&src_inf));
+
+                            pending.push(table_to_query(
+                                id2,
+                                src_inf.clone(),
+                                self.pool.clone(),
+                                self.disable_bounds,
+                                self.max_feature_count,
+                                tile_system.map(|x| x.1),
+                            ));
+                        }
                     }
                 }
             }

--- a/src/tilesystems/config.rs
+++ b/src/tilesystems/config.rs
@@ -1,55 +1,131 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use tilejson::Bounds;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TileSystemConfig {
     pub srid: i32,
     pub bounds: Bounds,
-    pub identifier: Option<String>,
+    pub identifier: String,
 }
 
-pub type TileSystemsConfig = HashMap<String, TileSystemConfig>;
+impl From<TileSystemConfig> for TileSystem {
+    fn from(value: TileSystemConfig) -> Self {
+        TileSystem::Custom(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum TileSystem {
+    Custom(TileSystemConfig),
+    WebMercatorQuad,
+}
+
+impl TileSystem {
+    pub fn is_web_mercator(&self) -> bool {
+        matches!(self, TileSystem::WebMercatorQuad)
+    }
+
+    pub fn get_srid(&self) -> i32 {
+        match self {
+            TileSystem::Custom(ts) => ts.srid,
+            TileSystem::WebMercatorQuad => 3857,
+        }
+    }
+}
+
+impl Default for TileSystem {
+    fn default() -> Self {
+        TileSystem::WebMercatorQuad
+    }
+}
+
+impl From<TileSystem> for Option<TileSystemConfig> {
+    fn from(val: TileSystem) -> Self {
+        match val {
+            TileSystem::WebMercatorQuad => None,
+            TileSystem::Custom(ts) => Some(ts),
+        }
+    }
+}
+
+impl From<Option<TileSystemConfig>> for TileSystem {
+    fn from(value: Option<TileSystemConfig>) -> Self {
+        match value {
+            None => TileSystem::WebMercatorQuad,
+            Some(ts) => TileSystem::Custom(ts),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use crate::config::tests::assert_config;
-    use crate::pg::PgConfig;
-    use crate::test_utils::some;
-    use crate::tilesystems::TileSystemConfig;
-    use crate::OneOrMany::One;
-    use crate::{BoolOrObject, Config};
+    use crate::tilesystems::{TileSystem, TileSystemConfig};
     use indoc::indoc;
-    use std::collections::HashMap;
     use tilejson::Bounds;
 
     #[test]
     pub fn test_parse_tile_systems_config() {
-        assert_config(
-            indoc! {"
-            postgres:
-              connection_string: 'postgresql://postgres@localhost/db'
-            tile_systems:
-              my_custom_tiling:
-                srid: 4326
-                bounds: [-180, -90, 180, 90]
-        "},
-            &Config {
-                postgres: Some(One(PgConfig {
-                    connection_string: some("postgresql://postgres@localhost/db"),
-                    auto_publish: Some(BoolOrObject::Bool(true)),
-                    ..Default::default()
-                })),
-                tile_systems: Some(HashMap::from([(
-                    "my_custom_tiling".to_string(),
-                    TileSystemConfig {
-                        srid: 4326,
-                        bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0),
-                        identifier: None,
-                    },
-                )])),
-                ..Default::default()
-            },
+        println!(
+            "{}",
+            serde_yaml::to_string(&TileSystem::Custom(TileSystemConfig {
+                identifier: "WGS84Quad".to_string(),
+                srid: 4326,
+                bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0)
+            }))
+            .unwrap()
+        );
+
+        let configs: Vec<TileSystem> = serde_yaml::from_str(indoc! {"
+            - type: WebMercatorQuad
+            - type: Custom
+              identifier: WGS84Quad
+              srid: 4326
+              bounds: [-180, -90, 180, 90]
+        "})
+        .unwrap();
+
+        assert_eq!(
+            configs,
+            vec![
+                TileSystem::WebMercatorQuad,
+                TileSystem::Custom(TileSystemConfig {
+                    identifier: "WGS84Quad".to_string(),
+                    srid: 4326,
+                    bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0)
+                })
+            ]
+        );
+
+        let maybe_config: Option<Vec<TileSystem>> = serde_yaml::from_str("").unwrap();
+        assert!(maybe_config.is_none());
+        let maybe_configs: Option<Vec<TileSystem>> = serde_yaml::from_str(
+            "
+            - type: WebMercatorQuad
+            - type: Custom
+              identifier: WGS84Quad
+              srid: 4326
+              bounds: [-180, -90, 180, 90]
+        ",
+        )
+        .unwrap();
+        assert!(maybe_configs.is_some());
+        assert_eq!(maybe_configs.unwrap().len(), 2);
+
+        let config: TileSystem = serde_yaml::from_str(indoc! {"\
+            type: Custom
+            identifier: WGS84Quad
+            srid: 4326
+            bounds: [-180, -90, 180, 90]
+        "})
+        .unwrap();
+        assert_eq!(
+            config,
+            TileSystem::Custom(TileSystemConfig {
+                identifier: "WGS84Quad".to_string(),
+                srid: 4326,
+                bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0)
+            })
         );
     }
 }

--- a/src/tilesystems/config.rs
+++ b/src/tilesystems/config.rs
@@ -6,6 +6,7 @@ use tilejson::Bounds;
 pub struct TileSystemConfig {
     pub srid: i32,
     pub bounds: Bounds,
+    pub identifier: Option<String>,
 }
 
 pub type TileSystemsConfig = HashMap<String, TileSystemConfig>;
@@ -44,6 +45,7 @@ mod tests {
                     TileSystemConfig {
                         srid: 4326,
                         bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0),
+                        identifier: None,
                     },
                 )])),
                 ..Default::default()

--- a/src/tilesystems/config.rs
+++ b/src/tilesystems/config.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tilejson::Bounds;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct TileSystemConfig {
+    pub srid: i32,
+    pub bounds: Bounds,
+}
+
+pub type TileSystemsConfig = HashMap<String, TileSystemConfig>;
+
+#[cfg(test)]
+mod tests {
+    use crate::config::tests::assert_config;
+    use crate::pg::PgConfig;
+    use crate::test_utils::some;
+    use crate::tilesystems::TileSystemConfig;
+    use crate::OneOrMany::One;
+    use crate::{BoolOrObject, Config};
+    use indoc::indoc;
+    use std::collections::HashMap;
+    use tilejson::Bounds;
+
+    #[test]
+    pub fn test_parse_tile_systems_config() {
+        assert_config(
+            indoc! {"
+            postgres:
+              connection_string: 'postgresql://postgres@localhost/db'
+            tile_systems:
+              my_custom_tiling:
+                srid: 4326
+                bounds: [-180, -90, 180, 90]
+        "},
+            &Config {
+                postgres: Some(One(PgConfig {
+                    connection_string: some("postgresql://postgres@localhost/db"),
+                    auto_publish: Some(BoolOrObject::Bool(true)),
+                    ..Default::default()
+                })),
+                tile_systems: Some(HashMap::from([(
+                    "my_custom_tiling".to_string(),
+                    TileSystemConfig {
+                        srid: 4326,
+                        bounds: Bounds::new(-180.0, -90.0, 180.0, 90.0),
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+    }
+}

--- a/src/tilesystems/mod.rs
+++ b/src/tilesystems/mod.rs
@@ -1,3 +1,3 @@
 mod config;
 
-pub use config::{TileSystemConfig, TileSystemsConfig};
+pub use config::{TileSystem, TileSystemConfig};

--- a/src/tilesystems/mod.rs
+++ b/src/tilesystems/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+
+pub use config::{TileSystemConfig, TileSystemsConfig};

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -92,6 +92,27 @@ postgres:
       properties:
         gid: int4
 
+    points1_wgs84:
+      layer_id: abc
+      schema: public
+      table: points1
+      minzoom: 0
+      maxzoom: 30
+      bounds: [-180.0, -90.0, 180.0, 90.0]
+      id_column: ~
+      geometry_column: geom
+      srid: 4326
+      extent: 4096
+      buffer: 64
+      clip_geom: true
+      geometry_type: POINT
+      tile_system:
+        identifier: WGS84Quad
+        srid: 4326
+        bounds: [-180.0, -90.0, 180.0, 90.0]
+      properties:
+        gid: int4
+
     points2:
       schema: public
       table: points2

--- a/tests/expected/configured/catalog_cfg.json
+++ b/tests/expected/configured/catalog_cfg.json
@@ -24,6 +24,11 @@
     "description": "public.points1.geom"
   },
   {
+    "id": "points1_wgs84",
+    "content_type": "application/x-protobuf",
+    "description": "public.points1.geom"
+  },
+  {
     "id": "points2",
     "content_type": "application/x-protobuf",
     "description": "public.points2.geom"

--- a/tests/expected/given_config.yaml
+++ b/tests/expected/given_config.yaml
@@ -39,6 +39,33 @@ postgres:
       geometry_type: POINT
       properties:
         gid: int4
+    points1_wgs84:
+      layer_id: abc
+      schema: public
+      table: points1
+      srid: 4326
+      geometry_column: geom
+      minzoom: 0
+      maxzoom: 30
+      bounds:
+      - -180.0
+      - -90.0
+      - 180.0
+      - 90.0
+      extent: 4096
+      buffer: 64
+      clip_geom: true
+      geometry_type: POINT
+      properties:
+        gid: int4
+      tile_system:
+        srid: 4326
+        bounds:
+        - -180.0
+        - -90.0
+        - 180.0
+        - 90.0
+        identifier: WGS84Quad
     points2:
       schema: public
       table: points2


### PR DESCRIPTION
This is first attempt at addressing #343

Adds a `tile_systems` section to the yml config:

```yaml
tile_systems:
  nztm:
    srid: 2193
    bounds: [1000000, 4700000, 2600000, 6300000]
  wgs84:
    srid: 4326
    bounds: [-180, -90, 180, 90]
```

Then, the tile URL becomes `/{source}:{tile_system}/{z}/{x}/{y}`

Issues:

- This in effect leads to each table source being duplicated in the catalog. E.g. `table1`, `table1:nztm`, `table1:wgs84` etc
- The URL for a multiple source request becomes `/{source}:{tile_system},{source2}:{tile_system}/{z}/{x}/{y}`. 
- Nothing is done to prevent multiple source requests using different tile systems
- Needs test coverage
- Configuration documentation needs updating

For the OpenLayer users out there. the trick to using this is to giving `VectorTile` source a custom tile grid:

```javascript
new ol.source.VectorTile({
      format: new ol.format.MVT(),
      projection: 'EPSG:2193',
      tileGrid: new ol.tilegrid.TileGrid({
          extent: [1000000, 4700000, 2600000, 6300000], // square of width 1600000
          resolutions: (new Array(10)).fill(0).map((e, i) => 1600000 / (256 * Math.pow(2, i)))
      }),
      url: `http://0.0.0.0:3000/${layer}/{z}/{x}/{y}`
  })
```
