### PR TITLE
Upgrade to pmtiles, rm async-trait in a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,13 +2892,12 @@ dependencies = [
 
 [[package]]
 name = "pmtiles"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5382dab62c7151c9fb050626ad18560b4900e133257033782abb3b7ae23f2234"
+checksum = "a1336029dbfe273811a751f91e85a6011bcfe399c9b8d1ad9662e96df2a2d74e"
 dependencies = [
  "async-compression",
  "async-recursion",
- "async-trait",
  "bytes",
  "fmmap",
  "hilbert_2d",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ mbtiles = { path = "./mbtiles", version = "0.9.0" }
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 pbf_font_tools = { version = "2.5.1", features = ["freetype"] }
-pmtiles = { version = "0.8", features = ["http-async", "mmap-async-tokio", "tilejson", "reqwest-rustls-tls-native-roots"] }
+pmtiles = { version = "0.9", features = ["http-async", "mmap-async-tokio", "tilejson", "reqwest-rustls-tls-native-roots"] }
 postgis = "0.9"
 postgres = { version = "0.19", features = ["with-time-0_3", "with-uuid-1", "with-serde_json-1"] }
 postgres-protocol = "0.6"

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use async_trait::async_trait;
 use futures::TryFutureExt;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -61,15 +60,23 @@ pub trait ConfigExtras: Clone + Debug + Default + PartialEq + Send {
     fn get_unrecognized(&self) -> &UnrecognizedValues;
 }
 
-#[async_trait]
 pub trait SourceConfigExtras: ConfigExtras {
     #[must_use]
     fn parse_urls() -> bool {
         false
     }
-    async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<Box<dyn Source>>;
 
-    async fn new_sources_url(&self, id: String, url: Url) -> FileResult<Box<dyn Source>>;
+    fn new_sources(
+        &self,
+        id: String,
+        path: PathBuf,
+    ) -> impl std::future::Future<Output = FileResult<Box<dyn Source>>> + Send;
+
+    fn new_sources_url(
+        &self,
+        id: String,
+        url: Url,
+    ) -> impl std::future::Future<Output = FileResult<Box<dyn Source>>> + Send;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/martin/src/mbtiles/mod.rs
+++ b/martin/src/mbtiles/mod.rs
@@ -29,12 +29,14 @@ impl ConfigExtras for MbtConfig {
     }
 }
 
-#[async_trait]
 impl SourceConfigExtras for MbtConfig {
     async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<Box<dyn Source>> {
         Ok(Box::new(MbtSource::new(id, path).await?))
     }
 
+    // TODO: Remove #[allow] after switching to Rust/Clippy v1.78+ in CI
+    //       See https://github.com/rust-lang/rust-clippy/pull/12323
+    #[allow(clippy::no_effect_underscore_binding)]
     async fn new_sources_url(&self, _id: String, _url: Url) -> FileResult<Box<dyn Source>> {
         unreachable!()
     }

--- a/martin/src/pmtiles/mod.rs
+++ b/martin/src/pmtiles/mod.rs
@@ -39,7 +39,6 @@ impl PmtCache {
     }
 }
 
-#[async_trait]
 impl DirectoryCache for PmtCache {
     async fn get_dir_entry(&self, offset: usize, tile_id: u64) -> DirCacheResult {
         if let Some(dir) = get_cached_value!(&self.cache, CacheValue::PmtDirectory, {
@@ -129,7 +128,7 @@ impl ConfigExtras for PmtConfig {
         &self.unrecognized
     }
 }
-#[async_trait]
+
 impl SourceConfigExtras for PmtConfig {
     fn parse_urls() -> bool {
         true

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use futures::future::try_join_all;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -65,7 +64,6 @@ pub struct SpriteConfig {
     pub unrecognized: UnrecognizedValues,
 }
 
-#[async_trait]
 impl ConfigExtras for SpriteConfig {
     fn get_unrecognized(&self) -> &UnrecognizedValues {
         &self.unrecognized


### PR DESCRIPTION
* Bump to pmtiles that doesn't use `async_trait` crate
* `trait SourceConfigExtras` no longer needs `#[async_trait]`