### PR TITLE
Feature: new `mbtiles diff` command

### DIFF
--- a/docs/src/mbtiles-diff.md
+++ b/docs/src/mbtiles-diff.md
@@ -1,0 +1,13 @@
+# Diffing MBTiles
+
+## `mbtiles diff`
+
+Diff command compares two mbtiles files `file A` and `file B`, and generates a delta (diff) file. If the diff file is [applied](mbtiles-copy.md#mbtiles-apply-patch) to `A`, it will produce `B`.  
+The delta file will contain all tiles that are different between the two files (modifications, insertions, and deletions as `NULL` values), for both the tile and metadata tables.  
+The only exception is `agg_tiles_has` metadata value. It will be renamed to `agg_tiles_hash_in_diff` and a new `agg_tiles_hash` will be generated for the diff file itself.
+
+```shell
+# This command will comapre `file_a.mbtiles` and `file_b.mbtiles`, and generate a new diff file `diff_result.mbtiles`,This command will compares file_a.mbtiles and file_b.mbtiles, and generates a new diff file diff_result.mbtiles 
+# If the diff file is applied to file_a, it will produce file_b. 
+mbtiles diff file_a.mbtiles file_b.mbtiles diff_result.mbtiles // 
+``` 

--- a/docs/src/mbtiles-diff.md
+++ b/docs/src/mbtiles-diff.md
@@ -2,10 +2,10 @@
 
 ## `mbtiles diff`
 
-Diff command compares two mbtiles files `file A` and `file B`, and generates a delta (diff) file. If the diff file
-is [applied](mbtiles-copy.md#mbtiles-apply-patch) to `A`, it will produce `B`.  
-The delta file will contain all tiles that are different between the two files (modifications, insertions, and deletions
-as `NULL` values), for both the tile and metadata tables.  
+Diff command compares two mbtiles files `A` and `B`, and generates a diff (delta) file.
+If the diff file is [applied](mbtiles-copy.md#mbtiles-apply-patch) to `A`, it will produce `B`.  
+The diff file will contain all tiles that are different between the two files
+(modifications, insertions, and deletions as `NULL` values), for both the tile and metadata tables.  
 The only exception is `agg_tiles_has` metadata value. It will be renamed to `agg_tiles_hash_in_diff` and a
 new `agg_tiles_hash` will be generated for the diff file itself.
 

--- a/docs/src/mbtiles-diff.md
+++ b/docs/src/mbtiles-diff.md
@@ -11,6 +11,16 @@ new `agg_tiles_hash` will be generated for the diff file itself.
 
 ```shell
 # This command will comapre `a.mbtiles` and `b.mbtiles`, and generate a new diff file `diff.mbtiles`.
-# If diff.mbtiles is applied to a.mbtiles, it will produce b.mbtiles 
 mbtiles diff a.mbtiles b.mbtiles diff.mbtiles
+
+# If diff.mbtiles is applied to a.mbtiles, it will produce b.mbtiles 
+mbtiles apply-diff a.mbtiles diff.mbtiles b2.mbtiles
+
+# b.mbtiles and b2.mbtiles should now be the same
+# Validate both files and see that their hash values are identical
+mbtiles validate b.mbtiles
+[INFO ] The agg_tiles_hashes=E95C1081447FB25674DCC1EB97F60C26 has been verified for b.mbtiles
+
+mbtiles validate b2.mbtiles
+[INFO ] The agg_tiles_hashes=E95C1081447FB25674DCC1EB97F60C26 has been verified for b2.mbtiles
 ```

--- a/docs/src/mbtiles-diff.md
+++ b/docs/src/mbtiles-diff.md
@@ -10,7 +10,7 @@ The only exception is `agg_tiles_has` metadata value. It will be renamed to `agg
 new `agg_tiles_hash` will be generated for the diff file itself.
 
 ```shell
-# This command will comapre `file_a.mbtiles` and `file_b.mbtiles`, and generate a new diff file `diff_result.mbtiles`,This command will compares file_a.mbtiles and file_b.mbtiles, and generates a new diff file diff_result.mbtiles 
-# If the diff file is applied to file_a, it will produce file_b. 
-mbtiles diff file_a.mbtiles file_b.mbtiles diff_result.mbtiles
+# This command will comapre `a.mbtiles` and `b.mbtiles`, and generate a new diff file `diff.mbtiles`.
+# If diff.mbtiles is applied to a.mbtiles, it will produce b.mbtiles 
+mbtiles diff a.mbtiles b.mbtiles diff.mbtiles
 ```

--- a/docs/src/mbtiles-diff.md
+++ b/docs/src/mbtiles-diff.md
@@ -2,12 +2,15 @@
 
 ## `mbtiles diff`
 
-Diff command compares two mbtiles files `file A` and `file B`, and generates a delta (diff) file. If the diff file is [applied](mbtiles-copy.md#mbtiles-apply-patch) to `A`, it will produce `B`.  
-The delta file will contain all tiles that are different between the two files (modifications, insertions, and deletions as `NULL` values), for both the tile and metadata tables.  
-The only exception is `agg_tiles_has` metadata value. It will be renamed to `agg_tiles_hash_in_diff` and a new `agg_tiles_hash` will be generated for the diff file itself.
+Diff command compares two mbtiles files `file A` and `file B`, and generates a delta (diff) file. If the diff file
+is [applied](mbtiles-copy.md#mbtiles-apply-patch) to `A`, it will produce `B`.  
+The delta file will contain all tiles that are different between the two files (modifications, insertions, and deletions
+as `NULL` values), for both the tile and metadata tables.  
+The only exception is `agg_tiles_has` metadata value. It will be renamed to `agg_tiles_hash_in_diff` and a
+new `agg_tiles_hash` will be generated for the diff file itself.
 
 ```shell
 # This command will comapre `file_a.mbtiles` and `file_b.mbtiles`, and generate a new diff file `diff_result.mbtiles`,This command will compares file_a.mbtiles and file_b.mbtiles, and generates a new diff file diff_result.mbtiles 
 # If the diff file is applied to file_a, it will produce file_b. 
-mbtiles diff file_a.mbtiles file_b.mbtiles diff_result.mbtiles // 
-``` 
+mbtiles diff file_a.mbtiles file_b.mbtiles diff_result.mbtiles
+```

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -52,6 +52,13 @@ enum Commands {
         /// Value to set, or nothing if the key should be deleted.
         value: Option<String>,
     },
+    /// Compare two files A and B, and generate a new diff file. If the diff file is applied to A, it will produce B.
+    #[command(name = "diff")]
+    Diff {
+        file_a: PathBuf,
+        file_b: PathBuf,
+        diff: PathBuf,
+    },
     /// Copy tiles from one mbtiles file to another.
     #[command(name = "copy", alias = "cp")]
     Copy(CopyArgs),
@@ -211,6 +218,28 @@ async fn main_int() -> anyhow::Result<()> {
             let mut conn = mbt.open_readonly().await?;
             println!("MBTiles file summary for {mbt}");
             println!("{}", mbt.summary(&mut conn).await?);
+        }
+        Commands::Diff {
+            file_a,
+            file_b,
+            diff,
+        } => {
+            let opts = MbtilesCopier {
+                src_file: file_a,
+                diff_with_file: Some(file_b),
+                dst_file: diff,
+                copy: CopyType::All,
+                skip_agg_tiles_hash: false,
+                on_duplicate: Some(CopyDuplicateMode::Override),
+                dst_type_cli: None,
+                dst_type: None,
+                min_zoom: None,
+                max_zoom: None,
+                zoom_levels: vec![],
+                bbox: vec![],
+                apply_patch: None,
+            };
+            opts.run().await?;
         }
     }
 

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -282,7 +282,7 @@ mod tests {
     use mbtiles::CopyDuplicateMode;
 
     use super::*;
-    use crate::Commands::{ApplyPatch, Copy, MetaGetValue, MetaSetValue, Validate};
+    use crate::Commands::{ApplyPatch, Copy, Diff, MetaGetValue, MetaSetValue, Validate};
     use crate::{Args, IntegrityCheckType};
 
     #[test]
@@ -549,6 +549,31 @@ mod tests {
                     integrity_check: IntegrityCheckType::Quick,
                     update_agg_tiles_hash: false,
                     agg_hash: Some(AggHashType::Off),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_diff() {
+        let file_a = PathBuf::from("../tests/fixtures/mbtiles/geography-class-jpg.mbtiles");
+        let file_b = PathBuf::from("file:copy_with_diff_with_file_mem_db?mode=memory&cache=shared");
+
+        let diff = PathBuf::from("../tests/fixtures/mbtiles/geography-class-jpg-modified.mbtiles");
+        assert_eq!(
+            Args::parse_from([
+                "mbtiles",
+                "diff",
+                file_a.to_str().unwrap(),
+                file_b.to_str().unwrap(),
+                diff.to_str().unwrap()
+            ]),
+            Args {
+                verbose: false,
+                command: Diff {
+                    file_a,
+                    file_b,
+                    diff,
                 }
             }
         );

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -556,24 +556,20 @@ mod tests {
 
     #[test]
     fn test_diff() {
-        let file_a = PathBuf::from("../tests/fixtures/mbtiles/geography-class-jpg.mbtiles");
-        let file_b = PathBuf::from("file:copy_with_diff_with_file_mem_db?mode=memory&cache=shared");
-
-        let diff = PathBuf::from("../tests/fixtures/mbtiles/geography-class-jpg-modified.mbtiles");
         assert_eq!(
             Args::parse_from([
                 "mbtiles",
                 "diff",
-                file_a.to_str().unwrap(),
-                file_b.to_str().unwrap(),
-                diff.to_str().unwrap()
+                "file-a.mbtiles",
+                "file-b.mbtiles",
+                "../delta.mbtiles",
             ]),
             Args {
                 verbose: false,
                 command: Diff {
-                    file_a,
-                    file_b,
-                    diff,
+                    file_a: PathBuf::from("file-a.mbtiles"),
+                    file_b: PathBuf::from("file-b.mbtiles"),
+                    diff: PathBuf::from("../delta.mbtiles"),
                 }
             }
         );

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -458,7 +458,11 @@ if [[ "$MBTILES_BIN" != "-" ]]; then
     "$TEST_TEMP_DIR/world_cities_diff.mbtiles" \
     --diff-with-file ./tests/fixtures/mbtiles/world_cities_modified.mbtiles \
     2>&1 | tee "$TEST_OUT_DIR/copy_diff.txt"
-
+  $MBTILES_BIN diff \
+       ./tests/fixtures/mbtiles/world_cities.mbtiles \
+       ./tests/fixtures/mbtiles/world_cities_modified.mbtiles \
+       "$TEST_TEMP_DIR/world_cities_diff2.mbtiles" \
+       2>&1 | tee "$TEST_OUT_DIR/copy_diff2.txt"
   if command -v sqlite3 > /dev/null; then
     # Apply this diff to the original version of the file
     cp ./tests/fixtures/mbtiles/world_cities.mbtiles "$TEST_TEMP_DIR/world_cities_copy.mbtiles"


### PR DESCRIPTION
Implement `mbtiles diff file_a.mbtiles file_b.mbtiles diff.mbtiles`. This should behave exactly the same as `mbtiles copy file_a.mbtiles --diff-with-file file_b.mbtiles diff.mbtiles`.

- [x] Add `mbtiles diff` as a separate command
- [x] Update doc