### PR TITLE
Use ORDERBY in calc_agg_tiles_hash - SQLite v3.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde_with = "3"
 serde_yaml = "0.9"
 size_format = "1.0.2"
 spreet = { version = "0.11", default-features = false }
-sqlite-hashes = { version = "0.6", default-features = false, features = ["md5", "window", "hex"] }
+sqlite-hashes = { version = "0.6", default-features = false, features = ["md5", "window", "hex"] }  # window forces libsqlite3-sys to bundle sqlite3. We require v3.44.0 or newer.
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio"] }
 subst = { version = "0.3", features = ["yaml"] }
 thiserror = "1"


### PR DESCRIPTION
Require SQLite v3.44+ ORDER BY clause inside aggregate function instead of the windowing one - might solve out of memory issues reported by users - see #1154