### PR TITLE
Update README.md export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each tile source will have a [TileJSON](https://github.com/mapbox/tilejson-spec)
 
 ```shell
 # publish all tables and functions from a single database
-export DATABASE_URL=postgresql://user:password@host:port/database
+export DATABASE_URL="postgresql://user:password@host:port/database"
 martin
 
 # same as above, but passing connection string via CLI, together with a directory of .mbtiles/.pmtiles files  


### PR DESCRIPTION
Quoting DATABASE_URL content variable prevents an issue from the command export. In case of a string (i.e. password) with given characters (i.e. '('), it can make the command fail. Quoting it prevents that from happening.
The issue happened on MacOS with an M1 chip.