### PR TITLE
Simplify conf parsing, separate func & tbl configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,9 +2842,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",

--- a/martin/src/args/pg.rs
+++ b/martin/src/args/pg.rs
@@ -55,7 +55,7 @@ impl PgArgs {
             .collect();
 
         match results.len() {
-            0 => OptOneMany::NoValue,
+            0 => OptOneMany::NoVals,
             1 => OptOneMany::One(results.into_iter().next().unwrap()),
             _ => OptOneMany::Many(results),
         }

--- a/martin/src/args/pg.rs
+++ b/martin/src/args/pg.rs
@@ -4,7 +4,7 @@ use crate::args::connections::Arguments;
 use crate::args::connections::State::{Ignore, Take};
 use crate::args::environment::Env;
 use crate::pg::{PgConfig, PgSslCerts, POOL_SIZE_DEFAULT};
-use crate::utils::OneOrMany;
+use crate::utils::{OptBoolObj, OptOneMany};
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
 #[command(about, version)]
@@ -30,7 +30,7 @@ impl PgArgs {
         self,
         cli_strings: &mut Arguments,
         env: &impl Env<'a>,
-    ) -> Option<OneOrMany<PgConfig>> {
+    ) -> OptOneMany<PgConfig> {
         let connections = Self::extract_conn_strings(cli_strings, env);
         let default_srid = self.get_default_srid(env);
         let certs = self.get_certs(env);
@@ -48,20 +48,20 @@ impl PgArgs {
                 },
                 max_feature_count: self.max_feature_count,
                 pool_size: self.pool_size,
-                auto_publish: None,
+                auto_publish: OptBoolObj::NoValue,
                 tables: None,
                 functions: None,
             })
             .collect();
 
         match results.len() {
-            0 => None,
-            1 => Some(OneOrMany::One(results.into_iter().next().unwrap())),
-            _ => Some(OneOrMany::Many(results)),
+            0 => OptOneMany::NoValue,
+            1 => OptOneMany::One(results.into_iter().next().unwrap()),
+            _ => OptOneMany::Many(results),
         }
     }
 
