### PR TITLE
Cleanup docker and related docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   db-is-ready:
     # This should match the version of postgres used in the CI workflow
-    image: postgis/postgis:14-3.3
+    image: postgis/postgis:14-3.3-alpine
     network_mode: host
     command:
       - "sh"

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -48,7 +48,7 @@ Available recipes:
     test-unit *ARGS        # Run Rust unit and doc tests (cargo test)
     test-int               # Run integration tests
     bless                  # Run integration tests and save its output as the new expected output
-    mdbook                 # Build and open mdbook documentation
+    book                   # Build and open mdbook documentation
     docs                   # Build and open code documentation
     coverage FORMAT='html' # Run code coverage on tests and save its output in the coverage directory. Parameter could be html or lcov.
     docker-build           # Build martin docker image
@@ -57,6 +57,7 @@ Available recipes:
     print-conn-str         # Print the connection string for the test database
     lint                   # Run cargo fmt and cargo clippy
     fmt                    # Run cargo fmt
+    fmt2                   # Run Nightly cargo fmt, ordering imports
     clippy                 # Run cargo clippy
-    prepare-sqlite         # Update sqlite database schema. Install SQLX cli if not already installed.
+    prepare-sqlite         # Update sqlite database schema.
 ```

--- a/docs/src/run-with-docker.md
+++ b/docs/src/run-with-docker.md
@@ -2,24 +2,39 @@
 
 You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/maplibre/martin)
 
+### Using Non-Local PostgreSQL
 ```shell
 docker run \
   -p 3000:3000 \
-  -e DATABASE_URL=postgresql://postgres@localhost/db \
+  -e DATABASE_URL=postgresql://postgres@postgres.example.com/db \
   ghcr.io/maplibre/martin
 ```
 
+### Exposing Local Files
+
+You can expose local files to the Docker container using the `-v` flag.
+
+```shell
+docker run \
+  -p 3000:3000 \
+  -v /path/to/local/files:/files \
+  ghcr.io/maplibre/martin /files
+```
+
+### Accessing Local PostgreSQL on Linux
+
 If you are running PostgreSQL instance on `localhost`, you have to change network settings to allow the Docker container to access the `localhost` network.
 
-For Linux, add the `--net=host` flag to access the `localhost` PostgreSQL service.
+For Linux, add the `--net=host` flag to access the `localhost` PostgreSQL service. You would not need to export ports with `-p` because the container is already using the host network.
 
 ```shell
 docker run \
   --net=host \
-  -p 3000:3000 \
   -e DATABASE_URL=postgresql://postgres@localhost/db \
   ghcr.io/maplibre/martin
 ```
+
+### Accessing Local PostgreSQL on macOS
 
 For macOS, use `host.docker.internal` as hostname to access the `localhost` PostgreSQL service.
 
@@ -29,6 +44,8 @@ docker run \
   -e DATABASE_URL=postgresql://postgres@host.docker.internal/db \
   ghcr.io/maplibre/martin
 ```
+
+### Accessing Local PostgreSQL on Windows
 
 For Windows, use `docker.for.win.localhost` as hostname to access the `localhost` PostgreSQL service.
 

--- a/justfile
+++ b/justfile
@@ -65,12 +65,8 @@ bench: start
     cargo bench
 
 # Run HTTP requests benchmark using OHA tool. Use with `just run-release`
-bench-http:
+bench-http: (cargo-install "oha")
     @echo "Make sure Martin was started with 'just run-release'"
-    @if ! command -v oha &> /dev/null; then \
-        echo "oha could not be found. Installing..." ;\
-        cargo install oha ;\
-    fi
     @echo "Warming up..."
     oha -z 5s --no-tui http://localhost:3000/function_zxy_query/18/235085/122323 > /dev/null
     oha -z 120s  http://localhost:3000/function_zxy_query/18/235085/122323
@@ -111,11 +107,7 @@ bless: start clean-test
     mv tests/output tests/expected
 
 # Build and open mdbook documentation
-book:
-    @if ! command -v mdbook &> /dev/null; then \
-        echo "mdbook could not be found. Installing..." ;\
-        cargo install mdbook ;\
-    fi
+book: (cargo-install "mdbook")
     mdbook serve docs --open --port 8321
 
 # Build and open code documentation
@@ -123,13 +115,9 @@ docs:
     cargo doc --no-deps --open
 
 # Run code coverage on tests and save its output in the coverage directory. Parameter could be html or lcov.
-coverage FORMAT='html':
+coverage FORMAT='html': (cargo-install "grcov")
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v grcov &> /dev/null; then \
-        echo "grcov could not be found. Installing..." ;\
-        cargo install grcov ;\
-    fi
     if ! rustup component list | grep llvm-tools-preview &> /dev/null; then \
         echo "llvm-tools-preview could not be found. Installing..." ;\
         rustup component add llvm-tools-preview ;\
@@ -219,8 +207,12 @@ prepare-sqlite: install-sqlx
 
 # Install SQLX cli if not already installed.
 [private]
-install-sqlx:
-    @if ! command -v cargo-sqlx &> /dev/null; then \
-        echo "SQLX cargo plugin could not be found. Installing..." ;\
-        cargo install sqlx-cli --no-default-features --features sqlite,native-tls ;\
+install-sqlx: (cargo-install "cargo-sqlx" "sqlx-cli" "--no-default-features" "--features" "sqlite,native-tls")
+
+# Check if a certain Cargo command is installed, and install it if needed
+[private]
+cargo-install $COMMAND $INSTALL_CMD="" *ARGS="":
+    @if ! command -v $COMMAND &> /dev/null; then \
+        echo "$COMMAND could not be found. Installing it with    cargo install ${INSTALL_CMD:-$COMMAND} {{ ARGS }}" ;\
+        cargo install ${INSTALL_CMD:-$COMMAND} {{ ARGS }} ;\
     fi

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ bless: start clean-test
     mv tests/output tests/expected
 
 # Build and open mdbook documentation
-mdbook:
+book:
     @if ! command -v mdbook &> /dev/null; then \
         echo "mdbook could not be found. Installing..." ;\
         cargo install mdbook ;\


### PR DESCRIPTION
* Use same docker image for postgis & psql
* Improve docker book
* rename just target `mdbook` to `book` (more obvious choice)
* Cleanup justfile to not duplicate "cargo install" check & installation