### PR TITLE
Add `--preferred-encoding (gzip|brotli)` to use when tile is not pre-encoded by source

### DIFF
--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -27,7 +27,7 @@ worker_processes: 8
 # Amount of memory (in MB) to use for caching tiles [default: 512, 0 to disable]
 cache_size_mb: 1024
 
-# Preferred tiles encoding, gzip or brotli, default brotili. You could also use br as a shortcut for brotli
+# If the client accepts multiple compression formats, and the tile source is not pre-compressed, which compression should be used. `gzip` is faster, but `brotli` is smaller, and may be faster with caching.  Defaults to brotli.
 preferred_encoding: gzip
 
 # Database configuration. This can also be a list of PG configs.

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -27,6 +27,9 @@ worker_processes: 8
 # Amount of memory (in MB) to use for caching tiles [default: 512, 0 to disable]
 cache_size_mb: 1024
 
+# Preferred tiles encoding, gzip or brotli, default brotili. You could also use br as a shortcut for brotli
+preferred_encoding: gzip
+
 # Database configuration. This can also be a list of PG configs.
 postgres:
   # Database connection string. You can use env vars too, for example:

--- a/docs/src/run-with-cli.md
+++ b/docs/src/run-with-cli.md
@@ -32,7 +32,7 @@ Options:
           Number of web server workers
 
       --preferred-encoding <PREFERRED_ENCODING>
-          Preferred tiles encoding. gzip or brotli, default brotili. You could also use br as a shortcut for brotli
+          Martin server preferred tile encoding. If the client accepts multiple compression formats, and the tile source is not pre-compressed, which compression should be used. `gzip` is faster, but `brotli` is smaller, and may be faster with caching.  Defaults to brotli
           
           [possible values: brotli, gzip]
           

--- a/docs/src/run-with-cli.md
+++ b/docs/src/run-with-cli.md
@@ -31,6 +31,11 @@ Options:
   -W, --workers <WORKERS>
           Number of web server workers
 
+      --preferred-encoding <PREFERRED_ENCODING>
+          Preferred tiles encoding. gzip or brotli, default brotili. You could also use br as a shortcut for brotli
+          
+          [possible values: brotli, gzip]
+          
   -b, --auto-bounds <AUTO_BOUNDS>
           Specify how bounds should be computed for the spatial PG tables. [DEFAULT: quick]
 

