### PR TITLE
feat: martin-cp can set metadata values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "martin"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -3,7 +3,7 @@ lints.workspace = true
 [package]
 name = "martin"
 # Once the release is published with the hash, update https://github.com/maplibre/homebrew-martin
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Stepan Kuzmin <to.stepan.kuzmin@gmail.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 keywords = ["maps", "tiles", "mbtiles", "pmtiles", "postgis"]

--- a/tests/expected/martin-cp/flat-with-hash_metadata.txt
+++ b/tests/expected/martin-cp/flat-with-hash_metadata.txt
@@ -9,6 +9,6 @@ tilejson:
   description: public.function_zxy_query_test
   name: function_zxy_query_test
   format: mvt
-  generator: martin-cp v0.11.2
+  generator: martin-cp v0.11.3
 agg_tiles_hash: 9B931A386D6075D1DA55323BD4DBEDAE
 

--- a/tests/expected/martin-cp/flat_metadata.txt
+++ b/tests/expected/martin-cp/flat_metadata.txt
@@ -18,6 +18,6 @@ tilejson:
   name: table_source
   foo: '{"bar":"foo"}'
   format: mvt
-  generator: martin-cp v0.11.2
+  generator: martin-cp v0.11.3
 agg_tiles_hash: EF19FCBCE73ADE1C85E856E6BBA9B4C7
 

--- a/tests/expected/martin-cp/normalized_metadata.txt
+++ b/tests/expected/martin-cp/normalized_metadata.txt
@@ -12,7 +12,7 @@ tilejson:
   - 85.0511
   center:
   - 0.0
-  - 20.0
+  - 0.0
   - 0
   description: 'One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. '
   legend: |-
@@ -25,7 +25,7 @@ tilejson:
     </div>
   maxzoom: 1
   minzoom: 0
-  name: Geography Class
+  name: normalized
   template: |-
     {{#__location__}}{{/__location__}}{{#__teaser__}}<div style="text-align:center;">
 
@@ -35,6 +35,6 @@ tilejson:
     </div>{{/__teaser__}}{{#__full__}}{{/__full__}}
   version: 1.0.0
   format: png
-  generator: martin-cp v0.11.2
+  generator: martin-cp v0.11.3
 agg_tiles_hash: A85C80BA1CE047E2D93DAC25C5179775
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -392,7 +392,8 @@ if [[ "$MARTIN_CP_BIN" != "-" ]]; then
       --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45"
   test_martin_cp "normalized" "${CFG[@]}" \
       --source geography-class-png --mbtiles-type normalized --concurrency 3 \
-      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45"
+      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45" \
+      --set-meta "name=normalized" --set-meta=center=0,0,0
 
   unset DATABASE_URL
 


### PR DESCRIPTION
Use `martin-cp --set-meta KEY=VALUE ...` to modify metadata values after the copying is complete.  Can be used multiple times.