### PR TITLE
Minor refactor and cleanup

### DIFF
--- a/justfile
+++ b/justfile
@@ -197,6 +197,10 @@ lint: fmt clippy
 fmt:
     cargo fmt --all -- --check
 
+# Run Nightly cargo fmt, ordering imports
+fmt2:
+    cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
+
 # Run cargo clippy
 clippy:
     cargo clippy --workspace --all-targets --all-features --bins --tests --lib --benches -- -D warnings

--- a/martin-mbtiles/src/mbtiles_queries.rs
+++ b/martin-mbtiles/src/mbtiles_queries.rs
@@ -1,5 +1,6 @@
-use crate::errors::MbtResult;
 use sqlx::{query, SqliteExecutor};
+
+use crate::errors::MbtResult;
 
 pub async fn is_deduplicated_type<T>(conn: &mut T) -> MbtResult<bool>
 where

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -12,6 +12,7 @@ use crate::config::{copy_unrecognized_config, Unrecognized};
 use crate::file_config::FileError::{InvalidFilePath, InvalidSourceFilePath, IoError};
 use crate::source::{Source, Sources, Xyz};
 use crate::utils::{sorted_opt_map, Error, IdResolver, OneOrMany};
+use crate::OneOrMany::{Many, One};
 
 #[derive(thiserror::Error, Debug)]
 pub enum FileError {
@@ -43,11 +44,11 @@ impl FileConfigEnum {
     pub fn extract_file_config(&mut self) -> FileConfig {
         match self {
             FileConfigEnum::Path(path) => FileConfig {
-                paths: Some(OneOrMany::One(mem::take(path))),
+                paths: Some(One(mem::take(path))),
                 ..FileConfig::default()
             },
             FileConfigEnum::Paths(paths) => FileConfig {
-                paths: Some(OneOrMany::Many(mem::take(paths))),
+                paths: Some(Many(mem::take(paths))),
                 ..Default::default()
             },
             FileConfigEnum::Config(cfg) => mem::take(cfg),

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -26,8 +26,10 @@ mod test_utils;
 #[cfg(test)]
 pub use crate::args::Env;
 pub use crate::config::{read_config, Config};
-pub use crate::source::{IdResolver, Source, Sources, Xyz};
-pub use crate::utils::{decode_brotli, decode_gzip, BoolOrObject, Error, OneOrMany, Result};
+pub use crate::source::{Source, Sources, Xyz};
+pub use crate::utils::{
+    decode_brotli, decode_gzip, BoolOrObject, Error, IdResolver, OneOrMany, Result,
+};
 
 // Ensure README.md contains valid code
 #[cfg(doctest)]

--- a/martin/src/pg/config.rs
+++ b/martin/src/pg/config.rs
@@ -7,8 +7,8 @@ use crate::pg::config_function::FuncInfoSources;
 use crate::pg::config_table::TableInfoSources;
 use crate::pg::configurator::PgBuilder;
 use crate::pg::utils::Result;
-use crate::source::{IdResolver, Sources};
-use crate::utils::{sorted_opt_map, BoolOrObject, OneOrMany};
+use crate::source::Sources;
+use crate::utils::{sorted_opt_map, BoolOrObject, IdResolver, OneOrMany};
 
 pub trait PgInfo {
     fn format_id(&self) -> String;

--- a/martin/src/pg/configurator.rs
+++ b/martin/src/pg/configurator.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use futures::future::join_all;
 use itertools::Itertools;
@@ -14,8 +14,8 @@ use crate::pg::pool::PgPool;
 use crate::pg::table_source::{calc_srid, get_table_sources, merge_table_info, table_to_query};
 use crate::pg::utils::PgError::InvalidTableExtent;
 use crate::pg::utils::Result;
-use crate::source::{IdResolver, Sources};
-use crate::utils::{find_info, normalize_key, BoolOrObject, InfoMap, OneOrMany};
+use crate::source::Sources;
+use crate::utils::{find_info, normalize_key, BoolOrObject, IdResolver, InfoMap, OneOrMany};
 
 pub type SqlFuncInfoMapMap = InfoMap<InfoMap<(PgSqlInfo, FunctionInfo)>>;
 pub type SqlTableInfoMapMapMap = InfoMap<InfoMap<InfoMap<TableInfo>>>;
@@ -139,7 +139,7 @@ impl PgBuilder {
             }
         }
 
-        let mut res: Sources = HashMap::new();
+        let mut res = Sources::default();
         let mut info_map = TableInfoSources::new();
         let pending = join_all(pending).await;
         for src in pending {
@@ -161,7 +161,7 @@ impl PgBuilder {
 
     pub async fn instantiate_functions(&self) -> Result<(Sources, FuncInfoSources)> {
         let mut all_funcs = get_function_sources(&self.pool).await?;
-        let mut res: Sources = HashMap::new();
+        let mut res = Sources::default();
         let mut info_map = FuncInfoSources::new();
         let mut used = HashSet::<(&str, &str)>::new();
 

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -2,4 +2,4 @@ mod config;
 mod server;
 
 pub use config::{SrvConfig, KEEP_ALIVE_DEFAULT, LISTEN_ADDRESSES_DEFAULT};
-pub use server::{new_server, router, AppState, IndexEntry, RESERVED_KEYWORDS};
+pub use server::{new_server, router, RESERVED_KEYWORDS};

--- a/martin/src/utils/id_resolver.rs
+++ b/martin/src/utils/id_resolver.rs
@@ -1,0 +1,93 @@
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default, Clone)]
+pub struct IdResolver {
+    /// name -> unique name
+    names: Arc<Mutex<HashMap<String, String>>>,
+    /// reserved names
+    reserved: HashSet<&'static str>,
+}
+
+impl IdResolver {
+    #[must_use]
+    pub fn new(reserved_keywords: &[&'static str]) -> Self {
+        Self {
+            names: Arc::new(Mutex::new(HashMap::new())),
+            reserved: reserved_keywords.iter().copied().collect(),
+        }
+    }
+
+    /// If source name already exists in the self.names structure,
+    /// try appending it with ".1", ".2", etc. until the name is unique.
+    /// Only alphanumeric characters plus dashes/dots/underscores are allowed.
+    #[must_use]
+    pub fn resolve(&self, name: &str, unique_name: String) -> String {
+        // Ensure name has no prohibited characters like spaces, commas, slashes, or non-unicode etc.
+        // Underscores, dashes, and dots are OK. All other characters will be replaced with dashes.
+        let mut name = name.replace(
+            |c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '.' && c != '-',
+            "-",
+        );
+
+        let mut names = self.names.lock().expect("IdResolver panicked");
+        if !self.reserved.contains(name.as_str()) {
+            match names.entry(name) {
+                Entry::Vacant(e) => {
+                    let id = e.key().clone();
+                    e.insert(unique_name);
+                    return id;
+                }
+                Entry::Occupied(e) => {
+                    name = e.key().clone();
+                    if e.get() == &unique_name {
+                        return name;
+                    }
+                }
+            }
+        }
+        // name already exists, try it with ".1", ".2", etc. until the value matches
+        // assume that reserved keywords never end in a "dot number", so don't check
+        let mut index: i32 = 1;
+        let mut new_name = String::new();
+        loop {
+            new_name.clear();
+            write!(&mut new_name, "{name}.{index}").unwrap();
+            index = index.checked_add(1).unwrap();
+            match names.entry(new_name.clone()) {
+                Entry::Vacant(e) => {
+                    e.insert(unique_name);
+                    return new_name;
+                }
+                Entry::Occupied(e) => {
+                    if e.get() == &unique_name {
+                        return new_name;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_resolve() {
+        let r = IdResolver::default();
+        assert_eq!(r.resolve("a", "a".to_string()), "a");
+        assert_eq!(r.resolve("a", "a".to_string()), "a");
+        assert_eq!(r.resolve("a", "b".to_string()), "a.1");
+        assert_eq!(r.resolve("a", "b".to_string()), "a.1");
+        assert_eq!(r.resolve("b", "a".to_string()), "b");
+        assert_eq!(r.resolve("b", "a".to_string()), "b");
+        assert_eq!(r.resolve("a.1", "a".to_string()), "a.1.1");
+        assert_eq!(r.resolve("a.1", "b".to_string()), "a.1");
+
+        assert_eq!(r.resolve("a b", "a b".to_string()), "a-b");
+        assert_eq!(r.resolve("a b", "ab2".to_string()), "a-b.1");
+    }
+}

--- a/martin/src/utils/mod.rs
+++ b/martin/src/utils/mod.rs
@@ -1,7 +1,9 @@
 mod error;
+mod id_resolver;
 mod one_or_many;
 mod utilities;
 
 pub use error::*;
+pub use id_resolver::IdResolver;
 pub use one_or_many::OneOrMany;
 pub use utilities::*;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 ## These should be enabled in the future, but for now its a manual step to simplify usage.
-## Use cargo nightly for these:    cargo +nightly fmt
+## Use Justfile fmt2 target instead:   just fmt2
 #imports_granularity = "Module"
 #group_imports = "StdExternalCrate"

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -15,8 +15,8 @@ mod test_utils;
 #[allow(clippy::wildcard_imports)]
 pub use test_utils::*;
 
-pub async fn mock_app_data(sources: Sources) -> Data<AppState> {
-    Data::new(AppState { sources })
+pub async fn mock_app_data(sources: Sources) -> Data<Sources> {
+    Data::new(sources)
 }
 
 #[must_use]


### PR DESCRIPTION
* moved `IdResolver` to a separate file
* added `just fmt2` build target to format code using nightly mode
* moved all Actix `Data<AppState>` into individual state objects, e.g. `Data<Sources>` (allows other source types, separate from `Sources` type)
* move all Source-related code to a new `Sources` struct (a simple wrapper over a HashMap)