### PR TITLE
pg func discovery ignore sys schemas

### DIFF
--- a/justfile
+++ b/justfile
@@ -138,7 +138,7 @@ test-int: clean-test install-sqlx
     fi
 
 # Run integration tests and save its output as the new expected output
-bless: start clean-test bless-insta
+bless: restart clean-test bless-insta
     rm -rf tests/temp
     cargo test -p martin --features bless-tests
     tests/test.sh

--- a/martin/src/pg/scripts/query_available_function.sql
+++ b/martin/src/pg/scripts/query_available_function.sql
@@ -23,6 +23,7 @@ WITH
                jsonb_agg(data_type::text ORDER BY ordinal_position)                     as input_types
         FROM information_schema.parameters
         WHERE parameter_mode = 'IN'
+          AND specific_schema NOT IN ('pg_catalog', 'information_schema')
         GROUP BY specific_name),
     --
     outputs AS (
@@ -32,6 +33,7 @@ WITH
                jsonb_agg(parameter_name::text ORDER BY ordinal_position) as out_names
         FROM information_schema.parameters
         WHERE parameter_mode = 'OUT'
+          AND specific_schema NOT IN ('pg_catalog', 'information_schema')
         GROUP BY specific_name),
     --
     comments AS (


### PR DESCRIPTION
* Blessing results should destroy test db
* ignore `pg_catalog` and  `information_schema` schemas during functions autodiscovery