### PR TITLE
Implement sprite catalog reporting

### DIFF
--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -18,6 +18,7 @@ mod source;
 pub mod sprites;
 pub mod srv;
 mod utils;
+pub use utils::Xyz;
 
 #[cfg(test)]
 #[path = "utils/test_utils.rs"]
@@ -27,8 +28,8 @@ mod test_utils;
 // Must make it accessible as carte::Env from both places when testing.
 #[cfg(test)]
 pub use crate::args::Env;
-pub use crate::config::{read_config, Config};
-pub use crate::source::{Source, Sources, Xyz};
+pub use crate::config::{read_config, Config, ServerState};
+pub use crate::source::Source;
 pub use crate::utils::{
     decode_brotli, decode_gzip, BoolOrObject, Error, IdResolver, OneOrMany, Result,
 };

--- a/martin/src/mbtiles/mod.rs
+++ b/martin/src/mbtiles/mod.rs
@@ -12,7 +12,6 @@ use tilejson::TileJSON;
 use crate::file_config::FileError;
 use crate::file_config::FileError::{AquireConnError, InvalidMetadata, IoError};
 use crate::source::{Tile, UrlQuery};
-use crate::utils::is_valid_zoom;
 use crate::{Error, Source, Xyz};
 
 #[derive(Clone)]
