### PR TITLE
Service startup await clippy lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[alias]
-installsqlx = "install sqlx-cli --no-default-features --features sqlite,native-tls"
-sqlxprep = "sqlx prepare --merged --database-url sqlite://mbtiles/data/geography-class-jpg.mbtiles"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - PGDATABASE=db
       - PGUSER=postgres
-      - PCPASSWORD=postgres
+      - PGPASSWORD=postgres
     volumes:
       - ./tests/fixtures:/fixtures
       - ./tests/fixtures/initdb-dc.sh:/docker-entrypoint-initdb.d/20_martin.sh

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -63,7 +63,7 @@ async fn main() {
 
     start(Args::parse())
         .await
-        .map_or_else(|e| on_error(e), |server| async { server.await })
+        .unwrap_or_else(|e| on_error(e))
         .await
         .unwrap_or_else(|e| on_error(e));
 }


### PR DESCRIPTION
Clippy v1.70 (yesterday's release) is complaining - https://rust-lang.github.io/rust-clippy/master/index.html#redundant_async_block

Also, a tiny typo spotted thx to spellchecking, and removing unused cargo aliases