### PR TITLE
Add ability to copy to existing mbtiles files

### DIFF
--- a/justfile
+++ b/justfile
@@ -207,7 +207,7 @@ git-pre-push: stop start
 # Update sqlite database schema.
 prepare-sqlite: install-sqlx
     mkdir -p martin-mbtiles/.sqlx
-    cd martin-mbtiles && cargo sqlx prepare --database-url sqlite://$PWD/../tests/fixtures/files/world_cities.mbtiles
+    cd martin-mbtiles && cargo sqlx prepare --database-url sqlite://$PWD/../tests/fixtures/files/world_cities.mbtiles -- --lib --tests
 
 # Install SQLX cli if not already installed.
 [private]

--- a/martin-mbtiles/.sqlx/query-0a4540e8c33c71222a68ff5ecc1a167b406de9961ac3cc69649c6152a6d7a9b7.json
+++ b/martin-mbtiles/.sqlx/query-0a4540e8c33c71222a68ff5ecc1a167b406de9961ac3cc69649c6152a6d7a9b7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "VACUUM",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "0a4540e8c33c71222a68ff5ecc1a167b406de9961ac3cc69649c6152a6d7a9b7"
+}

--- a/martin-mbtiles/.sqlx/query-176e99c6945b0789119d0d21a99de564de47dde1d588f17e68ec58115ac73a39.json
+++ b/martin-mbtiles/.sqlx/query-176e99c6945b0789119d0d21a99de564de47dde1d588f17e68ec58115ac73a39.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT 1 as has_rows FROM sqlite_schema LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "has_rows",
+        "ordinal": 0,
+        "type_info": "Int"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "176e99c6945b0789119d0d21a99de564de47dde1d588f17e68ec58115ac73a39"
+}

--- a/martin-mbtiles/.sqlx/query-3b2930e8d61f31ea1bf32efe340b7766f876ddb9a357a512ab3a37914bea003c.json
+++ b/martin-mbtiles/.sqlx/query-3b2930e8d61f31ea1bf32efe340b7766f876ddb9a357a512ab3a37914bea003c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "ATTACH DATABASE ? AS sourceDb",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "3b2930e8d61f31ea1bf32efe340b7766f876ddb9a357a512ab3a37914bea003c"
+}

--- a/martin-mbtiles/.sqlx/query-a115609880b2c6ed3beeb5aaf8c7e779ecf324e1862945fbd18da4bf5baf565b.json
+++ b/martin-mbtiles/.sqlx/query-a115609880b2c6ed3beeb5aaf8c7e779ecf324e1862945fbd18da4bf5baf565b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "ATTACH DATABASE ? AS newDb",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "a115609880b2c6ed3beeb5aaf8c7e779ecf324e1862945fbd18da4bf5baf565b"
+}

--- a/martin-mbtiles/.sqlx/query-b3aaef71d6a26404c3bebcc6ee8ad480aaa224721cd9ddb4ac5859f71a57727e.json
+++ b/martin-mbtiles/.sqlx/query-b3aaef71d6a26404c3bebcc6ee8ad480aaa224721cd9ddb4ac5859f71a57727e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "ATTACH DATABASE ? AS otherDb",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "b3aaef71d6a26404c3bebcc6ee8ad480aaa224721cd9ddb4ac5859f71a57727e"
+}

--- a/martin-mbtiles/.sqlx/query-e13e2e17d5bf56287bc0fd7c55a1f52ce710d8978e3b35b59b724fc5bee9f55c.json
+++ b/martin-mbtiles/.sqlx/query-e13e2e17d5bf56287bc0fd7c55a1f52ce710d8978e3b35b59b724fc5bee9f55c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "ATTACH DATABASE ? AS diffDb",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "e13e2e17d5bf56287bc0fd7c55a1f52ce710d8978e3b35b59b724fc5bee9f55c"
+}

