### PR TITLE
Split Clap code from `MbtilesCopier` into `CopyArgs`

### DIFF
--- a/.github/files/markdown.links.config.json
+++ b/.github/files/markdown.links.config.json
@@ -16,6 +16,9 @@
       "pattern": "^http://localhost"
     },
     {
+      "pattern": "^https://ghcr.io/maplibre/martin($|/|\\?)"
+    },
+    {
       "pattern": "^http://opensource.org"
     }
   ],

--- a/mbtiles/src/copier.rs
+++ b/mbtiles/src/copier.rs
@@ -1,8 +1,6 @@
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
-#[cfg(feature = "cli")]
-use clap::{Args, ValueEnum};
 use enum_display::EnumDisplay;
 use itertools::Itertools as _;
 use log::{debug, info, trace};
@@ -24,7 +22,7 @@ use crate::{
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, EnumDisplay, Serialize, Deserialize)]
 #[enum_display(case = "Kebab")]
-#[cfg_attr(feature = "cli", derive(ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum CopyDuplicateMode {
     Override,
     Ignore,
@@ -43,52 +41,32 @@ impl CopyDuplicateMode {
 }
 
 #[derive(Clone, Default, PartialEq, Debug)]
-#[cfg_attr(feature = "cli", derive(Args))]
 pub struct MbtilesCopier {
     /// MBTiles file to read from
     pub src_file: PathBuf,
     /// MBTiles file to write to
     pub dst_file: PathBuf,
     /// Output format of the destination file, ignored if the file exists. If not specified, defaults to the type of source
-    #[cfg_attr(
-        feature = "cli",
-        arg(
-            long = "mbtiles-type",
-            alias = "dst-type",
-            alias = "dst_type",
-            value_name = "SCHEMA",
-            value_enum
-        )
-    )]
     pub dst_type_cli: Option<MbtTypeCli>,
     /// Destination type with options
-    #[cfg_attr(feature = "cli", arg(skip))]
     pub dst_type: Option<MbtType>,
     /// Allow copying to existing files, and indicate what to do if a tile with the same Z/X/Y already exists
-    #[cfg_attr(feature = "cli", arg(long, value_enum))]
     pub on_duplicate: Option<CopyDuplicateMode>,
     /// Minimum zoom level to copy
-    #[cfg_attr(feature = "cli", arg(long, conflicts_with("zoom_levels")))]
     pub min_zoom: Option<u8>,
     /// Maximum zoom level to copy
-    #[cfg_attr(feature = "cli", arg(long, conflicts_with("zoom_levels")))]
     pub max_zoom: Option<u8>,
     /// List of zoom levels to copy
-    #[cfg_attr(feature = "cli", arg(long, value_delimiter = ','))]
     pub zoom_levels: Vec<u8>,
     /// Bounding box to copy, in the format `min_lon,min_lat,max_lon,max_lat`. Can be used multiple times.
-    #[cfg_attr(feature = "cli", arg(long))]
     pub bbox: Vec<Bounds>,
     /// Compare source file with this file, and only copy non-identical tiles to destination.
     /// It should be later possible to run `mbtiles apply-diff SRC_FILE DST_FILE` to get the same DIFF file.
-    #[cfg_attr(feature = "cli", arg(long, conflicts_with("apply_patch")))]
     pub diff_with_file: Option<PathBuf>,
     /// Compare source file with this file, and only copy non-identical tiles to destination.
     /// It should be later possible to run `mbtiles apply-diff SRC_FILE DST_FILE` to get the same DIFF file.
-    #[cfg_attr(feature = "cli", arg(long, conflicts_with("diff_with_file")))]
     pub apply_patch: Option<PathBuf>,
     /// Skip generating a global hash for mbtiles validation. By default, `mbtiles` will compute `agg_tiles_hash` metadata value.
-    #[cfg_attr(feature = "cli", arg(long))]
     pub skip_agg_tiles_hash: bool,
 }
 

--- a/mbtiles/src/mbtiles.rs
+++ b/mbtiles/src/mbtiles.rs
@@ -2,8 +2,6 @@ use std::ffi::OsStr;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
 use enum_display::EnumDisplay;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -16,7 +14,7 @@ use crate::{invert_y_value, CopyDuplicateMode, MbtType};
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize, EnumDisplay)]
 #[enum_display(case = "Kebab")]
-#[cfg_attr(feature = "cli", derive(ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum MbtTypeCli {
     Flat,
     FlatWithHash,

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 use std::str::from_utf8;
 
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
 use enum_display::EnumDisplay;
 use log::{debug, info, warn};
 use martin_tile_utils::{Format, TileInfo, MAX_ZOOM};
@@ -52,7 +50,7 @@ impl MbtType {
 
 #[derive(PartialEq, Eq, Default, Debug, Clone, EnumDisplay)]
 #[enum_display(case = "Kebab")]
-#[cfg_attr(feature = "cli", derive(ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum IntegrityCheckType {
     #[default]
     Quick,
@@ -62,7 +60,7 @@ pub enum IntegrityCheckType {
 
 #[derive(PartialEq, Eq, Default, Debug, Clone, EnumDisplay)]
 #[enum_display(case = "Kebab")]
-#[cfg_attr(feature = "cli", derive(ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum AggHashType {
     /// Verify that the aggregate tiles hash value in the metadata table matches the computed value. Used by default.
     #[default]


### PR DESCRIPTION
This allows easier reuse of the copy functionality without affecting CLI commands.

Closes #1071