### PR TITLE
mbtiles: Add `--apply-patch` to copy, rename apply-diff

### DIFF
--- a/martin-mbtiles/src/bin/main.rs
+++ b/martin-mbtiles/src/bin/main.rs
@@ -48,8 +48,8 @@ enum Commands {
     #[command(name = "copy")]
     Copy(MbtilesCopier),
     /// Apply diff file generated from 'copy' command
-    #[command(name = "apply-diff")]
-    ApplyDiff {
+    #[command(name = "apply-patch", alias = "apply-diff")]
+    ApplyPatch {
         /// MBTiles file to apply diff to
         src_file: PathBuf,
         /// Diff file
@@ -100,7 +100,7 @@ async fn main_int() -> anyhow::Result<()> {
         Commands::Copy(opts) => {
             opts.run().await?;
         }
-        Commands::ApplyDiff {
+        Commands::ApplyPatch {
             src_file,
             diff_file,
         } => {
@@ -150,7 +150,7 @@ mod tests {
     use clap::Parser;
     use martin_mbtiles::{CopyDuplicateMode, MbtilesCopier};
 
-    use crate::Commands::{ApplyDiff, Copy, MetaGetValue, MetaSetValue, Validate};
+    use crate::Commands::{ApplyPatch, Copy, MetaGetValue, MetaSetValue, Validate};
     use crate::{Args, IntegrityCheckType};
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
             Args::parse_from(["mbtiles", "apply-diff", "src_file", "diff_file"]),
             Args {
                 verbose: false,
-                command: ApplyDiff {
+                command: ApplyPatch {
                     src_file: PathBuf::from("src_file"),
                     diff_file: PathBuf::from("diff_file"),
                 }

--- a/martin-mbtiles/src/errors.rs
+++ b/martin-mbtiles/src/errors.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use martin_tile_utils::TileInfo;
 use sqlite_hashes::rusqlite;
 
+use crate::MbtType;
+
 #[derive(thiserror::Error, Debug)]
 pub enum MbtError {
     #[error("The source and destination MBTiles files are the same: {}", .0.display())]
@@ -55,6 +57,12 @@ pub enum MbtError {
 
     #[error("Unexpected duplicate tiles found when copying")]
     DuplicateValues,
+
+    #[error("Applying a patch while diffing is not supported")]
+    CannotApplyPatchAndDiff,
+
+    #[error("The MBTiles file {0} has data of type {1}, but the desired type was set to {2}")]
+    MismatchedTargetType(PathBuf, MbtType, MbtType),
 }
 
 pub type MbtResult<T> = Result<T, MbtError>;

--- a/martin-mbtiles/src/lib.rs
+++ b/martin-mbtiles/src/lib.rs
@@ -5,8 +5,8 @@ pub use errors::{MbtError, MbtResult};
 
 mod mbtiles;
 pub use mbtiles::{
-    calc_agg_tiles_hash, IntegrityCheckType, MbtType, Mbtiles, Metadata, AGG_TILES_HASH,
-    AGG_TILES_HASH_IN_DIFF,
+    calc_agg_tiles_hash, IntegrityCheckType, MbtType, MbtTypeCli, Mbtiles, Metadata,
+    AGG_TILES_HASH, AGG_TILES_HASH_IN_DIFF,
 };
 
 mod pool;

--- a/martin-mbtiles/src/patcher.rs
+++ b/martin-mbtiles/src/patcher.rs
@@ -31,7 +31,7 @@ pub async fn apply_patch(src_file: PathBuf, patch_file: PathBuf) -> MbtResult<()
         SELECT zoom_level, tile_column, tile_row, tile_data, tile_hash AS hash
         FROM patchDb.tiles_with_hash"
             }
-            Normalized => {
+            Normalized { .. } => {
                 "
         SELECT zoom_level, tile_column, tile_row, tile_data, map.tile_id AS hash
         FROM patchDb.map LEFT JOIN patchDb.images
@@ -58,7 +58,7 @@ pub async fn apply_patch(src_file: PathBuf, patch_file: PathBuf) -> MbtResult<()
     {select_from}"
             )],
         ),
-        Normalized => (
+        Normalized { .. } => (
             "map",
             vec![
                 format!(
@@ -93,7 +93,7 @@ pub async fn apply_patch(src_file: PathBuf, patch_file: PathBuf) -> MbtResult<()
     .execute(&mut conn)
     .await?;
 
-    if src_type == Normalized {
+    if src_type.is_normalized() {
         debug!("Removing unused tiles from the images table (normalized schema)");
         query("DELETE FROM images WHERE tile_id NOT IN (SELECT tile_id FROM map)")
             .execute(&mut conn)

--- a/martin-mbtiles/tests/mbtiles.rs
+++ b/martin-mbtiles/tests/mbtiles.rs
@@ -6,8 +6,10 @@ use ctor::ctor;
 use insta::{allow_duplicates, assert_display_snapshot};
 use log::info;
 use martin_mbtiles::IntegrityCheckType::Off;
-use martin_mbtiles::MbtType::{Flat, FlatWithHash, Normalized};
-use martin_mbtiles::{apply_patch, create_flat_tables, MbtResult, MbtType, Mbtiles, MbtilesCopier};
+use martin_mbtiles::MbtTypeCli::{Flat, FlatWithHash, Normalized};
+use martin_mbtiles::{
+    apply_patch, create_flat_tables, MbtResult, MbtTypeCli, Mbtiles, MbtilesCopier,
+};
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use rstest::{fixture, rstest};
 use serde::Serialize;
@@ -84,7 +86,7 @@ fn copier(src: &Mbtiles, dst: &Mbtiles) -> MbtilesCopier {
     MbtilesCopier::new(path(src), path(dst))
 }
 
-fn shorten(v: MbtType) -> &'static str {
+fn shorten(v: MbtTypeCli) -> &'static str {
     match v {
         Flat => "flat",
         FlatWithHash => "hash",
@@ -99,7 +101,7 @@ async fn open(file: &str) -> MbtResult<(Mbtiles, SqliteConnection)> {
 }
 
 macro_rules! open {
-    ($function:tt, $($arg:tt)*) => {
+    ($function:ident, $($arg:tt)*) => {
         open!(@"", $function, $($arg)*)
     };
     (@$extra:literal, $function:tt, $($arg:tt)*) => {{
@@ -110,18 +112,18 @@ macro_rules! open {
 
 /// Create a new SQLite file of given type without agg_tiles_hash metadata value
 macro_rules! new_file_no_hash {
-    ($function:tt, $dst_type:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {{
-        new_file!(@true, $function, $dst_type, $sql_meta, $sql_data, $($arg)*)
+    ($function:ident, $dst_type_cli:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {{
+        new_file!(@true, $function, $dst_type_cli, $sql_meta, $sql_data, $($arg)*)
     }};
 }
 
-/// Create a new SQLite file of type $dst_type with the given metadata and tiles
+/// Create a new SQLite file of type $dst_type_cli with the given metadata and tiles
 macro_rules! new_file {
-    ($function:tt, $dst_type:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {
-        new_file!(@false, $function, $dst_type, $sql_meta, $sql_data, $($arg)*)
+    ($function:ident, $dst_type_cli:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {
+        new_file!(@false, $function, $dst_type_cli, $sql_meta, $sql_data, $($arg)*)
     };
 
-    (@$skip_agg:expr, $function:tt, $dst_type:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {{
+    (@$skip_agg:expr, $function:tt, $dst_type_cli:expr, $sql_meta:expr, $sql_data:expr, $($arg:tt)*) => {{
         let (tmp_mbt, mut cn_tmp) = open!(@"temp", $function, $($arg)*);
         create_flat_tables(&mut cn_tmp).await.unwrap();
         cn_tmp.execute($sql_data).await.unwrap();
@@ -129,7 +131,7 @@ macro_rules! new_file {
 
         let (dst_mbt, cn_dst) = open!($function, $($arg)*);
         let mut opt = copier(&tmp_mbt, &dst_mbt);
-        opt.dst_type = Some($dst_type);
+        opt.dst_type_cli = Some($dst_type_cli);
         opt.skip_agg_tiles_hash = $skip_agg;
         opt.run().await.unwrap();
 
@@ -146,61 +148,84 @@ macro_rules! assert_snapshot {
     }};
 }
 
-macro_rules! assert_dump {
-    ($connection:expr, $($arg:tt)*) => {{
-        let dmp = dump($connection).await.unwrap();
-        assert_snapshot!(&dmp, $($arg)*);
-        dmp
-    }};
+#[derive(Default)]
+struct Databases(
+    HashMap<(&'static str, MbtTypeCli), (Vec<SqliteEntry>, Mbtiles, SqliteConnection)>,
+);
+
+impl Databases {
+    fn add(
+        &mut self,
+        name: &'static str,
+        typ: MbtTypeCli,
+        dump: Vec<SqliteEntry>,
+        mbtiles: Mbtiles,
+        conn: SqliteConnection,
+    ) {
+        self.0.insert((name, typ), (dump, mbtiles, conn));
+    }
+    fn dump(&self, name: &'static str, typ: MbtTypeCli) -> &Vec<SqliteEntry> {
+        &self.0.get(&(name, typ)).unwrap().0
+    }
+    fn mbtiles(&self, name: &'static str, typ: MbtTypeCli) -> &Mbtiles {
+        &self.0.get(&(name, typ)).unwrap().1
+    }
 }
 
-type Databases = HashMap<(&'static str, MbtType), Vec<SqliteEntry>>;
-
+/// Generate a set of databases for testing, and validate them against snapshot files.
+/// These dbs will be used by other tests to check against in various conditions.
 #[fixture]
 #[once]
 fn databases() -> Databases {
     futures::executor::block_on(async {
-        let mut result = HashMap::new();
+        let mut result = Databases::default();
         for &mbt_typ in &[Flat, FlatWithHash, Normalized] {
             let typ = shorten(mbt_typ);
-            let (raw_mbt, mut cn) = new_file_no_hash!(
+            let (raw_mbt, mut raw_cn) = new_file_no_hash!(
                 databases,
                 mbt_typ,
                 METADATA_V1,
                 TILES_V1,
                 "{typ}__v1-no-hash"
             );
-            let dmp = assert_dump!(&mut cn, "{typ}__v1-no-hash");
-            result.insert(("v1_no_hash", mbt_typ), dmp);
+            let dmp = dump(&mut raw_cn).await.unwrap();
+            assert_snapshot!(&dmp, "{typ}__v1-no-hash");
+            result.add("v1_no_hash", mbt_typ, dmp, raw_mbt, raw_cn);
 
             let (v1_mbt, mut v1_cn) = open!(databases, "{typ}__v1");
-            copier(&raw_mbt, &v1_mbt).run().await.unwrap();
-            let dmp = assert_dump!(&mut v1_cn, "{typ}__v1");
+            let raw_mbt = result.mbtiles("v1_no_hash", mbt_typ);
+            copier(raw_mbt, &v1_mbt).run().await.unwrap();
+            let dmp = dump(&mut v1_cn).await.unwrap();
+            assert_snapshot!(&dmp, "{typ}__v1");
             let hash = v1_mbt.validate(Off, false).await.unwrap();
             allow_duplicates! {
                 assert_display_snapshot!(hash, @"096A8399D486CF443A5DF0CEC1AD8BB2");
             }
-            result.insert(("v1", mbt_typ), dmp);
+            result.add("v1", mbt_typ, dmp, v1_mbt, v1_cn);
 
             let (v2_mbt, mut v2_cn) =
                 new_file!(databases, mbt_typ, METADATA_V2, TILES_V2, "{typ}__v2");
-            let dmp = assert_dump!(&mut v2_cn, "{typ}__v2");
+            let dmp = dump(&mut v2_cn).await.unwrap();
+            assert_snapshot!(&dmp, "{typ}__v2");
             let hash = v2_mbt.validate(Off, false).await.unwrap();
             allow_duplicates! {
                 assert_display_snapshot!(hash, @"FE0D3090E8B4E89F2C755C08E8D76BEA");
             }
-            result.insert(("v2", mbt_typ), dmp);
+            result.add("v2", mbt_typ, dmp, v2_mbt, v2_cn);
 
             let (dif_mbt, mut dif_cn) = open!(databases, "{typ}__dif");
-            let mut opt = copier(&v1_mbt, &dif_mbt);
-            opt.diff_with_file = Some(path(&v2_mbt));
+            let v1_mbt = result.mbtiles("v1", mbt_typ);
+            let mut opt = copier(v1_mbt, &dif_mbt);
+            let v2_mbt = result.mbtiles("v2", mbt_typ);
+            opt.diff_with_file = Some(path(v2_mbt));
             opt.run().await.unwrap();
-            let dmp = assert_dump!(&mut dif_cn, "{typ}__dif");
+            let dmp = dump(&mut dif_cn).await.unwrap();
+            assert_snapshot!(&dmp, "{typ}__dif");
             let hash = dif_mbt.validate(Off, false).await.unwrap();
             allow_duplicates! {
                 assert_display_snapshot!(hash, @"B86122579EDCDD4C51F3910894FCC1A1");
             }
-            result.insert(("dif", mbt_typ), dmp);
+            result.add("dif", mbt_typ, dmp, dif_mbt, dif_cn);
         }
         result
     })
@@ -210,8 +235,8 @@ fn databases() -> Databases {
 #[trace]
 #[actix_rt::test]
 async fn convert(
-    #[values(Flat, FlatWithHash, Normalized)] frm_type: MbtType,
-    #[values(Flat, FlatWithHash, Normalized)] dst_type: MbtType,
+    #[values(Flat, FlatWithHash, Normalized)] frm_type: MbtTypeCli,
+    #[values(Flat, FlatWithHash, Normalized)] dst_type: MbtTypeCli,
     #[notrace] databases: &Databases,
 ) -> MbtResult<()> {
     let (frm, to) = (shorten(frm_type), shorten(dst_type));
@@ -219,23 +244,23 @@ async fn convert(
     let (frm_mbt, _frm_cn) = new_file!(convert, frm_type, METADATA_V1, TILES_V1, "{frm}-{to}");
 
     let mut opt = copier(&frm_mbt, &mem);
-    opt.dst_type = Some(dst_type);
+    opt.dst_type_cli = Some(dst_type);
     let dmp = dump(&mut opt.run().await?).await?;
-    pretty_assert_eq!(databases.get(&("v1", dst_type)).unwrap(), &dmp);
+    pretty_assert_eq!(databases.dump("v1", dst_type), &dmp);
 
     let mut opt = copier(&frm_mbt, &mem);
-    opt.dst_type = Some(dst_type);
+    opt.dst_type_cli = Some(dst_type);
     opt.zoom_levels.insert(6);
     let z6only = dump(&mut opt.run().await?).await?;
     assert_snapshot!(z6only, "v1__z6__{frm}-{to}");
 
     let mut opt = copier(&frm_mbt, &mem);
-    opt.dst_type = Some(dst_type);
+    opt.dst_type_cli = Some(dst_type);
     opt.min_zoom = Some(6);
     pretty_assert_eq!(&z6only, &dump(&mut opt.run().await?).await?);
 
     let mut opt = copier(&frm_mbt, &mem);
-    opt.dst_type = Some(dst_type);
+    opt.dst_type_cli = Some(dst_type);
     opt.min_zoom = Some(6);
     opt.max_zoom = Some(6);
     pretty_assert_eq!(&z6only, &dump(&mut opt.run().await?).await?);
@@ -246,42 +271,45 @@ async fn convert(
 #[rstest]
 #[trace]
 #[actix_rt::test]
-async fn diff_apply(
-    #[values(Flat, FlatWithHash, Normalized)] v1_type: MbtType,
-    #[values(Flat, FlatWithHash, Normalized)] v2_type: MbtType,
-    #[values(None, Some(Flat), Some(FlatWithHash), Some(Normalized))] dif_type: Option<MbtType>,
+async fn diff_and_patch(
+    #[values(Flat, FlatWithHash, Normalized)] v1_type: MbtTypeCli,
+    #[values(Flat, FlatWithHash, Normalized)] v2_type: MbtTypeCli,
+    #[values(None, Some(Flat), Some(FlatWithHash), Some(Normalized))] dif_type: Option<MbtTypeCli>,
     #[notrace] databases: &Databases,
 ) -> MbtResult<()> {
     let (v1, v2) = (shorten(v1_type), shorten(v2_type));
     let dif = dif_type.map(shorten).unwrap_or("dflt");
     let prefix = format!("{v2}-{v1}={dif}");
 
-    let (v1_mbt, _v1_cn) = new_file! {diff_apply, v1_type, METADATA_V1, TILES_V1, "{prefix}__v1"};
-    let (v2_mbt, _v2_cn) = new_file! {diff_apply, v2_type, METADATA_V2, TILES_V2, "{prefix}__v2"};
-    let (dif_mbt, mut dif_cn) = open!(diff_apply, "{prefix}__dif");
+    let v1_mbt = databases.mbtiles("v1", v1_type);
+    let v2_mbt = databases.mbtiles("v2", v2_type);
+    let (dif_mbt, mut dif_cn) = open!(diff_and_patchdiff_and_patch, "{prefix}__dif");
 
     info!("TEST: Compare v1 with v2, and copy anything that's different (i.e. mathematically: v2-v1=diff)");
-    let mut opt = copier(&v1_mbt, &dif_mbt);
-    opt.diff_with_file = Some(path(&v2_mbt));
+    let mut opt = copier(v1_mbt, &dif_mbt);
+    opt.diff_with_file = Some(path(v2_mbt));
     if let Some(dif_type) = dif_type {
-        opt.dst_type = Some(dif_type);
+        opt.dst_type_cli = Some(dif_type);
     }
     opt.run().await?;
     pretty_assert_eq!(
         &dump(&mut dif_cn).await?,
-        databases
-            .get(&("dif", dif_type.unwrap_or(v1_type)))
-            .unwrap()
+        databases.dump("dif", dif_type.unwrap_or(v1_type))
     );
 
     for target_type in &[Flat, FlatWithHash, Normalized] {
         let trg = shorten(*target_type);
         let prefix = format!("{prefix}__to__{trg}");
-        let expected_v2 = databases.get(&("v2", *target_type)).unwrap();
+        let expected_v2 = databases.dump("v2", *target_type);
 
         info!("TEST: Applying the difference (v2-v1=diff) to v1, should get v2");
-        let (tar1_mbt, mut tar1_cn) =
-            new_file! {diff_apply, *target_type, METADATA_V1, TILES_V1, "{prefix}__v1"};
+        let (tar1_mbt, mut tar1_cn) = new_file!(
+            diff_and_patch,
+            *target_type,
+            METADATA_V1,
+            TILES_V1,
+            "{prefix}__v1"
+        );
         apply_patch(path(&tar1_mbt), path(&dif_mbt)).await?;
         let hash_v1 = tar1_mbt.validate(Off, false).await?;
         allow_duplicates! {
@@ -292,7 +320,7 @@ async fn diff_apply(
 
         info!("TEST: Applying the difference (v2-v1=diff) to v2, should not modify it");
         let (tar2_mbt, mut tar2_cn) =
-            new_file! {diff_apply, *target_type, METADATA_V2, TILES_V2, "{prefix}__v2"};
+            new_file! {diff_and_patch, *target_type, METADATA_V2, TILES_V2, "{prefix}__v2"};
         apply_patch(path(&tar2_mbt), path(&dif_mbt)).await?;
         let hash_v2 = tar2_mbt.validate(Off, false).await?;
         allow_duplicates! {
@@ -305,17 +333,56 @@ async fn diff_apply(
     Ok(())
 }
 
-// /// A simple tester to run specific values
-// #[actix_rt::test]
-// async fn test_one() {
-//     let dif_type = FlatWithHash;
-//     let src_type = Flat;
-//     let dst_type = Some(Normalized);
-//     let db = databases();
-//
-//     diff_apply(src_type, dif_type, dst_type, &db).await.unwrap();
-//     panic!()
-// }
+#[rstest]
+#[trace]
+#[actix_rt::test]
+async fn patch_on_copy(
+    #[values(Flat, FlatWithHash, Normalized)] v1_type: MbtTypeCli,
+    #[values(Flat, FlatWithHash, Normalized)] dif_type: MbtTypeCli,
+    #[values(None, Some(Flat), Some(FlatWithHash), Some(Normalized))] v2_type: Option<MbtTypeCli>,
+    #[notrace] databases: &Databases,
+) -> MbtResult<()> {
+    let (v1, dif) = (shorten(v1_type), shorten(dif_type));
+    let v2 = v2_type.map(shorten).unwrap_or("dflt");
+    let prefix = format!("{v1}+{dif}={v2}");
+
+    let v1_mbt = databases.mbtiles("v1", v1_type);
+    let dif_mbt = databases.mbtiles("dif", dif_type);
+    let (v2_mbt, mut v2_cn) = open!(patch_on_copy, "{prefix}__v2");
+
+    info!("TEST: Compare v1 with v2, and copy anything that's different (i.e. mathematically: v2-v1=diff)");
+    let mut opt = copier(v1_mbt, &v2_mbt);
+    opt.apply_patch = Some(path(dif_mbt));
+    if let Some(v2_type) = v2_type {
+        opt.dst_type_cli = Some(v2_type);
+    }
+    opt.run().await?;
+    pretty_assert_eq!(
+        &dump(&mut v2_cn).await?,
+        databases.dump("v2", v2_type.unwrap_or(v1_type))
+    );
+
+    Ok(())
+}
+
+/// A simple tester to run specific values
+#[actix_rt::test]
+#[ignore]
+async fn test_one() {
+    let src_type = FlatWithHash;
+    let dif_type = FlatWithHash;
+    // let dst_type = Some(FlatWithHash);
+    let dst_type = None;
+    let db = databases();
+
+    diff_and_patch(src_type, dif_type, dst_type, &db)
+        .await
+        .unwrap();
+    patch_on_copy(src_type, dif_type, dst_type, &db)
+        .await
+        .unwrap();
+    panic!("ALWAYS FAIL - this test is for debugging only, and should be disabled");
+}
 
 #[derive(Debug, sqlx::FromRow, Serialize, PartialEq)]
 struct SqliteEntry {

--- a/tests/expected/mbtiles/help.txt
+++ b/tests/expected/mbtiles/help.txt
@@ -3,13 +3,13 @@ A utility to work with .mbtiles file content
 Usage: mbtiles <COMMAND>
 
 Commands:
-  meta-all    Prints all values in the metadata table in a free-style, unstable YAML format
-  meta-get    Gets a single value from the MBTiles metadata table
-  meta-set    Sets a single value in the MBTiles' file metadata table or deletes it if no value
-  copy        Copy tiles from one mbtiles file to another
-  apply-diff  Apply diff file generated from 'copy' command
-  validate    Validate tile data if hash of tile data exists in file
-  help        Print this message or the help of the given subcommand(s)
+  meta-all     Prints all values in the metadata table in a free-style, unstable YAML format
+  meta-get     Gets a single value from the MBTiles metadata table
+  meta-set     Sets a single value in the MBTiles' file metadata table or deletes it if no value
+  copy         Copy tiles from one mbtiles file to another
+  apply-patch  Apply diff file generated from 'copy' command
+  validate     Validate tile data if hash of tile data exists in file
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help


### PR DESCRIPTION
* `mbtiles apply-diff` is now `apply-patch` (old name is still supported)
* `mbtiles copy` can now take `--apply-patch <file>` to apply the patch while copying from source to destination. This way, the source file will remain unmodified.