### PR TITLE
Add `meta-get` functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1452,7 @@ name = "martin-mbtiles"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
+ "anyhow",
  "clap",
  "futures",
  "log",
@@ -1454,6 +1461,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tilejson",
+ "tokio",
 ]
 
 [[package]]
@@ -2575,7 +2583,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.4.9",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,4 +120,4 @@ sqlx = { version = "0.6", features = ["offline", "sqlite", "runtime-actix-native
 subst = { version = "0.2", features = ["yaml"] }
 thiserror = "1"
 tilejson = "0.3"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.28.2", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ actix-cors = "0.6"
 actix-http = "3"
 actix-rt = "2"
 actix-web = "4"
+anyhow = "1.0"
 async-trait = "0.1"
 brotli = "3"
 cargo-husky = { version = "1", features = ["user-hooks"], default-features = false }
@@ -119,3 +120,4 @@ sqlx = { version = "0.6", features = ["offline", "sqlite", "runtime-actix-native
 subst = { version = "0.2", features = ["yaml"] }
 thiserror = "1"
 tilejson = "0.3"
+tokio = { version = "1.25.0", features = ["full"] }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,4 +20,5 @@
   - [Using with deck.gl](using-with-deck-gl.md)
   - [Using with Mapbox](using-with-mapbox.md)
   - [Recipes](recipes.md)
+- [Tools](tools.md)
 - [Development](development.md)

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -1,8 +1,7 @@
 # Tools
 
-## Mbtiles tools:
-A small binary utility that allows users to interact with mbtiles files from the CLI as follows: `mbtiles <command> <file.mbtiles>`
-- ### `meta-get`:
-    Retrieve a metadata value by key: `mbtiles meta-get <file.mbtiles> <options> <key>`.  
-    #### Options:
-  - `-r, --raw` : return the raw metadata value
+## MBTiles tools
+A small utility that allows users to interact with mbtiles files from the CLI as follows: `mbtiles <command> ...`
+
+#### `meta-get`
+Retrieve a metadata value by its name: `mbtiles meta-get <file.mbtiles> <key>`. See `mbtiles meta-get --help` to see available options.

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -1,0 +1,8 @@
+# Tools
+
+## Mbtiles tools:
+A small binary utility that allows users to interact with mbtiles files from the CLI as follows: `mbtiles <command> <file.mbtiles>`
+- ### `meta-get`:
+    Retrieve a metadata value by key: `mbtiles meta-get <file.mbtiles> <options> <key>`.  
+    #### Options:
+  - `-r, --raw` : return the raw metadata value

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ start-legacy: (docker-up "db-legacy")
 [private]
 docker-up name:
     docker-compose up -d {{ name }}
-    docker-compose run --rm db-is-ready
+    docker-compose run -T --rm db-is-ready
 
 alias _down := stop
 alias _stop-db := stop

--- a/martin-mbtiles/Cargo.toml
+++ b/martin-mbtiles/Cargo.toml
@@ -21,6 +21,8 @@ serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tilejson.workspace = true
+tokio = { version = "1.25.0", features = ["full"] }
+anyhow = "1.0"
 
 # Bin dependencies
 clap.workspace = true

--- a/martin-mbtiles/Cargo.toml
+++ b/martin-mbtiles/Cargo.toml
@@ -21,11 +21,11 @@ serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tilejson.workspace = true
-tokio = { version = "1.25.0", features = ["full"] }
-anyhow = "1.0"
 
 # Bin dependencies
+anyhow.workspace = true
 clap.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 # For testing, might as well use the same async framework as the Martin itself

--- a/martin-mbtiles/sqlx-data.json
+++ b/martin-mbtiles/sqlx-data.json
@@ -1,5 +1,23 @@
 {
   "db": "SQLite",
+  "386a375cf65c3e5aef51deffc99d23bd852ba445c1058aed380fe83bed618c29": {
+    "describe": {
+      "columns": [
+        {
+          "name": "value",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT value from metadata where name = ?"
+  },
   "5b298df51dccbf0d8a22433a99febc59c27dbf204d09a9c1fb0b3bf9aaad284b": {
     "describe": {
       "columns": [

--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -1,4 +1,6 @@
+use anyhow::Result;
 use clap::{Parser, Subcommand};
+use martin_mbtiles::Mbtiles;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -25,6 +27,8 @@ enum Commands {
     MetaGetValue {
         /// MBTiles file to read a value from
         file: PathBuf,
+        /// Value to read
+        key: String,
     },
     /// Sets a single value in the metadata table, or deletes it if no value.
     #[command(name = "meta-set")]
@@ -41,10 +45,25 @@ enum Commands {
     },
 }
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<()> {
     let args = Args::parse();
 
-    println!("Parsed args:\n");
-    println!("{args:#?}");
-    println!();
+    match args.command {
+        Commands::MetaGetValue { file, key } => {
+            let mbt = Mbtiles::new(&file).await?;
+
+            let value = mbt.get_metadata_value(&key).await?;
+
+            match value {
+                Some(s) => println!("The value for metadata key \"{key}\" is:\n \"{s}\""),
+                None => println!("No value for metadata key \"{key}\""),
+            }
+        }
+        _ => {
+            unimplemented!("Oops! This command is not yet available, stay tuned for future updates")
+        }
+    }
+
+    Ok(())
 }

--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -29,6 +29,9 @@ enum Commands {
         file: PathBuf,
         /// Value to read
         key: String,
+        /// Output the raw value
+        #[arg(short, long)]
+        raw: bool,
     },
     /// Sets a single value in the metadata table, or deletes it if no value.
     #[command(name = "meta-set")]
@@ -50,14 +53,20 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Commands::MetaGetValue { file, key } => {
+        Commands::MetaGetValue { file, key, raw } => {
             let mbt = Mbtiles::new(&file).await?;
 
             let value = mbt.get_metadata_value(&key).await?;
 
-            match value {
-                Some(s) => println!("The value for metadata key \"{key}\" is:\n \"{s}\""),
-                None => println!("No value for metadata key \"{key}\""),
+            if raw {
+                if let Some(s) = value {
+                    println!("{s}")
+                }
+            } else {
+                match value {
+                    Some(s) => println!(r#"The value for metadata key "{key}" is:\n "{s}""#),
+                    None => println!(r#"No value for metadata key "{key}""#),
+                }
             }
         }
         _ => {

--- a/martin-mbtiles/src/lib.rs
+++ b/martin-mbtiles/src/lib.rs
@@ -329,28 +329,27 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn when_metadata_get_valid_key_then_value() {
-        let mbt = Mbtiles::new(Path::new("../tests/fixtures/files/world_cities.mbtiles")).await;
-        let mbt = mbt.unwrap();
+    async fn metadata_get_key() {
+        let mbt = Mbtiles::new(Path::new("../tests/fixtures/files/world_cities.mbtiles"))
+            .await
+            .unwrap();
 
-        let bounds = mbt.get_metadata_value("bounds").await.unwrap().unwrap();
-        let name = mbt.get_metadata_value("name").await.unwrap().unwrap();
-        let maxzoom = mbt.get_metadata_value("maxzoom").await.unwrap().unwrap();
-
-        assert_eq!(bounds, "-123.123590,-37.818085,174.763027,59.352706");
-        assert_eq!(name, "Major cities from Natural Earth data");
-        assert_eq!(maxzoom, "6");
-    }
-
-    #[actix_rt::test]
-    async fn when_metadata_get_missing_key_then_none() {
-        let mbt = Mbtiles::new(Path::new("../tests/fixtures/files/world_cities.mbtiles")).await;
-        let mbt = mbt.unwrap();
-
-        let nonexistent_key_value = mbt.get_metadata_value("nonexistent_key").await.unwrap();
-        let empty_key_value = mbt.get_metadata_value("").await.unwrap();
-
-        assert_eq!(nonexistent_key_value, None);
-        assert_eq!(empty_key_value, None);
+        assert_eq!(
+            mbt.get_metadata_value("bounds").await.unwrap().unwrap(),
+            "-123.123590,-37.818085,174.763027,59.352706"
+        );
+        assert_eq!(
+            mbt.get_metadata_value("name").await.unwrap().unwrap(),
+            "Major cities from Natural Earth data"
+        );
+        assert_eq!(
+            mbt.get_metadata_value("maxzoom").await.unwrap().unwrap(),
+            "6"
+        );
+        assert_eq!(
+            mbt.get_metadata_value("nonexistent_key").await.unwrap(),
+            None
+        );
+        assert_eq!(mbt.get_metadata_value("").await.unwrap(), None);
     }
 }


### PR DESCRIPTION
* Add functionality to retrieve a metadata value in an mbtiles file by key; simple implementation for one of the items in #667 
* Also, disable TTY in docker-up `just` target