@@ -66,8 +65,12 @@ impl MbtSource {
 
 #[async_trait]
 impl Source for MbtSource {
-    fn get_tilejson(&self) -> TileJSON {
-        self.tilejson.clone()
+    fn get_id(&self) -> &str {
+        &self.id
+    }
+
+    fn get_tilejson(&self) -> &TileJSON {
+        &self.tilejson
     }
 
     fn get_tile_info(&self) -> TileInfo {
@@ -76,10 +79,6 @@ impl Source for MbtSource {
 
     fn clone_source(&self) -> Box<dyn Source> {
         Box::new(self.clone())
-    }
-
-    fn is_valid_zoom(&self, zoom: u8) -> bool {
-        is_valid_zoom(zoom, self.tilejson.minzoom, self.tilejson.maxzoom)
     }
 
     fn support_url_query(&self) -> bool {

--- a/martin/src/pg/config.rs
+++ b/martin/src/pg/config.rs
@@ -10,7 +10,7 @@ use crate::pg::config_function::FuncInfoSources;
 use crate::pg::config_table::TableInfoSources;
 use crate::pg::configurator::PgBuilder;
 use crate::pg::Result;
-use crate::source::Sources;
+use crate::source::TileInfoSources;
 use crate::utils::{on_slow, sorted_opt_map, BoolOrObject, IdResolver, OneOrMany};
 
 pub trait PgInfo {
@@ -111,7 +111,7 @@ impl PgConfig {
         Ok(res)
     }
 
-    pub async fn resolve(&mut self, id_resolver: IdResolver) -> crate::Result<Sources> {
+    pub async fn resolve(&mut self, id_resolver: IdResolver) -> crate::Result<TileInfoSources> {
         let pg = PgBuilder::new(self, id_resolver).await?;
         let inst_tables = on_slow(pg.instantiate_tables(), Duration::from_secs(5), || {
             if pg.disable_bounds() {

--- a/martin/src/pg/pg_source.rs
+++ b/martin/src/pg/pg_source.rs
@@ -11,8 +11,8 @@ use tilejson::TileJSON;
 use crate::pg::pool::PgPool;
 use crate::pg::utils::query_to_json;
 use crate::pg::PgError::{GetTileError, GetTileWithQueryError, PrepareQueryError};
-use crate::source::{Source, Tile, UrlQuery, Xyz};
-use crate::utils::{is_valid_zoom, Result};
+use crate::source::{Source, Tile, UrlQuery};
+use crate::{Result, Xyz};
 
 #[derive(Clone, Debug)]
 pub struct PgSource {
@@ -36,8 +36,12 @@ impl PgSource {
 
 #[async_trait]
 impl Source for PgSource {
-    fn get_tilejson(&self) -> TileJSON {
-        self.tilejson.clone()
+    fn get_id(&self) -> &str {
+        &self.id
+    }
+
+    fn get_tilejson(&self) -> &TileJSON {
+        &self.tilejson
     }
 
     fn get_tile_info(&self) -> TileInfo {
@@ -46,10 +50,6 @@ impl Source for PgSource {
 
     fn clone_source(&self) -> Box<dyn Source> {
         Box::new(self.clone())
-    }
-
-    fn is_valid_zoom(&self, zoom: u8) -> bool {
-        is_valid_zoom(zoom, self.tilejson.minzoom, self.tilejson.maxzoom)
     }
 
     fn support_url_query(&self) -> bool {

--- a/martin/src/pmtiles/mod.rs
+++ b/martin/src/pmtiles/mod.rs
@@ -13,9 +13,8 @@ use tilejson::TileJSON;
 
 use crate::file_config::FileError;
 use crate::file_config::FileError::{InvalidMetadata, IoError};
-use crate::source::{Source, Tile, UrlQuery, Xyz};
-use crate::utils::is_valid_zoom;
-use crate::Error;
+use crate::source::{Source, Tile, UrlQuery};
+use crate::{Error, Xyz};
 
 #[derive(Clone)]
 pub struct PmtSource {
@@ -114,8 +113,12 @@ impl PmtSource {
 
 #[async_trait]
 impl Source for PmtSource {
-    fn get_tilejson(&self) -> TileJSON {
-        self.tilejson.clone()
+    fn get_id(&self) -> &str {
+        &self.id
+    }
+
+    fn get_tilejson(&self) -> &TileJSON {
+        &self.tilejson
     }
 
     fn get_tile_info(&self) -> TileInfo {
@@ -124,10 +127,6 @@ impl Source for PmtSource {
 
     fn clone_source(&self) -> Box<dyn Source> {
         Box::new(self.clone())
-    }
-
-    fn is_valid_zoom(&self, zoom: u8) -> bool {
-        is_valid_zoom(zoom, self.tilejson.minzoom, self.tilejson.maxzoom)
     }
 
     fn support_url_query(&self) -> bool {

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -4,4 +4,4 @@ mod server;
 pub use config::{SrvConfig, KEEP_ALIVE_DEFAULT, LISTEN_ADDRESSES_DEFAULT};
 pub use server::{new_server, router, RESERVED_KEYWORDS};
 
-pub use crate::source::SourceEntry;
+pub use crate::source::CatalogSourceEntry;

--- a/martin/src/utils/mod.rs
+++ b/martin/src/utils/mod.rs
@@ -2,8 +2,10 @@ mod error;
 mod id_resolver;
 mod one_or_many;
 mod utilities;
+mod xyz;
 
 pub use error::*;
 pub use id_resolver::IdResolver;
 pub use one_or_many::OneOrMany;
 pub use utilities::*;
+pub use xyz::Xyz;

--- a/martin/src/utils/utilities.rs
+++ b/martin/src/utils/utilities.rs
@@ -9,12 +9,6 @@ use futures::pin_mut;
 use serde::{Deserialize, Serialize, Serializer};
 use tokio::time::timeout;
 
-#[must_use]
-pub fn is_valid_zoom(zoom: u8, minzoom: Option<u8>, maxzoom: Option<u8>) -> bool {
-    minzoom.map_or(true, |minzoom| zoom >= minzoom)
-        && maxzoom.map_or(true, |maxzoom| zoom <= maxzoom)
-}
-
 /// A serde helper to store a boolean as an object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/martin/src/utils/xyz.rs
+++ b/martin/src/utils/xyz.rs
@@ -1,0 +1,18 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Xyz {
+    pub z: u8,
+    pub x: u32,
+    pub y: u32,
+}
+
+impl Display for Xyz {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "{}/{}/{}", self.z, self.x, self.y)
+        } else {
+            write!(f, "{},{},{}", self.z, self.x, self.y)
+        }
+    }
+}

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -162,5 +162,6 @@
       "name": "Major cities from Natural Earth data",
       "description": "Major cities from Natural Earth data"
     }
-  }
+  },
+  "sprites": {}
 }

--- a/tests/expected/configured/catalog_cfg.json
+++ b/tests/expected/configured/catalog_cfg.json
@@ -39,5 +39,19 @@
       "content_type": "application/x-protobuf",
       "description": "public.table_source.geom"
     }
+  },
+  "sprites": {
+    "mysrc": {
+      "images": [
+        "bicycle"
+      ]
+    },
+    "src1": {
+      "images": [
+        "another_bicycle",
+        "bear",
+        "sub/circle"
+      ]
+    }
   }
 }


### PR DESCRIPTION
The `/catalog` now shows available sprites, which also paves way for the future font support.

Lots of small refactorings to streamline tile source management.  Now each tile source can produce its own catalog entry, making the whole thing much simpler.

Fixes #949 