### PR TITLE
Make the mbtiles and pmtiles deps optional.

### DIFF
--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -53,6 +53,7 @@ path = "src/bin/martin.rs"
 [[bin]]
 name = "martin-cp"
 path = "src/bin/martin-cp.rs"
+required-features = ["mbtiles"]
 
 [[bench]]
 name = "bench"
@@ -61,8 +62,8 @@ harness = false
 [features]
 default = ["fonts", "mbtiles", "pmtiles", "postgres", "sprites"]
 fonts = ["dep:bit-set", "dep:pbf_font_tools"]
-mbtiles = []
-pmtiles = []
+mbtiles = ["dep:mbtiles"]
+pmtiles = ["dep:pmtiles", "dep:reqwest"]
 postgres = ["dep:deadpool-postgres", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:semver", "dep:tokio-postgres-rustls"]
 sprites = ["dep:spreet"]
 bless-tests = []
@@ -84,16 +85,16 @@ itertools.workspace = true
 json-patch = { workspace = true, optional = true }
 log.workspace = true
 martin-tile-utils.workspace = true
-mbtiles.workspace = true
+mbtiles = { workspace = true, optional = true }
 moka.workspace = true
 num_cpus.workspace = true
 pbf_font_tools = { workspace = true, optional = true }
-pmtiles.workspace = true
+pmtiles = { workspace = true, optional = true }
 postgis = { workspace = true, optional = true }
 postgres-protocol = { workspace = true, optional = true }
 postgres = { workspace = true, optional = true }
 regex.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, optional = true }
 rustls-native-certs.workspace = true
 rustls-pemfile.workspace = true
 rustls.workspace = true

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -65,7 +65,7 @@ fonts = ["dep:bit-set", "dep:pbf_font_tools"]
 mbtiles = ["dep:mbtiles"]
 pmtiles = ["dep:pmtiles", "dep:reqwest"]
 postgres = ["dep:deadpool-postgres", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:semver", "dep:tokio-postgres-rustls"]
-sprites = ["dep:spreet"]
+sprites = ["dep:spreet", "tokio/fs"]
 bless-tests = []
 
 [dependencies]

--- a/martin/src/config.rs
+++ b/martin/src/config.rs
@@ -122,6 +122,7 @@ impl Config {
                     .weigher(|_key, value: &CacheValue| -> u32 {
                         match value {
                             CacheValue::Tile(v) => v.len().try_into().unwrap_or(u32::MAX),
+                            #[cfg(feature = "pmtiles")]
                             CacheValue::PmtDirectory(v) => {
                                 v.get_approx_byte_size().try_into().unwrap_or(u32::MAX)
                             }

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -43,6 +43,7 @@ pub enum FileError {
     #[error(r#"Unable to acquire connection to file: {0}"#)]
     AcquireConnError(String),
 
+    #[cfg(feature = "pmtiles")]
     #[error(r#"PMTiles error {0} processing {1}"#)]
     PmtError(pmtiles::PmtError, String),
 }

--- a/martin/src/utils/cache.rs
+++ b/martin/src/utils/cache.rs
@@ -1,4 +1,5 @@
 use moka::future::Cache;
+#[cfg(feature = "pmtiles")]
 use pmtiles::Directory;
 
 use crate::{TileCoord, TileData};
@@ -20,6 +21,7 @@ pub enum CacheKey {
 #[derive(Debug, Clone)]
 pub enum CacheValue {
     Tile(TileData),
+    #[cfg(feature = "pmtiles")]
     PmtDirectory(Directory),
 }
 
@@ -38,6 +40,7 @@ macro_rules! trace_cache {
 
 macro_rules! from_cache_value {
     ($value_type: path, $data: expr, $key: expr) => {
+        #[allow(irrefutable_let_patterns)]
         if let $value_type(data) = $data {
             data
         } else {

--- a/martin/src/utils/cache.rs
+++ b/martin/src/utils/cache.rs
@@ -1,6 +1,4 @@
 use moka::future::Cache;
-#[cfg(feature = "pmtiles")]
-use pmtiles::Directory;
 
 use crate::{TileCoord, TileData};
 
@@ -22,7 +20,7 @@ pub enum CacheKey {
 pub enum CacheValue {
     Tile(TileData),
     #[cfg(feature = "pmtiles")]
-    PmtDirectory(Directory),
+    PmtDirectory(pmtiles::Directory),
 }
 
 macro_rules! trace_cache {
@@ -48,6 +46,7 @@ macro_rules! from_cache_value {
         }
     };
 }
+
 #[cfg(feature = "pmtiles")]
 macro_rules! get_cached_value {
     ($cache: expr, $value_type: path, $make_key: expr) => {

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -3,6 +3,7 @@ use std::fmt::Write as _;
 use std::io;
 use std::path::PathBuf;
 
+#[cfg(feature = "mbtiles")]
 use mbtiles::MbtError;
 
 use crate::file_config::FileError;
@@ -61,6 +62,7 @@ pub enum MartinError {
     #[error(transparent)]
     PostgresError(#[from] crate::pg::PgError),
 
+    #[cfg(feature = "mbtiles")]
     #[error(transparent)]
     MbtilesError(#[from] MbtError),
 


### PR DESCRIPTION
This also makes the `mbtiles-cp` bin optional.

The binary is modestly smaller (by about 6%), but the target directory contains a lot less build products (by about 40%).