### PR TITLE
Fix martin `--auto-bounds` silently ignored with `--config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "criterion",
  "ctor",
  "deadpool-postgres",
+ "enum-display",
  "env_logger",
  "flate2",
  "futures",

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -79,11 +79,13 @@ bit-set = { workspace = true, optional = true }
 brotli.workspace = true
 clap.workspace = true
 deadpool-postgres = { workspace = true, optional = true }
+enum-display.workspace = true
 env_logger.workspace = true
 flate2.workspace = true
 futures.workspace = true
 itertools.workspace = true
 json-patch = { workspace = true, optional = true }
+lambda-web = { workspace = true, optional = true }
 log.workspace = true
 martin-tile-utils.workspace = true
 mbtiles = { workspace = true, optional = true }
@@ -92,8 +94,8 @@ num_cpus.workspace = true
 pbf_font_tools = { workspace = true, optional = true }
 pmtiles = { workspace = true, optional = true }
 postgis = { workspace = true, optional = true }
-postgres-protocol = { workspace = true, optional = true }
 postgres = { workspace = true, optional = true }
+postgres-protocol = { workspace = true, optional = true }
 regex.workspace = true
 rustls-native-certs.workspace = true
 rustls-pemfile.workspace = true
@@ -110,7 +112,6 @@ tilejson.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
 tokio-postgres-rustls = { workspace = true, optional = true }
 url.workspace = true
-lambda-web = { workspace = true, optional = true }
 
 [dev-dependencies]
 cargo-husky.workspace = true

--- a/martin/src/args/pg.rs
+++ b/martin/src/args/pg.rs
@@ -41,7 +41,7 @@ pub struct PgArgs {
     /// If a spatial PG table has SRID 0, then this default SRID will be used as a fallback.
     #[arg(short, long)]
     pub default_srid: Option<i32>,
-    #[arg(help = format!("Maximum Postgres connections pool size [DEFAULT: {}]", POOL_SIZE_DEFAULT), short, long)]
+    #[arg(help = format!("Maximum Postgres connections pool size [DEFAULT: {POOL_SIZE_DEFAULT}]"), short, long)]
     pub pool_size: Option<usize>,
     /// Limit the number of features in a tile from a PG table source.
     #[arg(short, long)]

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -6,9 +6,9 @@ use crate::srv::{SrvConfig, KEEP_ALIVE_DEFAULT, LISTEN_ADDRESSES_DEFAULT};
 #[derive(clap::Args, Debug, PartialEq, Default)]
 #[command(about, version)]
 pub struct SrvArgs {
-    #[arg(help = format!("Connection keep alive timeout. [DEFAULT: {}]", KEEP_ALIVE_DEFAULT), short, long)]
+    #[arg(help = format!("Connection keep alive timeout. [DEFAULT: {KEEP_ALIVE_DEFAULT}]"), short, long)]
     pub keep_alive: Option<u64>,
-    #[arg(help = format!("The socket address to bind. [DEFAULT: {}]", LISTEN_ADDRESSES_DEFAULT), short, long)]
+    #[arg(help = format!("The socket address to bind. [DEFAULT: {LISTEN_ADDRESSES_DEFAULT}]"), short, long)]
     pub listen_addresses: Option<String>,
     /// Set TileJSON URL path prefix, ignoring X-Rewrite-URL header. Must begin with a `/`. Examples: `/`, `/tiles`
     #[arg(long)]


### PR DESCRIPTION
When starting martin with both `--auto-bounds` and `--config`, the auto-bounds param was silently ignored, but now it will notify of the override.