--- a/martin-mbtiles/.sqlx/query-f547ff198e3bb604550a3f191e4ad8c695c4c2350f294aefd210eccec603d905.json
+++ b/martin-mbtiles/.sqlx/query-f547ff198e3bb604550a3f191e4ad8c695c4c2350f294aefd210eccec603d905.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "PRAGMA page_size = 512",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "f547ff198e3bb604550a3f191e4ad8c695c4c2350f294aefd210eccec603d905"
+}

--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -93,7 +93,7 @@ mod tests {
 
     use clap::error::ErrorKind;
     use clap::Parser;
-    use martin_mbtiles::TileCopierOptions;
+    use martin_mbtiles::{CopyDuplicateMode, TileCopierOptions};
 
     use crate::Args;
     use crate::Commands::{ApplyDiff, Copy, MetaGetValue};
@@ -240,6 +240,69 @@ mod tests {
                     TileCopierOptions::new(PathBuf::from("src_file"), PathBuf::from("dst_file"))
                         .diff_with_file(PathBuf::from("no_file"))
                         .force_simple(true)
+                )
+            }
+        );
+    }
+
+    #[test]
+    fn test_copy_diff_with_override_copy_duplicate_mode() {
+        assert_eq!(
+            Args::parse_from([
+                "mbtiles",
+                "copy",
+                "src_file",
+                "dst_file",
+                "--on-duplicate",
+                "override"
+            ]),
+            Args {
+                verbose: false,
+                command: Copy(
+                    TileCopierOptions::new(PathBuf::from("src_file"), PathBuf::from("dst_file"))
+                        .on_duplicate(CopyDuplicateMode::Override)
+                )
+            }
+        );
+    }
+
+    #[test]
+    fn test_copy_diff_with_ignore_copy_duplicate_mode() {
+        assert_eq!(
+            Args::parse_from([
+                "mbtiles",
+                "copy",
+                "src_file",
+                "dst_file",
+                "--on-duplicate",
+                "ignore"
+            ]),
+            Args {
+                verbose: false,
+                command: Copy(
+                    TileCopierOptions::new(PathBuf::from("src_file"), PathBuf::from("dst_file"))
+                        .on_duplicate(CopyDuplicateMode::Ignore)
+                )
+            }
+        );
+    }
+
+    #[test]
+    fn test_copy_diff_with_abort_copy_duplicate_mode() {
+        assert_eq!(
+            Args::parse_from([
+                "mbtiles",
+                "copy",
+                "src_file",
+                "dst_file",
+                "--on-duplicate",
+                "abort"
+            ]),
+            Args {
+                verbose: false,
+                command: Copy(
+                    TileCopierOptions::new(PathBuf::from("src_file"), PathBuf::from("dst_file"))
+                        .on_duplicate(CopyDuplicateMode::Abort)
                 )
             }
         );

--- a/martin-mbtiles/src/errors.rs
+++ b/martin-mbtiles/src/errors.rs
@@ -28,6 +28,12 @@ pub enum MbtError {
 
     #[error("The destination file {0} is non-empty")]
     NonEmptyTargetFile(PathBuf),
+
+    #[error("The file {0} is does not have the required uniqueness constraint")]
+    NoUniquenessConstraint(String),
+
+    #[error("Unexpected duplicate values found when copying")]
+    DuplicateValues(),
 }
 
 pub type MbtResult<T> = Result<T, MbtError>;

--- a/martin-mbtiles/src/errors.rs
+++ b/martin-mbtiles/src/errors.rs
@@ -33,7 +33,7 @@ pub enum MbtError {
     NoUniquenessConstraint(String),
 
     #[error("Unexpected duplicate tiles found when copying")]
-    DuplicateValues(),
+    DuplicateValues,
 }
 
 pub type MbtResult<T> = Result<T, MbtError>;

--- a/martin-mbtiles/src/errors.rs
+++ b/martin-mbtiles/src/errors.rs
@@ -32,6 +32,9 @@ pub enum MbtError {
     #[error("The file {0} does not have the required uniqueness constraint")]
     NoUniquenessConstraint(String),
 
+    #[error("Could not copy MBTiles file: {reason}")]
+    UnsupportedCopyOperation { reason: String },
+
     #[error("Unexpected duplicate tiles found when copying")]
     DuplicateValues,
 }

--- a/martin-mbtiles/src/errors.rs
+++ b/martin-mbtiles/src/errors.rs
@@ -29,10 +29,10 @@ pub enum MbtError {
     #[error("The destination file {0} is non-empty")]
     NonEmptyTargetFile(PathBuf),
 
-    #[error("The file {0} is does not have the required uniqueness constraint")]
+    #[error("The file {0} does not have the required uniqueness constraint")]
     NoUniquenessConstraint(String),
 
-    #[error("Unexpected duplicate values found when copying")]
+    #[error("Unexpected duplicate tiles found when copying")]
     DuplicateValues(),
 }
 

--- a/martin-mbtiles/src/lib.rs
+++ b/martin-mbtiles/src/lib.rs
@@ -9,4 +9,6 @@ mod tile_copier;
 pub use errors::MbtError;
 pub use mbtiles::{Mbtiles, Metadata};
 pub use mbtiles_pool::MbtilesPool;
-pub use tile_copier::{apply_mbtiles_diff, copy_mbtiles_file, TileCopierOptions};
+pub use tile_copier::{
+    apply_mbtiles_diff, copy_mbtiles_file, CopyDuplicateMode, TileCopierOptions,
+};

--- a/martin-mbtiles/src/tile_copier.rs
+++ b/martin-mbtiles/src/tile_copier.rs
@@ -13,7 +13,8 @@ use crate::mbtiles::MbtType;
 use crate::mbtiles::MbtType::TileTables;
 use crate::{MbtError, Mbtiles};
 
-#[derive(ValueEnum, PartialEq, Eq, Default, Debug, Clone)]
+#[derive(PartialEq, Eq, Default, Debug, Clone)]
+#[cfg_attr(feature = "cli", derive(ValueEnum))]
 enum CopyDuplicateMode {
     #[default]
     Override,

--- a/martin-mbtiles/src/tile_copier.rs
+++ b/martin-mbtiles/src/tile_copier.rs
@@ -15,7 +15,7 @@ use crate::{MbtError, Mbtiles};
 
 #[derive(PartialEq, Eq, Default, Debug, Clone)]
 #[cfg_attr(feature = "cli", derive(ValueEnum))]
-enum CopyDuplicateMode {
+pub enum CopyDuplicateMode {
     #[default]
     Override,
     Ignore,

--- a/martin-mbtiles/src/tile_copier.rs
+++ b/martin-mbtiles/src/tile_copier.rs
@@ -267,7 +267,7 @@ impl TileCopier {
                     match &self.options.on_duplicate {
                         CopyDuplicateMode::Override => "OR REPLACE",
                         CopyDuplicateMode::Ignore => "OR IGNORE",
-                        _ => "",
+                        CopyDuplicateMode::Abort => "",
                     }
                 ),
             )
@@ -279,7 +279,7 @@ impl TileCopier {
         let on_duplicate_sql = match &self.options.on_duplicate {
             CopyDuplicateMode::Override => "OR REPLACE",
             CopyDuplicateMode::Ignore => "OR IGNORE",
-            _ => "",
+            CopyDuplicateMode::Abort => "",
         };
         query(&format!(
             "INSERT {on_duplicate_sql} INTO map SELECT * FROM sourceDb.map"

--- a/martin-mbtiles/src/tile_copier.rs
+++ b/martin-mbtiles/src/tile_copier.rs
@@ -199,9 +199,6 @@ impl TileCopier {
                 .await?;
         } else {
             mbtiles_type = open_and_detect_type(&self.dst_mbtiles).await?;
-            self.dst_mbtiles
-                .check_for_uniqueness_constraint(&mut conn, Some(mbtiles_type.clone()))
-                .await?;
 
             if self.options.on_duplicate == CopyDuplicateMode::Abort
                 && query(


### PR DESCRIPTION
* Allow the `dst` in `mbtiles copy <src> <dst>` command to already contain data, merging tilesets
* Add `mbtiles copy --on-duplicate (override|ignore|abort)`