--- a/martin/benches/bench.rs
+++ b/martin/benches/bench.rs
@@ -58,7 +58,7 @@ impl Source for NullSource {
 }
 
 async fn process_tile(sources: &TileSources) {
-    let src = DynTileSource::new(sources, "null", Some(0), "", None, None).unwrap();
+    let src = DynTileSource::new(sources, "null", Some(0), "", None, None, None).unwrap();
     src.get_http_response(TileCoord { z: 0, x: 0, y: 0 })
         .await
         .unwrap();

--- a/martin/src/args/mod.rs
+++ b/martin/src/args/mod.rs
@@ -13,4 +13,5 @@ mod root;
 pub use root::{Args, ExtraArgs, MetaArgs};
 
 mod srv;
+pub use srv::PreferredEncoding;
 pub use srv::SrvArgs;

--- a/martin/src/args/root.rs
+++ b/martin/src/args/root.rs
@@ -160,7 +160,9 @@ pub fn parse_file_args<T: crate::file_config::ConfigExtras>(
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
+    use crate::args::PreferredEncoding;
     use crate::test_utils::FauxEnv;
     use crate::MartinError::UnrecognizableConnections;
 
@@ -213,6 +215,28 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(args, (cfg, meta));
+    }
+
+    #[test]
+    fn cli_encoding_arguments() {
+        let config1 = parse(&["martin", "--preferred-encoding", "brotli"]);
+        let config2 = parse(&["martin", "--preferred-encoding", "br"]);
+        let config3 = parse(&["martin", "--preferred-encoding", "gzip"]);
+        let config4 = parse(&["martin"]);
+
+        assert_eq!(
+            config1.unwrap().0.srv.preferred_encoding,
+            Some(PreferredEncoding::Brotli)
+        );
+        assert_eq!(
+            config2.unwrap().0.srv.preferred_encoding,
+            Some(PreferredEncoding::Brotli)
+        );
+        assert_eq!(
+            config3.unwrap().0.srv.preferred_encoding,
+            Some(PreferredEncoding::Gzip)
+        );
+        assert_eq!(config4.unwrap().0.srv.preferred_encoding, None);
     }
 
     #[test]

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -12,7 +12,7 @@ pub struct SrvArgs {
     /// Number of web server workers
     #[arg(short = 'W', long)]
     pub workers: Option<usize>,
-    /// Preferred tiles encoding. gzip or brotli, default brotili. You could also use br as a shortcut for brotli
+    /// Martin server preferred tile encoding. If the client accepts multiple compression formats, and the tile source is not pre-compressed, which compression should be used. `gzip` is faster, but `brotli` is smaller, and may be faster with caching.  Defaults to brotli.
     #[arg(long)]
     pub preferred_encoding: Option<PreferredEncoding>,
 }

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -13,7 +13,7 @@ pub struct SrvArgs {
     #[arg(short = 'W', long)]
     pub workers: Option<usize>,
     /// Preferred tiles encoding. gzip or brotli, default brotili. You could also use br as a shortcut for brotli
-    #[arg(short, long)]
+    #[arg(long)]
     pub preferred_encoding: Option<PreferredEncoding>,
 }
 

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -1,4 +1,6 @@
 use crate::srv::{SrvConfig, KEEP_ALIVE_DEFAULT, LISTEN_ADDRESSES_DEFAULT};
+use martin_tile_utils::Encoding;
+use TileEncoding::{Brotli, Gzip};
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
 #[command(about, version)]
@@ -10,6 +12,8 @@ pub struct SrvArgs {
     /// Number of web server workers
     #[arg(short = 'W', long)]
     pub workers: Option<usize>,
+    #[arg(help = "to do", short, long)]
+    pub preferred_encoding: Option<String>,
 }
 
 impl SrvArgs {
@@ -23,6 +27,16 @@ impl SrvArgs {
         }
         if self.workers.is_some() {
             srv_config.worker_processes = self.workers;
+        }
+        if let Some(encoding_str) = self.preferred_encoding {
+            match encoding_str.as_str() {
+                "gzip" => srv_config.preferred_encoding = Option::from(Encoding::Gzip),
+                "brotli" => srv_config.preferred_encoding = Option::from(Encoding::Brotli),
+                "br" => srv_config.preferred_encoding = Option::from(Encoding::Brotli),
+                _ => panic!("Invalid encoding: {}", encoding_str),
+            }
+        } else {
+            srv_config.preferred_encoding = Option::from(Encoding::Brotli);
         }
     }
 }

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -22,6 +22,7 @@ pub struct SrvArgs {
 pub enum PreferredEncoding {
     #[default]
     #[serde(alias = "br")]
+    #[clap(alias("br"))]
     Brotli,
     Gzip,
 }

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -283,6 +283,7 @@ async fn run_tile_copy(args: CopyArgs, state: ServerState) -> MartinCpResult<()>
         args.url_query.as_deref().unwrap_or_default(),
         Some(parse_encoding(args.encoding.as_str())?),
         None,
+        None,
     )?;
     // parallel async below uses move, so we must only use copyable types
     let src = &src;

--- a/martin/src/config.rs
+++ b/martin/src/config.rs
@@ -10,6 +10,7 @@ use futures::future::try_join_all;
 use log::info;
 use serde::{Deserialize, Serialize};
 use subst::VariableMap;
