### PR TITLE
Adapt justfiles for Docker Compose command

### DIFF
--- a/demo/justfile
+++ b/demo/justfile
@@ -2,6 +2,8 @@
 
 set shell := ["bash", "-c"]
 
+dockercompose := `if docker-compose --version &> /dev/null; then echo "docker-compose"; else echo "docker compose"; fi`
+
 @_default:
     just --list --unsorted
 
@@ -9,20 +11,20 @@ clean:
     rm -rf frontend/node_modules
 
 up:
-    docker-compose up
+   {{ dockercompose }} up
 
 up-build:
-    docker-compose up --build
+    {{ dockercompose }} up --build
 
 build:
-    docker-compose build
+    {{ dockercompose }} build
 
 up-backend:
-    docker-compose up db tiles --detach
+    {{ dockercompose }} up db tiles --detach
 
 frontend *ARGS:
-    docker-compose up frontend {{ ARGS }}
+    {{ dockercompose }} up frontend {{ ARGS }}
 
 [no-exit-message]
 frontend-sh:
-    docker-compose run --interactive --entrypoint sh frontend
+    {{ dockercompose }} run --interactive --entrypoint sh frontend

--- a/demo/justfile
+++ b/demo/justfile
@@ -11,7 +11,7 @@ clean:
     rm -rf frontend/node_modules
 
 up:
-   {{ dockercompose }} up
+    {{ dockercompose }} up
 
 up-build:
     {{ dockercompose }} up --build

--- a/justfile
+++ b/justfile
@@ -15,6 +15,8 @@ export CARGO_TERM_COLOR := "always"
 #export RUST_LOG := "sqlx::query=info,trace"
 #export RUST_BACKTRACE := "1"
 
+dockercompose := `if docker-compose --version &> /dev/null; then echo "docker-compose"; else echo "docker compose"; fi`
+
 @_default:
     {{ just_executable() }} --list --unsorted
 
@@ -71,12 +73,12 @@ start-legacy: (docker-up "db-legacy") docker-is-ready
 # Start a specific test database, e.g. db or db-legacy
 [private]
 docker-up name: start-pmtiles-server
-    docker-compose up -d {{ name }}
+    {{ dockercompose }} up -d {{ name }}
 
 # Wait for the test database to be ready
 [private]
 docker-is-ready:
-    docker-compose run -T --rm db-is-ready
+    {{ dockercompose }} run -T --rm db-is-ready
 
 alias _down := stop
 alias _stop-db := stop
@@ -89,11 +91,11 @@ restart:
 
 # Stop the test database
 stop:
-    docker-compose down --remove-orphans
+    {{ dockercompose }} down --remove-orphans
 
 # Start test server for testing HTTP pmtiles
 start-pmtiles-server:
-    docker-compose up -d fileserver
+    {{ dockercompose }} up -d fileserver
 
 # Run benchmark tests
 bench:


### PR DESCRIPTION
This should solve #1149. See also [my comment there for the approach](https://github.com/maplibre/martin/issues/11). In short through a variable that is substituted. Note that this may not work if an older Docker version is installed without the Python `docker-compose` script...As both variants will not be present. Maybe add an extra test+warning msg for that case.

```
dockercompose := `if docker-compose --version &> /dev/null; then echo "docker-compose"; else echo "docker compose"; fi`
.
.
up:
   {{ dockercompose }} up

up-build:
    {{ dockercompose }} up --build
.
.
```
 