### PR TITLE
Require `--on-duplicate` when adding to existing mbtiles files

### DIFF
--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_copy_diff_with_override_copy_duplicate_mode() {
         let mut opt = MbtilesCopier::new(PathBuf::from("src_file"), PathBuf::from("dst_file"));
-        opt.on_duplicate = CopyDuplicateMode::Override;
+        opt.on_duplicate = Some(CopyDuplicateMode::Override);
         assert_eq!(
             Args::parse_from([
                 "mbtiles",
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn test_copy_diff_with_ignore_copy_duplicate_mode() {
         let mut opt = MbtilesCopier::new(PathBuf::from("src_file"), PathBuf::from("dst_file"));
-        opt.on_duplicate = CopyDuplicateMode::Ignore;
+        opt.on_duplicate = Some(CopyDuplicateMode::Ignore);
         assert_eq!(
             Args::parse_from([
                 "mbtiles",
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_copy_diff_with_abort_copy_duplicate_mode() {
         let mut opt = MbtilesCopier::new(PathBuf::from("src_file"), PathBuf::from("dst_file"));
-        opt.on_duplicate = CopyDuplicateMode::Abort;
+        opt.on_duplicate = Some(CopyDuplicateMode::Abort);
         assert_eq!(
             Args::parse_from([
                 "mbtiles",

--- a/mbtiles/src/errors.rs
+++ b/mbtiles/src/errors.rs
@@ -71,6 +71,9 @@ pub enum MbtError {
 
     #[error("The MBTiles file {0} has data of type {1}, but the desired type was set to {2}")]
     MismatchedTargetType(PathBuf, MbtType, MbtType),
+
+    #[error("Unless  --on-duplicate (override|ignore|abort)  is set, writing tiles to an existing non-empty MBTiles file is disabled. Either set --on-duplicate flag, or delete {}", .0.display())]
+    DestinationFileExists(PathBuf),
 }
 
 pub type MbtResult<T> = Result<T, MbtError>;


### PR DESCRIPTION
When using `martin-cp` or `mbtiles copy` into an existing file, require the user to set `--on-duplicate (override|ignore|abort)`. This prevents accidental writing to an existing file.