### PR TITLE
Add cargo binstall support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,34 +546,34 @@ jobs:
 
           cd aarch64-apple-darwin
           chmod +x martin mbtiles
-          tar czvf ../files/martin-Darwin-aarch64.tar.gz martin mbtiles
+          tar czvf ../files/martin-aarch64-apple-darwin.tar.gz martin mbtiles
           cd ..
           
           cd x86_64-apple-darwin
           chmod +x martin mbtiles
-          tar czvf ../files/martin-Darwin-x86_64.tar.gz martin mbtiles
+          tar czvf ../files/martin-x86_64-apple-darwin.tar.gz martin mbtiles
           cd ..
           
           cd x86_64-unknown-linux-gnu
           chmod +x martin mbtiles
-          tar czvf ../files/martin-Linux-x86_64.tar.gz martin mbtiles
+          tar czvf ../files/martin-x86_64-unknown-linux-gnu.tar.gz martin mbtiles
           cd ..
                     
           cd aarch64-unknown-linux-musl
           chmod +x martin mbtiles
-          tar czvf ../files/martin-Linux-aarch64-musl.tar.gz martin mbtiles
+          tar czvf ../files/martin-aarch64-unknown-linux-musl.tar.gz martin mbtiles
           cd ..
         
           cd x86_64-unknown-linux-musl
           chmod +x martin mbtiles
-          tar czvf ../files/martin-Linux-x86_64-musl.tar.gz martin mbtiles
+          tar czvf ../files/martin-x86_64-unknown-linux-musl.tar.gz martin mbtiles
           cd ..
           
           #
           # Special case for Windows
           #
           cd x86_64-pc-windows-msvc
-          7z a ../files/martin-Windows-x86_64.zip martin.exe mbtiles.exe
+          7z a ../files/martin-x86_64-pc-windows-msvc.zip martin.exe mbtiles.exe
           cd ..
           
           #
@@ -595,10 +595,10 @@ jobs:
           
           cat << EOF > homebrew_config.yaml
           version: "$MARTIN_VERSION"
-          macos_arm_sha256: "$(shasum -a 256 files/martin-Darwin-aarch64.tar.gz | cut -d' ' -f1)"
-          macos_intel_sha256: "$(shasum -a 256 files/martin-Darwin-x86_64.tar.gz | cut -d' ' -f1)"
-          linux_arm_sha256: "$(shasum -a 256 files/martin-Linux-aarch64-musl.tar.gz | cut -d' ' -f1)"
-          linux_intel_sha256: "$(shasum -a 256 files/martin-Linux-x86_64-musl.tar.gz | cut -d' ' -f1)"
+          macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF
 
       - name: Save Homebrew Config

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 | macOS    | [.tar.gz][rl-macos-x64]                                                                          | [.tar.gz][rl-macos-a64]             |
 | Windows  | [.zip][rl-win64-zip]                                                                             |                                     |
 
-[rl-linux-x64]: https://github.com/maplibre/martin/releases/latest/download/martin-Linux-x86_64.tar.gz
-[rl-linux-x64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-Linux-x86_64-musl.tar.gz
+[rl-linux-x64]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-gnu.tar.gz
+[rl-linux-x64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-musl.tar.gz
 [rl-linux-x64-deb]: https://github.com/maplibre/martin/releases/latest/download/martin-Debian-x86_64.deb
-[rl-linux-a64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-Linux-aarch64-musl.tar.gz
-[rl-macos-x64]: https://github.com/maplibre/martin/releases/latest/download/martin-Darwin-x86_64.tar.gz
-[rl-macos-a64]: https://github.com/maplibre/martin/releases/latest/download/martin-Darwin-aarch64.tar.gz
-[rl-win64-zip]: https://github.com/maplibre/martin/releases/latest/download/martin-Windows-x86_64.zip
+[rl-linux-a64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-unknown-linux-musl.tar.gz
+[rl-macos-x64]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-apple-darwin.tar.gz
+[rl-macos-a64]: https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-apple-darwin.tar.gz
+[rl-win64-zip]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-pc-windows-msvc.zip
 
 If you are using macOS and [Homebrew](https://brew.sh/) you can install `martin` and `mbtiles` using Homebrew tap.
 

--- a/docs/src/10-installation.md
+++ b/docs/src/10-installation.md
@@ -12,9 +12,9 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 | macOS    | [64-bit][rl-macos-tar] |
 | Windows  | [64-bit][rl-win64-zip] |
 
-[rl-linux-tar]: https://github.com/maplibre/martin/releases/latest/download/martin-Linux-x86_64.tar.gz
-[rl-macos-tar]: https://github.com/maplibre/martin/releases/latest/download/martin-Darwin-x86_64.tar.gz
-[rl-win64-zip]: https://github.com/maplibre/martin/releases/latest/download/martin-Windows-x86_64.zip
+[rl-linux-tar]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-gnu.tar.gz
+[rl-macos-tar]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-apple-darwin.tar.gz
+[rl-win64-zip]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-pc-windows-msvc.zip
 
 ### Building with Cargo
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,16 +1,5 @@
 lints.workspace = true
 
-
-
-[package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-{ archive-suffix }"
-bin-dir = "{ name }{ binary-ext }"
-pkg-fmt = "tgz"
-
-[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-fmt = "zip"
-
-
 [package]
 name = "martin"
 # Once the release is published with the hash, update https://github.com/maplibre/homebrew-martin

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,5 +1,16 @@
 lints.workspace = true
 
+
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-{ archive-suffix }"
+bin-dir = "{ name }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+
 [package]
 name = "martin"
 # Once the release is published with the hash, update https://github.com/maplibre/homebrew-martin


### PR DESCRIPTION
Try to fix #1005
- [x] Add cargo binstall support
- [x] Update links
- [x] Update [home-brew](https://github.com/maplibre/homebrew-martin) by another [PR](https://github.com/maplibre/homebrew-martin/pull/8)
- [x] To check is there anything to do for `mbtiles`