### PR TITLE
Update documentation for running with Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   fileserver:
     image: nginx:alpine

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -3,11 +3,9 @@
 You can use example [`docker-compose.yml`](https://raw.githubusercontent.com/maplibre/martin/main/docker-compose.yml) file as a reference
 
 ```yml
-version: '3'
-
 services:
   martin:
-    image: ghcr.io/maplibre/martin:v0.11.2
+    image: ghcr.io/maplibre/martin:v0.13.0
     restart: unless-stopped
     ports:
       - "3000:3000"
@@ -17,7 +15,7 @@ services:
       - db
 
   db:
-    image: postgis/postgis:14-3.3-alpine
+    image: postgis/postgis:16-3.4-alpine
     restart: unless-stopped
     environment:
       - POSTGRES_DB=db
@@ -31,13 +29,13 @@ services:
 First, you need to start `db` service
 
 ```shell
-docker-compose up -d db
+docker compose up -d db
 ```
 
 Then, after `db` service is ready to accept connections, you can start `martin`
 
 ```shell
-docker-compose up -d martin
+docker compose up -d martin
 ```
 
 By default, Martin will be available at [localhost:3000](http://localhost:3000/)


### PR DESCRIPTION
Some small changes to make the Docker compose documentation up to date:
- Update dependency versions of PostGIS and Martin
- Use the bundled `docker compose` extension, not `docker-compose`. (see https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose)
- Remove `version` from the Docker Compose file (see https://docs.docker.com/compose/compose-file/04-version-and-name/)