### PR TITLE
fix: cargo publish warning about README

### DIFF
--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-readme.workspace = true
+readme = "README.md"
 homepage.workspace = true
 
 [package.metadata.deb]


### PR DESCRIPTION
**Description**
- When running `cargo publish -p martin`, the following warning was displayed. 
```shell
readme `../README.md` appears to be a path outside of the package, but there is already a file named `README.md` in the root of the package. The archived crate will contain the copy in the root of the package. Update the readme to point to the path relative to the root of the package to remove this warning.
```
- Till the time of this PR, the issue was probably a bug with Cargo, in case of a project with a symlink readme linking to the workspace readme. 

**Changes Made**
- To avoid the warning until the issue is fixed with Cargo, the solution is by manually setting `readme = "README.md"` instead of `readme.workspace = true`.

**Testing**
- [x] I have tried running `cargo publish -p martin` for a few seconds, and hit `Ctrl+C` the moment it starts compiling. The above readme warning is no longer shown.

Closes: #914 