### PR TITLE
Debian package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
         run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md
+      - name: Install cargo-deb
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install dpkg -y
+          sudo apt install dpkg-dev -y
+          sudo apt install liblzma-dev -y
+          cargo install cargo-deb
       - name: Run build
         shell: bash
         run: |
@@ -82,6 +89,12 @@ jobs:
             mv target/${{ matrix.target }}/release/martin target_releases
             mv target/${{ matrix.target }}/release/mbtiles target_releases
           fi
+      - name: Run build (debian package)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          cargo deb -v -p martin --output target/debian/martin.deb
+          mv target/debian/martin.deb target_releases
       - name: Save build artifact build-${{ matrix.target }}
         uses: actions/upload-artifact@v3
         with:
@@ -156,7 +169,7 @@ jobs:
         with:
           name: build-${{ matrix.target }}
           path: target/
-      - name: Integration Tests
+      - name: Integration Tests (without debian package)
         if: matrix.target != 'aarch64-apple-darwin'
         shell: bash
         run: |
@@ -171,7 +184,18 @@ jobs:
           MARTIN_BIN: target/martin${{ matrix.ext }}
           MBTILES_BUILD: "-"
           MBTILES_BIN: target/mbtiles${{ matrix.ext }}
-
+      - name: Integration Tests (with debian package)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          sudo dpkg -i target/martin.deb
+          tests/test.sh
+        env:
+          DATABASE_URL: ${{ steps.pg.outputs.connection-uri }}
+          MARTIN_BUILD: "-"
+          MARTIN_BIN: /usr/bin/martin
+          MBTILES_BUILD: "-"
+          MBTILES_BIN: target/mbtiles${{ matrix.ext }}
       - name: Compare test output results (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: diff --brief --recursive --new-file tests/output tests/expected
@@ -196,6 +220,13 @@ jobs:
           else
             tar czvf ../${{ matrix.name }} martin${{ matrix.ext }} mbtiles${{ matrix.ext }}
           fi
+          cd -
+      - name: package (debian)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          cd target/
+          tar czvf ../martin-debian-x86_64.tar.gz martin.deb
           cd -
       - name: Generate SHA-256 (MacOS)
         if: matrix.target == 'x86_64-apple-darwin' || matrix.target == 'aarch64-apple-darwin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,7 @@ jobs:
       - name: Install cargo-deb
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install dpkg -y
-          sudo apt install dpkg-dev -y
-          sudo apt install liblzma-dev -y
+          sudo apt install -y dpkg dpkg-dev liblzma-dev
           cargo install cargo-deb
       - name: Run build
         shell: bash
@@ -169,7 +167,7 @@ jobs:
         with:
           name: build-${{ matrix.target }}
           path: target/
-      - name: Integration Tests (without debian package)
+      - name: Integration Tests
         if: matrix.target != 'aarch64-apple-darwin'
         shell: bash
         run: |
@@ -221,7 +219,7 @@ jobs:
             tar czvf ../${{ matrix.name }} martin${{ matrix.ext }} mbtiles${{ matrix.ext }}
           fi
           cd -
-      - name: package (debian)
+      - name: Package (debian)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/maplibre/martin"
 rust-version = "1.65"
+readme = "README.md"
+homepage = "https://martin.maplibre.org/"
 
 [workspace.dependencies]
 actix = "0.13"

--- a/justfile
+++ b/justfile
@@ -110,6 +110,10 @@ bless: start clean-test
 book: (cargo-install "mdbook")
     mdbook serve docs --open --port 8321
 
+# Build debian package
+package-deb: (cargo-install "cargo-deb")
+    cargo deb -v -p martin --output target/debian/martin.deb
+
 # Build and open code documentation
 docs:
     cargo doc --no-deps --open

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -13,6 +13,13 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+
+[package.metadata.deb]
+name = "martin"
+maintainer = "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>, Yuri Astrakhan <YuriAstrakhan@gmail.com>, MapLibre contributors"
+depends = "$auto"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
Add deb package  by [cargo-deb](https://crates.io/crates/cargo-deb)
- [ ] add deb package metadata
- [ ] more research on systemd integration

To inspect the package:
```shell
# install cargo-deb dependices
sudo apt install dpkg
sudo apt install dpkg-dev
sudo apt install liblzma-dev

cargo install cargo-deb
cd martin
cargo deb
The Debian package will be created in `target/debian/martin_0.8.7_amd64.deb` . 
```

To decompress this package:
```shell
dpkg -x martin_0.8.7_amd64.deb path_of_decompress  
```
