### PR TITLE
Update quick-start-linux.md

### DIFF
--- a/docs/src/quick-start-linux.md
+++ b/docs/src/quick-start-linux.md
@@ -5,10 +5,10 @@ mkdir martin
 cd martin
 
 # Download some sample data
-curl -O https://github.com/maplibre/martin/blob/main/tests/fixtures/mbtiles/world_cities.mbtiles
+curl -L -O https://github.com/maplibre/martin/blob/main/tests/fixtures/mbtiles/world_cities.mbtiles
 
 # Download the latest version of Martin binary, extract it, and make it executable
-curl -O https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-gnu.tar.gz 
+curl -L -O https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-gnu.tar.gz 
 tar -xzf martin-x86_64-unknown-linux-gnu.tar.gz
 chmod +x ./martin
 


### PR DESCRIPTION
Curl fails to follow redirects by default. 
Adding `-L` instructs it to follow them and allows Marlin to be downloaded.