### PR TITLE
Add `metrics` to reserved list, docs

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -16,6 +16,12 @@ Martin data is available via the HTTP `GET` endpoints:
 ## Duplicate Source ID
 In case there is more than one source that has the same name, e.g. a PG function is available in two schemas/connections, or a table has more than one geometry columns, sources will be assigned unique IDs such as `/points`, `/points.1`, etc.
 
+## Reserved Source IDs
+Some source IDs are reserved for internal use. If you try to use them, they will be automatically renamed to a unique ID the same way as duplicate source IDs are handled, e.g. a `catalog` source will become `catalog.1`.
+
+Some of the reserved IDs: `_`, `catalog`, `config`, `font`, `health`, `help`, `index`, `manifest`, `metrics`, `refresh`,
+`reload`, `sprite`, `status`.
+
 ## Catalog
 
 A list of all available sources is available via catalogue endpoint:

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -30,10 +30,11 @@ use crate::utils::{decode_brotli, decode_gzip, encode_brotli, encode_gzip};
 use crate::Error::BindingError;
 
 /// List of keywords that cannot be used as source IDs. Some of these are reserved for future use.
-/// Reserved keywords must never end in a "dot number" (e.g. ".1")
+/// Reserved keywords must never end in a "dot number" (e.g. ".1").
+/// This list is documented in the `docs/src/using.md` file, which should be kept in sync.
 pub const RESERVED_KEYWORDS: &[&str] = &[
-    "catalog", "config", "font", "health", "help", "index", "manifest", "refresh", "reload",
-    "sprite", "status",
+    "_", "catalog", "config", "font", "health", "help", "index", "manifest", "metrics", "refresh",
+    "reload", "sprite", "status",
 ];
 
 static SUPPORTED_ENCODINGS: &[HeaderEnc] = &[


### PR DESCRIPTION
This adds `metrics` as a reserved keyword, so any source with that name will be auto-renamed to `metrics.1`, ...

minor change to allow for #793 