### PR TITLE
Show tile boundaries in debug.html

### DIFF
--- a/tests/debug.html
+++ b/tests/debug.html
@@ -285,6 +285,7 @@
     });
 
     map.on('load', async function () {
+        map.showTileBoundaries = true;
         const catalog = await fetch('http://0.0.0.0:3000/catalog');
         const sources = (await catalog.json()).tiles;
         // Set up the corresponding toggle button for each layer.


### PR DESCRIPTION
Try to implement #845 
Based on the  [method](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#showtileboundaries:~:text=map.ts%3A3347-,showTileBoundaries) in doc:

* The map will render an outline around each tile and the tile ID
* The uncompressed file size of the first vector source is drawn in the top left corner of each tile, next to the tile ID. 
 
The second one, the file size is only for the first vector source, is this misleading? I mean, will the user think it's the  sum file size of all sources? @nyurik 