### PR TITLE
Warn when source IDs are renamed

### DIFF
--- a/martin/src/utils/id_resolver.rs
+++ b/martin/src/utils/id_resolver.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -25,6 +26,22 @@ impl IdResolver {
     /// Only alphanumeric characters plus dashes/dots/underscores are allowed.
     #[must_use]
     pub fn resolve(&self, name: &str, unique_name: String) -> String {
+        let info = if name == unique_name {
+            None
+        } else {
+            Some(unique_name.clone())
+        };
+        let new_name = self.resolve_int(name, unique_name);
+        if name != new_name {
+            warn!("Source `{name}`{info} was renamed to `{new_name}`. Source IDs must be unique, cannot be reserved, and must contain alpha-numeric characters or `._-`",
+                 info = info.map_or(String::new(), |v| format!(" ({v})"))
+            );
+        }
+        new_name
+    }
+
+    #[must_use]
+    fn resolve_int(&self, name: &str, unique_name: String) -> String {
         // Ensure name has no prohibited characters like spaces, commas, slashes, or non-unicode etc.
         // Underscores, dashes, and dots are OK. All other characters will be replaced with dashes.
         let mut name = name.replace(

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -120,6 +120,7 @@ validate_log()
 
   # Older versions of PostGIS don't support the margin parameter, so we need to remove it from the log
   remove_line "$LOG_FILE" 'Margin parameter in ST_TileEnvelope is not supported'
+  remove_line "$LOG_FILE" 'Source IDs must be unique'
 
   # Make sure the log has just the expected warnings, remove them, and test that there are no other ones
   test_log_has_str "$LOG_FILE" 'WARN  martin::pg::table_source] Table public.table_source has no spatial index on column geom'


### PR DESCRIPTION
Make sure the users know when a source name was automatically modified, and why.

See also #826