### PR TITLE
add agg-tiles-hash calc to `martin-cp`

### DIFF
--- a/docs/src/martin-cp.md
+++ b/docs/src/martin-cp.md
@@ -1,6 +1,8 @@
 # Generating Tiles in Bulk
 
-`martin-cp` is a tool for generating tiles in bulk, and save retrieved tiles into a new or an existing MBTiles file. It can be used to generate tiles for a large area or multiple areas. If multiple areas overlap, it will generate tiles only once. `martin-cp` supports the same configuration file and CLI arguments as Martin server, so it can support all sources and even combining sources.
+`martin-cp` is a tool for generating tiles in bulk, from any source(s) supported by Martin, and save retrieved tiles into a new or an existing MBTiles file. `martin-cp` can be used to generate tiles for a large area or multiple areas (bounding boxes). If multiple areas overlap, it will ensure each tile is generated only once. `martin-cp` supports the same configuration file and CLI arguments as Martin server, so it can support all sources and even combining sources.
+
+After copying, `martin-cp` will update the `agg_tiles_hash` metadata value unless `--skip-agg-tiles-hash` is specified. This allows the MBTiles file to be [validated](./mbtiles-validation.md#aggregate-content-validation) using `mbtiles validate` command.
 
 ## Usage
 
@@ -12,6 +14,8 @@ martin-cp  --output-file tileset.mbtiles \
            "--bbox=-180,-90,180,90"      \
            --min-zoom 0                  \
            --max-zoom 10                 \
-           --source my_table             \
+           --source source_name          \
            postgresql://postgres@localhost:5432/db
 ```
+
+You 

--- a/tests/expected/martin-cp/flat-with-hash_metadata.txt
+++ b/tests/expected/martin-cp/flat-with-hash_metadata.txt
@@ -10,4 +10,5 @@ tilejson:
   name: function_zxy_query_test
   format: mvt
   generator: martin-cp v0.11.2
+agg_tiles_hash: 9B931A386D6075D1DA55323BD4DBEDAE
 

--- a/tests/expected/martin-cp/flat_metadata.txt
+++ b/tests/expected/martin-cp/flat_metadata.txt
@@ -19,4 +19,5 @@ tilejson:
   foo: '{"bar":"foo"}'
   format: mvt
   generator: martin-cp v0.11.2
+agg_tiles_hash: EF19FCBCE73ADE1C85E856E6BBA9B4C7
 

--- a/tests/expected/martin-cp/normalized_metadata.txt
+++ b/tests/expected/martin-cp/normalized_metadata.txt
@@ -36,4 +36,5 @@ tilejson:
   version: 1.0.0
   format: png
   generator: martin-cp v0.11.2
+agg_tiles_hash: A85C80BA1CE047E2D93DAC25C5179775
 


### PR DESCRIPTION
* Automatically computes `agg-tiles-hash` metadata value after copying tiles
* Add a `--skip-agg-tiles-hash` option