### PR TITLE
Retrieve function source description from comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "treediff",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1803,7 @@ dependencies = [
  "futures",
  "indoc",
  "itertools 0.11.0",
+ "json-patch",
  "log",
  "martin-mbtiles",
  "martin-tile-utils",
@@ -3636,6 +3649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "treediff"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = "1"
 futures = "0.3"
 indoc = "2"
 itertools = "0.11"
+json-patch = "1.0"
 log = "0.4"
 martin-mbtiles = { path = "./martin-mbtiles", version = "0.4.0", default-features = false, features = ["native-tls"] }  # disable CLI tools
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.1.0" }

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -60,6 +60,7 @@ brotli.workspace = true
 clap.workspace = true
 deadpool-postgres.workspace = true
 env_logger.workspace = true
+json-patch.workspace = true
 flate2.workspace = true
 futures.workspace = true
 itertools.workspace = true

--- a/martin/src/pg/config_function.rs
+++ b/martin/src/pg/config_function.rs
@@ -1,3 +1,4 @@
+use log::error;
 use serde::{Deserialize, Serialize};
 use tilejson::{Bounds, TileJSON};
 
@@ -30,16 +31,21 @@ pub struct FunctionInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
 
+    /// TileJSON provided by the SQL function comment. Not serialized.
+    #[serde(skip)]
+    pub tilejson: Option<serde_json::Value>,
+
     #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
 
 impl FunctionInfo {
     #[must_use]
-    pub fn new(schema: String, function: String) -> Self {
+    pub fn new(schema: String, function: String, tilejson: Option<serde_json::Value>) -> Self {
         Self {
             schema,
             function,
+            tilejson,
             ..Default::default()
         }
     }
@@ -61,6 +67,34 @@ impl FunctionInfo {
             ..Default::default()
         }
     }
+
+    /// Merge the `self.tilejson` from the function comment into the generated tilejson (param)
+    fn merge_json(&self, tilejson: TileJSON) -> TileJSON {
+        let Some(tj) = &self.tilejson else {
+            // Nothing to merge in, keep the original
+            return tilejson;
+        };
+        // Not the most efficient, but this is only executed once per source:
+        // * Convert the TileJSON struct to a serde_json::Value
+        // * Merge the self.tilejson into the value
+        // * Convert the merged value back to a TileJSON struct
+        // * In case of errors, return the original tilejson
+        let mut tilejson2 = match serde_json::to_value(tilejson.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to serialize tilejson, unable to merge function comment: {e}");
+                return tilejson;
+            }
+        };
+        json_patch::merge(&mut tilejson2, tj);
+        match serde_json::from_value(tilejson2.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to deserialize merged function comment tilejson: {e}");
+                tilejson
+            }
+        }
+    }
 }
 
 impl PgInfo for FunctionInfo {
@@ -77,6 +111,6 @@ impl PgInfo for FunctionInfo {
         tilejson.minzoom = self.minzoom;
         tilejson.maxzoom = self.maxzoom;
         tilejson.bounds = self.bounds;
-        tilejson
+        self.merge_json(tilejson)
     }
 }

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -17,7 +17,7 @@
   {
     "id": "function_Mixed_Name",
     "content_type": "application/x-protobuf",
-    "description": "MixedCase.function_Mixed_Name"
+    "description": "a function source with MixedCase name"
   },
   {
     "id": "function_null",
@@ -51,8 +51,7 @@
   },
   {
     "id": "function_zxy_query",
-    "content_type": "application/x-protobuf",
-    "description": "public.function_zxy_query"
+    "content_type": "application/x-protobuf"
   },
   {
     "id": "function_zxy_query_jsonb",

--- a/tests/expected/auto/fnc.json
+++ b/tests/expected/auto/fnc.json
@@ -3,6 +3,8 @@
   "tiles": [
     "http://localhost:3111/function_zxy_query/{z}/{x}/{y}"
   ],
-  "description": "public.function_zxy_query",
-  "name": "function_zxy_query"
+  "name": "function_zxy_query",
+  "foo": {
+    "bar": "foo"
+  }
 }

--- a/tests/fixtures/functions/function_Mixed_Name.sql
+++ b/tests/fixtures/functions/function_Mixed_Name.sql
@@ -13,3 +13,20 @@ RETURNS TABLE("mVt" bytea, key text) AS $$
       WHERE "Geom" && ST_Transform(ST_TileEnvelope("Z", x, y), 4326)
   ) as tile WHERE geom IS NOT NULL) src
 $$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
+DO $do$ BEGIN
+    EXECUTE 'COMMENT ON FUNCTION "MixedCase"."function_Mixed_Name" (INT4, INT4, INT4) IS $tj$' || $$
+    {
+        "description": "a function source with MixedCase name",
+        "vector_layers": [
+            {
+                "id": "MixedCase.function_Mixed_Name",
+                "fields": {
+                    "TABLE": "",
+                    "Geom": ""
+                }
+            }
+        ]
+    }
+    $$::json || '$tj$';
+END $do$;

--- a/tests/fixtures/functions/function_zxy_query.sql
+++ b/tests/fixtures/functions/function_zxy_query.sql
@@ -16,3 +16,12 @@ BEGIN
   RETURN mvt;
 END
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+DO $do$ BEGIN
+    EXECUTE 'COMMENT ON FUNCTION public.function_zxy_query (INT4, INT4, INT4, JSON) IS $tj$' || $$
+    {
+      "description": null,
+      "foo": {"bar": "foo"}
+    }
+    $$::json || '$tj$';
+END $do$;


### PR DESCRIPTION
If a PostgreSQL function has an SQL comment, it will try to parse as JSON and use its values to override the auto-generated TileJSON.  It is recommended to use this form when creating comments to ensure valid JSON values.

```sql
DO $do$ BEGIN
    EXECUTE 'COMMENT ON FUNCTION YOUR_FUNCTION (ARG1_TYPE,ARG2_TYPE,..ARGN_TYPE) IS $tj$' || $$
    {
      "description": "description override",
      ...
    }
    $$::json || '$tj$';
END $do$;
```

Partially implements #822