### PR TITLE
Include readme as docs for all crates

### DIFF
--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 // This code was partially adapted from https://github.com/maplibre/mbtileserver-rs
 // project originally written by Kaveh Karimi and licensed under MIT/Apache-2.0
 

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 // Bounds struct derives PartialEq, but not Eq,

--- a/mbtiles/src/lib.rs
+++ b/mbtiles/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![allow(clippy::missing_errors_doc)]
 
 mod errors;


### PR DESCRIPTION
This adds documentation in the https://docs.rs site.