+use martin_tile_utils::Encoding;
 
 #[cfg(any(feature = "mbtiles", feature = "pmtiles", feature = "sprites"))]
 use crate::file_config::FileConfigEnum;
@@ -32,6 +33,7 @@ pub struct ServerState {
     pub sprites: SpriteSources,
     #[cfg(feature = "fonts")]
     pub fonts: FontSources,
+    pub preferred_encoding: Encoding,
 }
 
 #[serde_with::skip_serializing_none]
@@ -143,6 +145,7 @@ impl Config {
             #[cfg(feature = "fonts")]
             fonts: FontSources::resolve(&mut self.fonts)?,
             cache,
+            preferred_encoding: self.srv.preferred_encoding.unwrap_or(Encoding::Brotli),
         })
     }
 

--- a/martin/src/config.rs
+++ b/martin/src/config.rs
@@ -10,7 +10,6 @@ use futures::future::try_join_all;
 use log::info;
 use serde::{Deserialize, Serialize};
 use subst::VariableMap;
-use martin_tile_utils::Encoding;
 
 #[cfg(any(feature = "mbtiles", feature = "pmtiles", feature = "sprites"))]
 use crate::file_config::FileConfigEnum;
@@ -33,7 +32,6 @@ pub struct ServerState {
     pub sprites: SpriteSources,
     #[cfg(feature = "fonts")]
     pub fonts: FontSources,
-    pub preferred_encoding: Encoding,
 }
 
 #[serde_with::skip_serializing_none]
@@ -145,7 +143,6 @@ impl Config {
             #[cfg(feature = "fonts")]
             fonts: FontSources::resolve(&mut self.fonts)?,
             cache,
-            preferred_encoding: self.srv.preferred_encoding.unwrap_or(Encoding::Brotli),
         })
     }
 

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -1,3 +1,4 @@
+use martin_tile_utils::Encoding;
 use serde::{Deserialize, Serialize};
 
 pub const KEEP_ALIVE_DEFAULT: u64 = 75;
@@ -9,6 +10,7 @@ pub struct SrvConfig {
     pub keep_alive: Option<u64>,
     pub listen_addresses: Option<String>,
     pub worker_processes: Option<usize>,
+    pub preferred_encoding: Option<Encoding>,
 }
 
 #[cfg(test)]
@@ -31,6 +33,7 @@ mod tests {
                 keep_alive: Some(75),
                 listen_addresses: some("0.0.0.0:3000"),
                 worker_processes: Some(8),
+                preferred_encoding: None,
             }
         );
     }

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -49,7 +49,7 @@ mod tests {
                 keep_alive: Some(75),
                 listen_addresses: some("0.0.0.0:3000"),
                 worker_processes: Some(8),
-                preferred_encoding: Some(PreferredEncoding::Brotli), 
+                preferred_encoding: Some(PreferredEncoding::Brotli),
             }
         );
         assert_eq!(
@@ -64,7 +64,7 @@ mod tests {
                 keep_alive: Some(75),
                 listen_addresses: some("0.0.0.0:3000"),
                 worker_processes: Some(8),
-                preferred_encoding: Some(PreferredEncoding::Brotli), 
+                preferred_encoding: Some(PreferredEncoding::Brotli),
             }
         );
     }

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -6,7 +6,7 @@ pub const KEEP_ALIVE_DEFAULT: u64 = 75;
 pub const LISTEN_ADDRESSES_DEFAULT: &str = "0.0.0.0:3000";
 
 #[serde_with::skip_serializing_none]
-#[derive(Clone,Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct SrvConfig {
     pub keep_alive: Option<u64>,
     pub listen_addresses: Option<String>,

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -1,16 +1,17 @@
-use martin_tile_utils::Encoding;
 use serde::{Deserialize, Serialize};