-    pub fn override_config<'a>(self, pg_config: &mut OneOrMany<PgConfig>, env: &impl Env<'a>) {
+    pub fn override_config<'a>(self, pg_config: &mut OptOneMany<PgConfig>, env: &impl Env<'a>) {
         if self.default_srid.is_some() {
             info!("Overriding configured default SRID to {} on all Postgres connections because of a CLI parameter", self.default_srid.unwrap());
             pg_config.iter_mut().for_each(|c| {
@@ -224,10 +224,10 @@ mod tests {
         let config = PgArgs::default().into_config(&mut args, &FauxEnv::default());
         assert_eq!(
             config,
-            Some(OneOrMany::One(PgConfig {
+            OptOneMany::One(PgConfig {
                 connection_string: some("postgres://localhost:5432"),
                 ..Default::default()
-            }))
+            })
         );
         assert!(args.check().is_ok());
     }
@@ -248,7 +248,7 @@ mod tests {
         let config = PgArgs::default().into_config(&mut args, &env);
         assert_eq!(
             config,
-            Some(OneOrMany::One(PgConfig {
+            OptOneMany::One(PgConfig {
                 connection_string: some("postgres://localhost:5432"),
                 default_srid: Some(10),
                 ssl_certificates: PgSslCerts {
@@ -256,7 +256,7 @@ mod tests {
                     ..Default::default()
                 },
                 ..Default::default()
-            }))
+            })
         );
         assert!(args.check().is_ok());
     }
@@ -282,7 +282,7 @@ mod tests {
         let config = pg_args.into_config(&mut args, &env);
         assert_eq!(
             config,
-            Some(OneOrMany::One(PgConfig {
+            OptOneMany::One(PgConfig {
                 connection_string: some("postgres://localhost:5432"),
                 default_srid: Some(20),
                 ssl_certificates: PgSslCerts {
@@ -291,7 +291,7 @@ mod tests {
                     ssl_root_cert: Some(PathBuf::from("root")),
                 },
                 ..Default::default()
-            }))
+            })
         );
         assert!(args.check().is_ok());
     }

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::args::Env;
 pub use crate::config::{read_config, Config, ServerState};
 pub use crate::source::Source;
 pub use crate::utils::{
-    decode_brotli, decode_gzip, BoolOrObject, Error, IdResolver, OneOrMany, Result,
+    decode_brotli, decode_gzip, Error, IdResolver, OptBoolObj, OptOneMany, Result,
 };
 
 // Ensure README.md contains valid code

--- a/martin/src/pg/config.rs
+++ b/martin/src/pg/config.rs
@@ -63,13 +63,13 @@ pub struct PgCfgPublish {
     #[serde(alias = "from_schema")]
     pub from_schemas: OptOneMany<String>,
     #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
-    pub tables: OptBoolObj<PgCfgPublishType>,
+    pub tables: OptBoolObj<PgCfgPublishTables>,
     #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
-    pub functions: OptBoolObj<PgCfgPublishType>,
+    pub functions: OptBoolObj<PgCfgPublishFuncs>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct PgCfgPublishType {
+pub struct PgCfgPublishTables {
     #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
     #[serde(alias = "from_schema")]
     pub from_schemas: OptOneMany<String>,
@@ -88,6 +88,16 @@ pub struct PgCfgPublishType {
     pub buffer: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PgCfgPublishFuncs {
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    #[serde(alias = "from_schema")]
+    pub from_schemas: OptOneMany<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "id_format")]
+    pub source_id_format: Option<String>,
 }
 
 impl PgConfig {

--- a/martin/src/pg/mod.rs
+++ b/martin/src/pg/mod.rs
@@ -16,5 +16,3 @@ pub use config_table::TableInfo;
 pub use errors::{PgError, Result};
 pub use function_source::query_available_function;
 pub use pool::{PgPool, POOL_SIZE_DEFAULT};
-
-pub use crate::utils::BoolOrObject;

--- a/martin/src/pg/mod.rs
+++ b/martin/src/pg/mod.rs
@@ -10,7 +10,7 @@ mod table_source;
 mod tls;
 mod utils;
 
-pub use config::{PgCfgPublish, PgCfgPublishType, PgConfig, PgSslCerts};
+pub use config::{PgCfgPublish, PgCfgPublishFuncs, PgCfgPublishTables, PgConfig, PgSslCerts};
 pub use config_function::FunctionInfo;
 pub use config_table::TableInfo;
 pub use errors::{PgError, Result};

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -55,12 +55,11 @@ pub type SpriteCatalog = BTreeMap<String, CatalogSpriteEntry>;
 pub struct SpriteSources(HashMap<String, SpriteSource>);
 
 impl SpriteSources {
-    pub fn resolve(config: &mut Option<FileConfigEnum>) -> Result<Self, FileError> {
-        let Some(cfg) = config else {
+    pub fn resolve(config: &mut FileConfigEnum) -> Result<Self, FileError> {
+        let Some(cfg) = config.extract_file_config() else {
             return Ok(Self::default());
         };
 
-        let cfg = cfg.extract_file_config();
         let mut results = Self::default();
         let mut directories = Vec::new();
         let mut configs = HashMap::new();
@@ -72,18 +71,16 @@ impl SpriteSources {
             }
         };
 
-        if let Some(paths) = cfg.paths {
-            for path in paths {
-                let Some(name) = path.file_name() else {
-                    warn!(
-                        "Ignoring sprite source with no name from {}",
-                        path.display()
-                    );
-                    continue;
-                };
-                directories.push(path.clone());
-                results.add_source(name.to_string_lossy().to_string(), path);
-            }
+        for path in cfg.paths {
+            let Some(name) = path.file_name() else {
+                warn!(
+                    "Ignoring sprite source with no name from {}",
+                    path.display()
+                );
+                continue;
+            };
+            directories.push(path.clone());
+            results.add_source(name.to_string_lossy().to_string(), path);
         }
 
         *config = FileConfigEnum::new_extended(directories, configs, cfg.unrecognized);

--- a/martin/src/utils/cfg_containers.rs
+++ b/martin/src/utils/cfg_containers.rs
@@ -2,27 +2,47 @@ use std::vec::IntoIter;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// A serde helper to store a boolean as an object.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum OneOrMany<T> {
+pub enum OptBoolObj<T> {
+    #[default]
+    #[serde(skip)]
+    NoValue,
+    Bool(bool),
+    Object(T),
+}
+
+impl<T> OptBoolObj<T> {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::NoValue)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OptOneMany<T> {
+    #[default]
+    NoValue,
     One(T),
     Many(Vec<T>),
 }
 
-impl<T> IntoIterator for OneOrMany<T> {
+impl<T> IntoIterator for OptOneMany<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
+            Self::NoValue => Vec::new().into_iter(),
             Self::One(v) => vec![v].into_iter(),
             Self::Many(v) => v.into_iter(),
         }
     }
 }
 
-impl<T: Clone> OneOrMany<T> {
-    pub fn new_opt<I: IntoIterator<Item = T>>(iter: I) -> Option<Self> {
+impl<T> OptOneMany<T> {
+    pub fn new<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut iter = iter.into_iter();
         match (iter.next(), iter.next()) {
             (Some(first), Some(second)) => {
@@ -30,15 +50,20 @@ impl<T: Clone> OneOrMany<T> {
                 vec.push(first);
                 vec.push(second);
                 vec.extend(iter);
-                Some(Self::Many(vec))
+                Self::Many(vec)
             }
-            (Some(first), None) => Some(Self::One(first)),
-            (None, _) => None,
+            (Some(first), None) => Self::One(first),
+            (None, _) => Self::NoValue,
         }
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::NoValue)
     }
 
     pub fn is_empty(&self) -> bool {
         match self {
+            Self::NoValue => true,
             Self::One(_) => false,
             Self::Many(v) => v.is_empty(),
         }
@@ -46,20 +71,23 @@ impl<T: Clone> OneOrMany<T> {
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         match self {
-            OneOrMany::Many(v) => v.iter(),
-            OneOrMany::One(v) => std::slice::from_ref(v).iter(),
+            Self::NoValue => [].iter(),
+            Self::One(v) => std::slice::from_ref(v).iter(),
+            Self::Many(v) => v.iter(),
         }
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         match self {
-            Self::Many(v) => v.iter_mut(),
+            Self::NoValue => [].iter_mut(),
             Self::One(v) => std::slice::from_mut(v).iter_mut(),
+            Self::Many(v) => v.iter_mut(),
         }
     }
 
     pub fn as_slice(&self) -> &[T] {
         match self {
+            Self::NoValue => &[],
             Self::One(item) => std::slice::from_ref(item),
             Self::Many(v) => v.as_slice(),
         }
@@ -69,16 +97,16 @@ impl<T: Clone> OneOrMany<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::OneOrMany::{Many, One};
+    use crate::OptOneMany::{Many, NoValue, One};
 
     #[test]
     fn test_one_or_many() {
         let mut one = One(1);
         let mut many = Many(vec![1, 2, 3]);
 
-        assert_eq!(OneOrMany::new_opt(vec![1, 2, 3]), Some(Many(vec![1, 2, 3])));
-        assert_eq!(OneOrMany::new_opt(vec![1]), Some(One(1)));
-        assert_eq!(OneOrMany::new_opt(Vec::<i32>::new()), None);
+        assert_eq!(OptOneMany::new(vec![1, 2, 3]), Many(vec![1, 2, 3]));
+        assert_eq!(OptOneMany::new(vec![1]), One(1));
+        assert_eq!(OptOneMany::new(Vec::<i32>::new()), NoValue);
 
         assert_eq!(one.iter_mut().collect::<Vec<_>>(), vec![&1]);
         assert_eq!(many.iter_mut().collect::<Vec<_>>(), vec![&1, &2, &3]);

--- a/martin/src/utils/mod.rs
+++ b/martin/src/utils/mod.rs
@@ -1,11 +1,11 @@
+mod cfg_containers;
 mod error;
 mod id_resolver;
-mod one_or_many;
 mod utilities;
 mod xyz;
 
+pub use cfg_containers::{OptBoolObj, OptOneMany};
 pub use error::*;
 pub use id_resolver::IdResolver;
-pub use one_or_many::OneOrMany;
 pub use utilities::*;
 pub use xyz::Xyz;

--- a/martin/src/utils/utilities.rs
+++ b/martin/src/utils/utilities.rs
@@ -23,6 +23,21 @@ pub fn sorted_btree_map<K: Serialize + Ord, V>(value: &HashMap<K, V>) -> BTreeMa
     BTreeMap::from_iter(items)
 }
 
+#[cfg(test)]
+pub fn sorted_opt_set<S: Serializer>(
+    value: &Option<std::collections::HashSet<String>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    value
+        .as_ref()
+        .map(|v| {
+            let mut v: Vec<_> = v.iter().collect();
+            v.sort();
+            v
+        })
+        .serialize(serializer)
+}
+
 pub fn decode_gzip(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut decoder = GzDecoder::new(data);
     let mut decompressed = Vec::new();

--- a/martin/src/utils/utilities.rs
+++ b/martin/src/utils/utilities.rs
@@ -6,16 +6,8 @@ use std::time::Duration;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use futures::pin_mut;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Serialize, Serializer};
 use tokio::time::timeout;
-
-/// A serde helper to store a boolean as an object.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BoolOrObject<T> {
-    Bool(bool),
-    Object(T),
-}
 
 /// Sort an optional hashmap by key, case-insensitive first, then case-sensitive
 pub fn sorted_opt_map<S: Serializer, T: Serialize>(

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -4,7 +4,7 @@ use actix_web::test::{call_and_read_body_json, call_service, read_body, TestRequ
 use ctor::ctor;
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
-use martin::OneOrMany;
+use martin::OptOneMany;
 use tilejson::TileJSON;
 
 pub mod utils;
@@ -1092,7 +1092,7 @@ tables:
     )
     .await;
 
-    let OneOrMany::One(cfg) = cfg.postgres.unwrap() else {
+    let OptOneMany::One(cfg) = cfg.postgres else {
         panic!()
     };
     for (name, _) in cfg.tables.unwrap_or_default() {

--- a/martin/tests/utils/pg_utils.rs
+++ b/martin/tests/utils/pg_utils.rs
@@ -34,8 +34,6 @@ pub fn table<'a>(mock: &'a MockSource, name: &str) -> &'a TableInfo {
     let (_, config) = mock;
     let vals: Vec<&TableInfo> = config
         .postgres
-        .as_ref()
-        .unwrap()
         .iter()
         .flat_map(|v| v.tables.iter().map(|vv| vv.get(name)))
         .flatten()


### PR DESCRIPTION
* Simplify code by adding `None` to the enums we use for configuration
* Separate postgres auto-publish configuration into table and function structs