### PR TITLE
Better error reporting for config and other params

### DIFF
--- a/martin/src/args/root.rs
+++ b/martin/src/args/root.rs
@@ -55,7 +55,7 @@ impl Args {
             warn!("The WATCH_MODE env variable is no longer supported, and will be ignored");
         }
         if self.meta.config.is_some() && !self.meta.connection.is_empty() {
-            return Err(Error::ConfigAndConnectionsError);
+            return Err(Error::ConfigAndConnectionsError(self.meta.connection));
         }
 
         self.srv.merge_into_config(&mut config.srv);
@@ -174,7 +174,7 @@ mod tests {
         let env = FauxEnv::default();
         let mut config = Config::default();
         let err = args.merge_into_config(&mut config, &env).unwrap_err();
-        assert!(matches!(err, crate::Error::ConfigAndConnectionsError));
+        assert!(matches!(err, crate::Error::ConfigAndConnectionsError(..)));
     }
 
     #[test]

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::io;
 use std::path::PathBuf;
 
@@ -7,10 +8,30 @@ use crate::sprites::SpriteError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+fn elide_vec(vec: &[String], max_items: usize, max_len: usize) -> String {
+    let mut s = String::new();
+    for (i, v) in vec.iter().enumerate() {
+        if i > max_items {
+            let _ = write!(s, " and {} more", vec.len() - i);
+            break;
+        }
+        if i > 0 {
+            s.push(' ');
+        }
+        if v.len() > max_len {
+            s.push_str(&v[..max_len]);
+            s.push('…');
+        } else {
+            s.push_str(v);
+        }
+    }
+    s
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("The --config and the connection parameters cannot be used together")]
-    ConfigAndConnectionsError,
+    #[error("The --config and the connection parameters cannot be used together. Please remove unsupported parameters '{}'", elide_vec(.0, 3, 15))]
+    ConfigAndConnectionsError(Vec<String>),
 
     #[error("Unable to bind to {1}: {0}")]
     BindingError(io::Error, String),


### PR DESCRIPTION
This prints an extended error message, explaining to the user what params must be removed.

Fixes #938