### PR TITLE
Fix day picker when clicking the first day of a range 

### DIFF
--- a/demo/frontend/src/Components/Map/Filters/Filters.tsx
+++ b/demo/frontend/src/Components/Map/Filters/Filters.tsx
@@ -28,8 +28,11 @@ class Filters extends PureComponent<{visibleLayer, toggleLayer, range, hour, cha
 
   handleDayClick = (day) => {
     const range = addToRange(day, this.props.range);
-
-    this.props.changeFilter('range', range);
+    if (range) {
+      this.props.changeFilter('range', range);
+    } else {
+      this.props.changeFilter('range', { from: null, to: null });
+    }
   };
 
   changeTime = (e) => {

--- a/demo/frontend/src/Components/Map/Map.tsx
+++ b/demo/frontend/src/Components/Map/Map.tsx
@@ -44,9 +44,11 @@ class Map extends PureComponent<{}, {visibleLayer: any, range: any, hour: any}> 
   }
 
   componentDidUpdate() {
-    const newStyle = this.map.getStyle();
-    newStyle.sources['trips_source'].url = `/tiles/get_trips?${this.getQueryParams()}`;
-    this.map.setStyle(newStyle);
+    if (this.isQueryParamsComplete()) {
+      const newStyle = this.map.getStyle();
+      newStyle.sources['trips_source'].url = `/tiles/get_trips?${this.getQueryParams()}`;
+      this.map.setStyle(newStyle);
+    }
   }
 
   mapOnLoad = () => {
@@ -66,6 +68,11 @@ class Map extends PureComponent<{}, {visibleLayer: any, range: any, hour: any}> 
       ...state,
       [filter]: value
     }));
+  };
+
+  isQueryParamsComplete = () => {
+    const { range: { from, to } } = this.state;
+    return !!from && !!to;
   };
 
   getQueryParams = () => {


### PR DESCRIPTION
Filters were breaking when `addToRange` returned an undefined. [ This happens when the date you want to add is the start date of the range.](https://github.com/gpbl/react-day-picker/blob/9ad13dc72fff814dcf720a62f6e3b5ea38e8af6d/src/contexts/SelectRange/utils/addToRange.ts#L23-L24) Based on the `react-day-picker`, undefined range means neither from nor to where set. 

I did the following to fix this 
1. Set from and to to be null when range is undefined to not break destructuring
2. Add a condition to only update the tile url when all the needed query parameters are complete to prevent incomplete tile fetching 

https://github.com/maplibre/martin/assets/30991698/dfbf111a-c7e0-4a0f-97c8-098f0951e3c3


Closes #1193 