### PR TITLE
Make martin-cp integration tests ignore gen version

### DIFF
--- a/justfile
+++ b/justfile
@@ -155,7 +155,10 @@ test-int: clean-test install-sqlx
     fi
 
 # Run integration tests and save its output as the new expected output
-bless: restart clean-test bless-insta-martin bless-insta-mbtiles bless-tests
+bless: restart clean-test bless-insta-martin bless-insta-mbtiles bless-tests bless-int
+
+# Bless integration tests
+bless-int:
     rm -rf tests/temp
     tests/test.sh
     rm -rf tests/expected

--- a/tests/expected/martin-cp/flat-with-hash_metadata.txt
+++ b/tests/expected/martin-cp/flat-with-hash_metadata.txt
@@ -9,6 +9,6 @@ tilejson:
   description: public.function_zxy_query_test
   name: function_zxy_query_test
   format: mvt
-  generator: martin-cp v0.11.5
+  generator: martin-cp v0.0.0
 agg_tiles_hash: 9B931A386D6075D1DA55323BD4DBEDAE
 

--- a/tests/expected/martin-cp/flat_metadata.txt
+++ b/tests/expected/martin-cp/flat_metadata.txt
@@ -18,6 +18,6 @@ tilejson:
   name: table_source
   foo: '{"bar":"foo"}'
   format: mvt
-  generator: martin-cp v0.11.5
+  generator: martin-cp v0.0.0
 agg_tiles_hash: EF19FCBCE73ADE1C85E856E6BBA9B4C7
 

--- a/tests/expected/martin-cp/normalized_metadata.txt
+++ b/tests/expected/martin-cp/normalized_metadata.txt
@@ -35,6 +35,6 @@ tilejson:
     </div>{{/__teaser__}}{{#__full__}}{{/__full__}}
   version: 1.0.0
   format: png
-  generator: martin-cp v0.11.5
+  generator: martin-cp v0.0.0
 agg_tiles_hash: A85C80BA1CE047E2D93DAC25C5179775
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -394,14 +394,16 @@ if [[ "$MARTIN_CP_BIN" != "-" ]]; then
 
   test_martin_cp "flat" "${CFG[@]}" \
       --source table_source --mbtiles-type flat --concurrency 3 \
-      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45"
+      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45" \
+      --set-meta "generator=martin-cp v0.0.0"
   test_martin_cp "flat-with-hash" "${CFG[@]}" \
       --source function_zxy_query_test --url-query 'foo=bar&token=martin' --encoding 'identity' --mbtiles-type flat-with-hash --concurrency 3 \
-      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45"
+      --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45" \
+      --set-meta "generator=martin-cp v0.0.0"
   test_martin_cp "normalized" "${CFG[@]}" \
       --source geography-class-png --mbtiles-type normalized --concurrency 3 \
       --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45" \
-      --set-meta "name=normalized" --set-meta=center=0,0,0
+      --set-meta "generator=martin-cp v0.0.0" --set-meta "name=normalized" --set-meta=center=0,0,0
 
   unset DATABASE_URL
 


### PR DESCRIPTION
This avoids blessing test results after version upgrade