+
+use crate::args::PreferredEncoding;
 
 pub const KEEP_ALIVE_DEFAULT: u64 = 75;
 pub const LISTEN_ADDRESSES_DEFAULT: &str = "0.0.0.0:3000";
 
 #[serde_with::skip_serializing_none]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone,Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct SrvConfig {
     pub keep_alive: Option<u64>,
     pub listen_addresses: Option<String>,
     pub worker_processes: Option<usize>,
-    pub preferred_encoding: Option<Encoding>,
+    pub preferred_encoding: Option<PreferredEncoding>,
 }
 
 #[cfg(test)]

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -22,7 +22,7 @@ mod tests {
     use crate::test_utils::some;
 
     #[test]
-    fn parse_empty_config() {
+    fn parse_config() {
         assert_eq!(
             serde_yaml::from_str::<SrvConfig>(indoc! {"
                 keep_alive: 75
@@ -35,6 +35,36 @@ mod tests {
                 listen_addresses: some("0.0.0.0:3000"),
                 worker_processes: Some(8),
                 preferred_encoding: None,
+            }
+        );
+        assert_eq!(
+            serde_yaml::from_str::<SrvConfig>(indoc! {"
+                keep_alive: 75
+                listen_addresses: '0.0.0.0:3000'
+                worker_processes: 8
+                preferred_encoding: br
+            "})
+            .unwrap(),
+            SrvConfig {
+                keep_alive: Some(75),
+                listen_addresses: some("0.0.0.0:3000"),
+                worker_processes: Some(8),
+                preferred_encoding: Some(PreferredEncoding::Brotli), 
+            }
+        );
+        assert_eq!(
+            serde_yaml::from_str::<SrvConfig>(indoc! {"
+                keep_alive: 75
+                listen_addresses: '0.0.0.0:3000'
+                worker_processes: 8
+                preferred_encoding: brotli
+            "})
+            .unwrap(),
+            SrvConfig {
+                keep_alive: Some(75),
+                listen_addresses: some("0.0.0.0:3000"),
+                worker_processes: Some(8),
+                preferred_encoding: Some(PreferredEncoding::Brotli), 
             }
         );
     }

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -108,8 +108,8 @@ type Server = Pin<Box<dyn Future<Output = MartinResult<()>>>>;
 pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server, String)> {
     let catalog = Catalog::new(&state)?;
 
-    let keep_alive = Duration::from_secs(config.keep_alive.clone().unwrap_or(KEEP_ALIVE_DEFAULT));
-    let worker_processes = config.worker_processes.clone().unwrap_or_else(num_cpus::get);
+    let keep_alive = Duration::from_secs(config.keep_alive.unwrap_or(KEEP_ALIVE_DEFAULT));
+    let worker_processes = config.worker_processes.unwrap_or_else(num_cpus::get);
     let listen_addresses = config
         .listen_addresses
         .clone()

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -107,7 +107,6 @@ type Server = Pin<Box<dyn Future<Output = MartinResult<()>>>>;
 /// Create a future for an Actix web server together with the listening address.
 pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server, String)> {
     let catalog = Catalog::new(&state)?;
-
     let factory = move || {
         let cors_middleware = Cors::default()
             .allow_any_origin()
@@ -115,8 +114,7 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
 
         let app = App::new()
             .app_data(Data::new(state.tiles.clone()))
-            .app_data(Data::new(state.cache.clone()))
-            .app_data(Data::new(state.preferred_encoding));
+            .app_data(Data::new(state.cache.clone()));
 
         #[cfg(feature = "sprites")]
         let app = app.app_data(Data::new(state.sprites.clone()));
@@ -125,6 +123,7 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
         let app = app.app_data(Data::new(state.fonts.clone()));
 
         app.app_data(Data::new(catalog.clone()))
+            .app_data(Data::new(config.clone()))
             .wrap(cors_middleware)
             .wrap(middleware::NormalizePath::new(TrailingSlash::MergeOnly))
             .wrap(middleware::Logger::default())

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -115,7 +115,8 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
 
         let app = App::new()
             .app_data(Data::new(state.tiles.clone()))
-            .app_data(Data::new(state.cache.clone()));
+            .app_data(Data::new(state.cache.clone()))
+            .app_data(Data::new(state.preferred_encoding));
 
         #[cfg(feature = "sprites")]
         let app = app.app_data(Data::new(state.sprites.clone()));

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -107,6 +107,14 @@ type Server = Pin<Box<dyn Future<Output = MartinResult<()>>>>;
 /// Create a future for an Actix web server together with the listening address.
 pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server, String)> {
     let catalog = Catalog::new(&state)?;
+
+    let keep_alive = Duration::from_secs(config.keep_alive.clone().unwrap_or(KEEP_ALIVE_DEFAULT));
+    let worker_processes = config.worker_processes.clone().unwrap_or_else(num_cpus::get);
+    let listen_addresses = config
+        .listen_addresses
+        .clone()
+        .unwrap_or_else(|| LISTEN_ADDRESSES_DEFAULT.to_owned());
+
     let factory = move || {
         let cors_middleware = Cors::default()
             .allow_any_origin()
@@ -135,12 +143,6 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
         let server = run_actix_on_lambda(factory).err_into();
         return Ok((Box::pin(server), "(aws lambda)".into()));
     }
-
-    let keep_alive = Duration::from_secs(config.keep_alive.unwrap_or(KEEP_ALIVE_DEFAULT));
-    let worker_processes = config.worker_processes.unwrap_or_else(num_cpus::get);
-    let listen_addresses = config
-        .listen_addresses
-        .unwrap_or_else(|| LISTEN_ADDRESSES_DEFAULT.to_owned());
 
     let server = HttpServer::new(factory)
         .bind(listen_addresses.clone())

--- a/martin/src/srv/tiles.rs
+++ b/martin/src/srv/tiles.rs
@@ -10,20 +10,16 @@ use log::trace;
 use martin_tile_utils::{Encoding, Format, TileInfo};
 use serde::Deserialize;
 
+use crate::args::PreferredEncoding;
 use crate::source::{Source, TileSources, UrlQuery};
 use crate::srv::server::map_internal_error;
+use crate::srv::SrvConfig;
 use crate::utils::cache::get_or_insert_cached_value;
 use crate::utils::{
     decode_brotli, decode_gzip, encode_brotli, encode_gzip, CacheKey, CacheValue, MainCache,
     OptMainCache,
 };
 use crate::{Tile, TileCoord, TileData};
-
-static SUPPORTED_ENCODINGS: &[HeaderEnc] = &[
-    HeaderEnc::brotli(),
-    HeaderEnc::gzip(),
-    HeaderEnc::identity(),
-];
 
 #[derive(Deserialize, Clone)]
 pub struct TileRequest {
@@ -36,6 +32,7 @@ pub struct TileRequest {
 #[route("/{source_ids}/{z}/{x}/{y}", method = "GET", method = "HEAD")]
 async fn get_tile(
     req: HttpRequest,
+    srv_config: Data<SrvConfig>,
     path: Path<TileRequest>,
     sources: Data<TileSources>,
     cache: Data<OptMainCache>,
@@ -46,6 +43,7 @@ async fn get_tile(
         Some(path.z),
         req.query_string(),
         req.get_header::<AcceptEncoding>(),
+        srv_config.preferred_encoding,
         cache.as_ref().as_ref(),
     )?;
 
@@ -62,7 +60,8 @@ pub struct DynTileSource<'a> {
     pub info: TileInfo,
     pub query_str: Option<&'a str>,
     pub query_obj: Option<UrlQuery>,
-    pub encodings: Option<AcceptEncoding>,
+    pub accept_encodings: Option<AcceptEncoding>,
+    pub prefered_encodings: Option<PreferredEncoding>,
     pub cache: Option<&'a MainCache>,
 }
 
@@ -72,7 +71,8 @@ impl<'a> DynTileSource<'a> {
         source_ids: &str,
         zoom: Option<u8>,
         query: &'a str,
-        encodings: Option<AcceptEncoding>,
+        accpect_encodings: Option<AcceptEncoding>,
+        preferred_encoding: Option<PreferredEncoding>,
         cache: Option<&'a MainCache>,
     ) -> ActixResult<Self> {
         let (sources, use_url_query, info) = sources.get_sources(source_ids, zoom)?;
@@ -93,7 +93,8 @@ impl<'a> DynTileSource<'a> {
             info,
             query_str,
             query_obj,
-            encodings,
+            accept_encodings: accpect_encodings,
+            prefered_encodings: preferred_encoding,
             cache,
         })
     }
@@ -169,7 +170,7 @@ impl<'a> DynTileSource<'a> {
 
     fn recompress(&self, tile: TileData) -> ActixResult<Tile> {
         let mut tile = Tile::new(tile, self.info);
-        if let Some(accept_enc) = &self.encodings {
+        if let Some(accept_enc) = &self.accept_encodings {
             if self.info.encoding.is_encoded() {
                 // already compressed, see if we can send it as is, or need to re-compress
                 if !accept_enc.iter().any(|e| {
@@ -184,9 +185,30 @@ impl<'a> DynTileSource<'a> {
                 }
             }
             if tile.info.encoding == Encoding::Uncompressed {
+                let ordered_encodings = if let Some(prefered) = self.prefered_encodings {
+                    match prefered {
+                        PreferredEncoding::Brotli => [
+                            HeaderEnc::brotli(),
+                            HeaderEnc::gzip(),
+                            HeaderEnc::identity(),
+                        ],
+                        PreferredEncoding::Gzip => [
+                            HeaderEnc::gzip(),
+                            HeaderEnc::brotli(),
+                            HeaderEnc::identity(),
+                        ],
+                    }
+                } else {
+                    [
+                        HeaderEnc::brotli(),
+                        HeaderEnc::gzip(),
+                        HeaderEnc::identity(),
+                    ]
+                };
                 // only apply compression if the content supports it
                 if let Some(HeaderEnc::Known(enc)) =
-                    accept_enc.negotiate(SUPPORTED_ENCODINGS.iter())
+                    // accept_enc.negotiate(SUPPORTED_ENCODINGS.iter())
+                    accept_enc.negotiate(ordered_encodings.iter())
                 {
                     // (re-)compress the tile into the preferred encoding
                     tile = encode(tile, enc)?;
@@ -278,7 +300,7 @@ mod tests {
             ("empty,non-empty", vec![1_u8, 2, 3]),
             ("empty,non-empty,empty", vec![1_u8, 2, 3]),
         ] {
-            let src = DynTileSource::new(&sources, source_id, None, "", None, None).unwrap();
+            let src = DynTileSource::new(&sources, source_id, None, "", None, None, None).unwrap();
             let xyz = TileCoord { z: 0, x: 0, y: 0 };
             assert_eq!(expected, &src.get_tile_content(xyz).await.unwrap().data);
         }

--- a/martin/src/srv/tiles.rs
+++ b/martin/src/srv/tiles.rs
@@ -268,7 +268,6 @@ pub fn to_encoding(val: ContentEncoding) -> Option<Encoding> {
 
 #[cfg(test)]
 mod tests {
-    use actix_http::header::HeaderValue;
     use tilejson::tilejson;
 
     use super::*;

--- a/martin/src/srv/tiles.rs
+++ b/martin/src/srv/tiles.rs
@@ -205,7 +205,6 @@ impl<'a> DynTileSource<'a> {
 
                 // only apply compression if the content supports it
                 if let Some(HeaderEnc::Known(enc)) =
-                    // accept_enc.negotiate(SUPPORTED_ENCODINGS.iter())
                     accept_enc.negotiate(ordered_encodings.iter())
                 {
                     // (re-)compress the tile into the preferred encoding

--- a/martin/src/srv/tiles.rs
+++ b/martin/src/srv/tiles.rs
@@ -204,8 +204,7 @@ impl<'a> DynTileSource<'a> {
                 };
 
                 // only apply compression if the content supports it
-                if let Some(HeaderEnc::Known(enc)) =
-                    accept_enc.negotiate(ordered_encodings.iter())
+                if let Some(HeaderEnc::Known(enc)) = accept_enc.negotiate(ordered_encodings.iter())
                 {
                     // (re-)compress the tile into the preferred encoding
                     tile = encode(tile, enc)?;

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -4,6 +4,7 @@ use ctor::ctor;
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
 use martin::decode_gzip;
+use martin::srv::SrvConfig;
 use tilejson::TileJSON;
 
 pub mod utils;
@@ -24,6 +25,12 @@ macro_rules! create_app {
                 ))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
+                .app_data(actix_web::web::Data::new(SrvConfig {
+                    keep_alive: None,
+                    listen_addresses: None,
+                    worker_processes: None,
+                    preferred_encoding: None,
+                }))
                 .configure(::martin::srv::router),
         )
         .await

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -25,12 +25,7 @@ macro_rules! create_app {
                 ))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
-                .app_data(actix_web::web::Data::new(SrvConfig {
-                    keep_alive: None,
-                    listen_addresses: None,
-                    worker_processes: None,
-                    preferred_encoding: None,
-                }))
+                .app_data(actix_web::web::Data::new(SrvConfig::default()))
                 .configure(::martin::srv::router),
         )
         .await

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -6,6 +6,7 @@ use actix_web::test::{call_and_read_body_json, call_service, read_body, TestRequ
 use ctor::ctor;
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
+use martin::srv::SrvConfig;
 use martin::OptOneMany;
 use tilejson::TileJSON;
 
@@ -28,6 +29,12 @@ macro_rules! create_app {
                 ))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
+                .app_data(actix_web::web::Data::new(SrvConfig {
+                    keep_alive: None,
+                    listen_addresses: None,
+                    worker_processes: None,
+                    preferred_encoding: None,
+                }))
                 .configure(::martin::srv::router),
         )
         .await

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -29,12 +29,7 @@ macro_rules! create_app {
                 ))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
-                .app_data(actix_web::web::Data::new(SrvConfig {
-                    keep_alive: None,
-                    listen_addresses: None,
-                    worker_processes: None,
-                    preferred_encoding: None,
-                }))
+                .app_data(actix_web::web::Data::new(SrvConfig::default()))
                 .configure(::martin::srv::router),
         )
         .await
@@ -1096,12 +1091,7 @@ tables:
             ))
             .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
             .app_data(actix_web::web::Data::new(state.tiles))
-            .app_data(actix_web::web::Data::new(SrvConfig {
-                keep_alive: None,
-                listen_addresses: None,
-                worker_processes: None,
-                preferred_encoding: None,
-            }))
+            .app_data(actix_web::web::Data::new(SrvConfig::default()))
             .configure(::martin::srv::router),
     )
     .await;

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -1096,6 +1096,12 @@ tables:
             ))
             .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
             .app_data(actix_web::web::Data::new(state.tiles))
+            .app_data(actix_web::web::Data::new(SrvConfig {
+                keep_alive: None,
+                listen_addresses: None,
+                worker_processes: None,
+                preferred_encoding: None,
+            }))
             .configure(::martin::srv::router),
     )
     .await;

--- a/martin/tests/pmt_server_test.rs
+++ b/martin/tests/pmt_server_test.rs
@@ -4,8 +4,8 @@ use ctor::ctor;
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
 use martin::decode_gzip;
-use tilejson::TileJSON;
 use martin::srv::SrvConfig;
+use tilejson::TileJSON;
 
 pub mod utils;
 pub use utils::*;
@@ -18,21 +18,21 @@ fn init() {
 macro_rules! create_app {
     ($sources:expr) => {{
         let state = mock_sources(mock_cfg($sources)).await.0;
-                ::actix_web::test::init_service(
-                    ::actix_web::App::new()
-                        .app_data(actix_web::web::Data::new(
-                            ::martin::srv::Catalog::new(&state).unwrap(),
-                        ))
-                        .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
-                        .app_data(actix_web::web::Data::new(state.tiles))
-                        .app_data(actix_web::web::Data::new(SrvConfig {
-                            keep_alive: None,
-                            listen_addresses: None,
-                            worker_processes: None,
-                            preferred_encoding: None,
-                        }))
-                        .configure(::martin::srv::router),
-                )
+        ::actix_web::test::init_service(
+            ::actix_web::App::new()
+                .app_data(actix_web::web::Data::new(
+                    ::martin::srv::Catalog::new(&state).unwrap(),
+                ))
+                .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
+                .app_data(actix_web::web::Data::new(state.tiles))
+                .app_data(actix_web::web::Data::new(SrvConfig {
+                    keep_alive: None,
+                    listen_addresses: None,
+                    worker_processes: None,
+                    preferred_encoding: None,
+                }))
+                .configure(::martin::srv::router),
+        )
         .await
     }};
 }

--- a/martin/tests/pmt_server_test.rs
+++ b/martin/tests/pmt_server_test.rs
@@ -25,12 +25,7 @@ macro_rules! create_app {
                 ))
                 .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
                 .app_data(actix_web::web::Data::new(state.tiles))
-                .app_data(actix_web::web::Data::new(SrvConfig {
-                    keep_alive: None,
-                    listen_addresses: None,
-                    worker_processes: None,
-                    preferred_encoding: None,
-                }))
+                .app_data(actix_web::web::Data::new(SrvConfig::default()))
                 .configure(::martin::srv::router),
         )
         .await

--- a/martin/tests/pmt_server_test.rs
+++ b/martin/tests/pmt_server_test.rs
@@ -5,6 +5,7 @@ use indoc::indoc;
 use insta::assert_yaml_snapshot;
 use martin::decode_gzip;
 use tilejson::TileJSON;
+use martin::srv::SrvConfig;
 
 pub mod utils;
 pub use utils::*;
@@ -17,15 +18,21 @@ fn init() {
 macro_rules! create_app {
     ($sources:expr) => {{
         let state = mock_sources(mock_cfg($sources)).await.0;
-        ::actix_web::test::init_service(
-            ::actix_web::App::new()
-                .app_data(actix_web::web::Data::new(
-                    ::martin::srv::Catalog::new(&state).unwrap(),
-                ))
-                .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
-                .app_data(actix_web::web::Data::new(state.tiles))
-                .configure(::martin::srv::router),
-        )
+                ::actix_web::test::init_service(
+                    ::actix_web::App::new()
+                        .app_data(actix_web::web::Data::new(
+                            ::martin::srv::Catalog::new(&state).unwrap(),
+                        ))
+                        .app_data(actix_web::web::Data::new(::martin::NO_MAIN_CACHE))
+                        .app_data(actix_web::web::Data::new(state.tiles))
+                        .app_data(actix_web::web::Data::new(SrvConfig {
+                            keep_alive: None,
+                            listen_addresses: None,
+                            worker_processes: None,
+                            preferred_encoding: None,
+                        }))
+                        .configure(::martin::srv::router),
+                )
         .await
     }};
 }


### PR DESCRIPTION
Try to fix #1178 

- [x] Add optional `--preferred-encoding` to cli, `br` `brotli` and `gzip` are allowed
- [x] Add optional `preferred-encoding` to config, `br` `brotli` and `gzip` are allowed
- [x] Add test
- [x] Update doc