### PR TITLE
Log a warning if PG startup takes too long

### DIFF
--- a/martin/src/pg/config.rs
+++ b/martin/src/pg/config.rs
@@ -1,6 +1,10 @@
 use futures::future::try_join;
+use futures::pin_mut;
+use log::warn;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use tilejson::TileJSON;
+use tokio::time::timeout;
 
 use crate::config::{copy_unrecognized_config, UnrecognizedValues};
 use crate::pg::config_function::FuncInfoSources;
@@ -110,8 +114,18 @@ impl PgConfig {
 
     pub async fn resolve(&mut self, id_resolver: IdResolver) -> crate::Result<Sources> {
         let pg = PgBuilder::new(self, id_resolver).await?;
+
+        let instantiate_tables = pg.instantiate_tables();
+        pin_mut!(instantiate_tables);
+        if timeout(Duration::from_secs(5), &mut instantiate_tables)
+            .await
+            .is_err()
+        {
+            warn!("PostgreSQL table discovery is taking too long. Make sure your table geo columns have a GIS index, or use --disabling-bounds.");
+        }
+
         let ((mut tables, tbl_info), (funcs, func_info)) =
-            try_join(pg.instantiate_tables(), pg.instantiate_functions()).await?;
+            try_join(instantiate_tables, pg.instantiate_functions()).await?;
 
         self.tables = Some(tbl_info);
         self.functions = Some(func_info);

--- a/martin/src/pg/configurator.rs
+++ b/martin/src/pg/configurator.rs
@@ -63,6 +63,14 @@ impl PgBuilder {
         })
     }
 
+    pub fn disable_bounds(&self) -> bool {
+        self.disable_bounds
+    }
+
+    pub fn get_id(&self) -> &str {
+        self.pool.get_id()
+    }
+
     // FIXME: this function has gotten too long due to the new formatting rules, need to be refactored
     #[allow(clippy::too_many_lines)]
     pub async fn instantiate_tables(&self) -> Result<(Sources, TableInfoSources)> {


### PR DESCRIPTION
Adds a warning message using the suggested implementation in #810. Thanks for the recommended approach in the ticket! This one seemed straightforward enough that local tests would do, which I ran by adding a delay to `instantiate_tables`.

I'm getting a clippy error locally for having `Deserialize` on a type with methods using `unsafe`, but it looks like that might be a more significant update.

Fixes #810