### PR TITLE
bug: ensure agg_tiles_hash_after_apply is added even on empty mbtiles

### DIFF
--- a/mbtiles/src/copier.rs
+++ b/mbtiles/src/copier.rs
@@ -235,6 +235,7 @@ impl MbtileCopierInt {
             // Also insert all names from sourceDb.metadata that do not exist in diffDb.metadata, with their value set to NULL.
             // Rename agg_tiles_hash to agg_tiles_hash_in_diff because agg_tiles_hash will be auto-added later
             if self.options.diff_with_file.is_some() {
+                // Include agg_tiles_hash value even if it is the same because we will still need it when applying the diff
                 sql = format!(
                     "
     INSERT {on_dupl} INTO metadata (name, value)
@@ -245,7 +246,7 @@ impl MbtileCopierInt {
                  , difMD.value as value
             FROM sourceDb.metadata AS srcMD FULL JOIN diffDb.metadata AS difMD
                  ON srcMD.name = difMD.name
-            WHERE srcMD.value != difMD.value OR srcMD.value ISNULL OR difMD.value ISNULL
+            WHERE srcMD.value != difMD.value OR srcMD.value ISNULL OR difMD.value ISNULL OR srcMD.name = '{AGG_TILES_HASH}'
         ) joinedMD
         WHERE name != '{AGG_TILES_HASH_IN_DIFF}'"
                 );

--- a/mbtiles/tests/snapshots/copy__databases@flat__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__dif_empty.snap
@@ -9,7 +9,10 @@ sql = '''
 CREATE TABLE metadata (
              name text NOT NULL PRIMARY KEY,
              value text)'''
-values = ['(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )']
+values = [
+    '(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )',
+    '(  "agg_tiles_hash_after_apply", "9ED9178D7025276336C783C2B54D6258"  )',
+]
 
 [[]]
 type = 'table'

--- a/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
@@ -9,7 +9,10 @@ sql = '''
 CREATE TABLE metadata (
              name text NOT NULL PRIMARY KEY,
              value text)'''
-values = ['(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )']
+values = [
+    '(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )',
+    '(  "agg_tiles_hash_after_apply", "9ED9178D7025276336C783C2B54D6258"  )',
+]
 
 [[]]
 type = 'table'

--- a/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
@@ -30,7 +30,10 @@ sql = '''
 CREATE TABLE metadata (
              name text NOT NULL PRIMARY KEY,
              value text)'''
-values = ['(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )']
+values = [
+    '(  "agg_tiles_hash", "D41D8CD98F00B204E9800998ECF8427E"  )',
+    '(  "agg_tiles_hash_after_apply", "9ED9178D7025276336C783C2B54D6258"  )',
+]
 
 [[]]
 type = 'index'


### PR DESCRIPTION
If a diff between two mbtiles is empty, `agg_tiles_hash_after_apply` must still be generated.  It was not before because two identical tilesets would have the same `agg_tiles_hash`, thus skipping the generation of `agg_tiles_hash_after_apply`