### PR TITLE
adjust book style

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,8 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Martin Documentation"
+
+[output.html]
+curly-quotes = true
+git-repository-url = "https://github.com/maplibre/martin"
+edit-url-template = "https://github.com/maplibre/martin/edit/main/docs/{path}"


### PR DESCRIPTION
- [ ] allow fold/unfold chapter lists.I tried [this](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlfold) but it didn't work.
- [x] add edit links to the originating docs.
- [x] add link to martin repository. Should it link to [marin](https://github.com/maplibre/martin) or [matin doc](https://github.com/maplibre/martin/tree/main/docs)?
- [ ] other stuffs need to talk?

[comprehensive-rust](https://github.com/google/comprehensive-rust)  has something like this(see [mdbook doc](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options)),does marin want it?

```toml
[output.html]
curly-quotes = true
```
Some stuffs [comprehensive-rust](https://github.com/google/comprehensive-rust) used but I think martin dosen't need.
* [mdbook-svgbob](https://github.com/boozook/mdbook-svgbob)
* [mdbook-exerciser](https://github.com/google/comprehensive-rust/tree/main/mdbook-exerciser)
