### PR TITLE
Add force-simple parameter when copying

### DIFF
--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -45,22 +45,8 @@ enum Commands {
     /// Copy tiles from one mbtiles file to another.
     #[command(name = "copy")]
     Copy {
-        /// MBTiles file to read from
-        src_file: PathBuf,
-        /// MBTiles file to write to
-        dst_file: PathBuf,
-        /// Force the output file to be in a simple MBTiles format with a `tiles` table
-        #[arg(long)]
-        force_simple: bool,
-        /// Minimum zoom level to copy
-        #[arg(long)]
-        min_zoom: Option<u8>,
-        /// Maximum zoom level to copy
-        #[arg(long)]
-        max_zoom: Option<u8>,
-        /// List of zoom levels to copy; if provided, min-zoom and max-zoom will be ignored
-        #[arg(long, value_delimiter(','))]
-        zoom_levels: Vec<u8>,
+        #[clap(flatten)]
+        opts: TileCopierOptions,
     },
 }
 
@@ -72,22 +58,8 @@ async fn main() -> Result<()> {
         Commands::MetaGetValue { file, key } => {
             meta_get_value(file.as_path(), &key).await?;
         }
-        Commands::Copy {
-            src_file,
-            dst_file,
-            force_simple,
-            min_zoom,
-            max_zoom,
-            zoom_levels,
-        } => {
-            let copy_opts = TileCopierOptions::new()
-                .verbose(args.verbose)
-                .force_simple(force_simple)
-                .min_zoom(min_zoom)
-                .max_zoom(max_zoom)
-                .zooms(zoom_levels);
-
-            let tile_copier = TileCopier::new(src_file, dst_file, copy_opts)?;
+        Commands::Copy { opts } => {
+            let tile_copier = TileCopier::new(opts)?;
 
             tile_copier.run().await?;
         }

--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -49,6 +49,9 @@ enum Commands {
         src_file: PathBuf,
         /// MBTiles file to write to
         dst_file: PathBuf,
+        /// Force the output file to be in a simple MBTiles format with a `tiles` table
+        #[arg(long)]
+        force_simple: bool,
         /// Minimum zoom level to copy
         #[arg(long)]
         min_zoom: Option<u8>,
@@ -72,12 +75,14 @@ async fn main() -> Result<()> {
         Commands::Copy {
             src_file,
             dst_file,
+            force_simple,
             min_zoom,
             max_zoom,
             zoom_levels,
         } => {
             let copy_opts = TileCopierOptions::new()
                 .verbose(args.verbose)
+                .force_simple(force_simple)
                 .min_zoom(min_zoom)
                 .max_zoom(max_zoom)
                 .zooms(zoom_levels);

--- a/martin-mbtiles/src/lib.rs
+++ b/martin-mbtiles/src/lib.rs
@@ -9,4 +9,4 @@ mod tile_copier;
 pub use errors::MbtError;
 pub use mbtiles::{Mbtiles, Metadata};
 pub use mbtiles_pool::MbtilesPool;
-pub use tile_copier::{TileCopier, TileCopierOptions};
+pub use tile_copier::{copy_mbtiles_file, TileCopierOptions};


### PR DESCRIPTION
Add `--force-simple` flag to `mbtiles copy` tool.
If supplied, ensures the destination file has a `tiles` _table_ (as opposed to a `tiles` _view_ made up of `images` and `map` tables).