### PR TITLE
Downgrade log level for unknown MBTiles metadata

### DIFF
--- a/martin-mbtiles/src/mbtiles.rs
+++ b/martin-mbtiles/src/mbtiles.rs
@@ -137,7 +137,7 @@ impl Mbtiles {
                     }
                     _ => {
                         let file = &self.filename;
-                        warn!("{file} has an unrecognized metadata value {name}={value}");
+                        info!("{file} has an unrecognized metadata value {name}={value}");
                         tj.other.insert(name, Value::String(value));
                     }
                 }


### PR DESCRIPTION
#799  Downgrade log level from `warn` to `info` when there is unrecognized metadata value in `MBTiles` file . 