### PR TITLE
Use cargo sparse index in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache openssl-dev musl-dev perl build-base
 
 WORKDIR /usr/src/martin
 ADD . .
-RUN cargo build --release --features=vendored-openssl
+RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --release --features=vendored-openssl
 
 
 FROM alpine:latest


### PR DESCRIPTION
Make docker builds much faster with the latest sparse cargo registry setting

Note that we can revert this PR after the rust 1.70  is out, as i heard it will become the default