### PR TITLE
Typo fix

### DIFF
--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -60,7 +60,7 @@ Every zip-based Lambda function runs a file called `bootstrap`.
 cat <<EOF >src/bootstrap
 #!/bin/sh
 set -eu
-exec martin --config ${_HANDLER}.yaml
+exec martin --config \${_HANDLER}.yaml
 EOF
 ```
 


### PR DESCRIPTION
I'm torn between "Run this bash script to create this file" and "The file should look like this" and open to ideas for clarity, but I think adding the backslash is more likely to be noticed by someone who creates the file without using the heredoc than the other way around.

Fixes #1335