### PR TITLE
Fix `mbtiles copy --dst-type` arg name, better err msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,7 @@ version = "0.1.4"
 
 [[package]]
 name = "mbtiles"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/mbtiles/src/copier.rs
+++ b/mbtiles/src/copier.rs
@@ -36,7 +36,10 @@ pub struct MbtilesCopier {
     /// MBTiles file to write to
     pub dst_file: PathBuf,
     /// Output format of the destination file, ignored if the file exists. If not specified, defaults to the type of source
-    #[cfg_attr(feature = "cli", arg(long = "dst_type", value_enum))]
+    #[cfg_attr(
+        feature = "cli",
+        arg(long = "dst-type", alias = "dst_type", value_enum)
+    )]
     pub dst_type_cli: Option<MbtTypeCli>,
     /// Destination type with options
     #[cfg_attr(feature = "cli", arg(skip))]

--- a/mbtiles/src/errors.rs
+++ b/mbtiles/src/errors.rs
@@ -28,7 +28,7 @@ pub enum MbtError {
     #[error("Invalid data format for MBTile file {0}")]
     InvalidDataFormat(String),
 
-    #[error("Integrity check failed for MBTile file {0} for the following reasons: \n {1:?}")]
+    #[error("Integrity check failed for MBTile file {0} for the following reasons:\n    {1:?}")]
     FailedIntegrityCheck(String, Vec<String>),
 
     #[error("At least one tile has mismatching hash: stored value is `{1}` != computed value `{2}` in MBTile file {0}")]
@@ -37,7 +37,9 @@ pub enum MbtError {
     #[error("Computed aggregate tiles hash {0} does not match tile data in metadata {1} for MBTile file {2}")]
     AggHashMismatch(String, String, String),
 
-    #[error("Metadata value `agg_tiles_hash` is not set in MBTiles file {0}")]
+    #[error(
+        "Metadata value `agg_tiles_hash` is not set in MBTiles file {0}\n    Use `mbtiles validate --update-agg-tiles-hash {0}` to fix this."
+    )]
     AggHashValueNotFound(String),
 
     #[error(r#"Filename "{0}" passed to SQLite must be valid UTF-8"#)]


### PR DESCRIPTION
* Fix `mbtiles copy --dst-type` to use a `-` instead of `_`
* Better error message for `agg_tiles_hash`