### PR TITLE
Revert arm64 docker support (#613) and following

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,10 @@ jobs:
         include:
           - platform: linux/amd64
             file: Dockerfile
-          - platform: linux/arm64
-            file: arm64.Dockerfile
+        # Arm64 does not publish properly, see #655
+        # - platform: linux/arm64
+        #   file: arm64.Dockerfile
+
     runs-on: ubuntu-latest
     steps:
 
@@ -36,18 +38,18 @@ jobs:
         with:
           images: ghcr.io/maplibre/martin
 
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-        with:
-          platforms: linux/arm64,linux/amd64
+      # # https://github.com/docker/setup-qemu-action
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2.1.0
+      #   with:
+      #     platforms: linux/arm64,linux/amd64
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.5.0
         with:
           install: true
-          platforms: ${{ matrix.platform }}
+          # platforms: ${{ matrix.platform }}
 
       - name: Build the Docker image
         id: docker_build
@@ -58,10 +60,10 @@ jobs:
           load: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          # platforms: ${{ matrix.platform }}
 
       - name: Start postgres
-        # arm64 cannot be tested just yet
+        # arm64 testing cannot be tested in a cross-platform env
         if: matrix.platform == 'linux/amd64'
         uses: nyurik/action-setup-postgis@v1
         id: pg
@@ -72,7 +74,7 @@ jobs:
           rights: --superuser
 
       - name: Init database
-        # arm64 cannot be tested just yet
+        # arm64 testing cannot be tested in a cross-platform env
         if: matrix.platform == 'linux/amd64'
         shell: bash
         run: tests/fixtures/initdb.sh
@@ -80,7 +82,7 @@ jobs:
           DATABASE_URL: ${{ steps.pg.outputs.connection-uri }}
 
       - name: Test Docker image
-        # arm64 cannot be tested just yet
+        # arm64 testing cannot be tested in a cross-platform env
         if: matrix.platform == 'linux/amd64'
         run: |
           TAG=$(echo '${{ steps.docker_meta.outputs.json }}' | jq -r '.tags[0]')
@@ -105,7 +107,6 @@ jobs:
         with:
           file: ${{ matrix.file }}
           push: true
-          load: false
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          # platforms: ${{ matrix.platform }}


### PR DESCRIPTION
This reverts commit c358ec53af3ef6e239093d69c8a7790f6eb1f68e, as well as any other related changes to the docker github action.

It is clearly not working, while also not allowing us to build proper releases quicker.

Several ways to fix:
* Use 3rd party CI service to just build multi-platform docker images
* Use cross-compilation wiht github actions
* (???)

See also #655,  #603 and #505