### PR TITLE
add HEALTHCHECK instruction to the Dockerfile

### DIFF
--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -4,4 +4,5 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 
+HEALTHCHECK CMD curl --fail http://localhost:3000/health
 ENTRYPOINT ["/usr/local/bin/martin"]

--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -4,5 +4,5 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 
-HEALTHCHECK CMD curl --fail http://localhost:3000/health
+HEALTHCHECK CMD wget --spider http://localhost:3000/health || exit 1
 ENTRYPOINT ["/usr/local/bin/martin"]

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -40,3 +40,5 @@ docker compose up -d martin
 ```
 
 By default, Martin will be available at [localhost:3000](http://localhost:3000/)
+
+Official Docker image includes a `HEALTHCHECK` instruction which will be used by Docker Compose. Note that Compose won't restart unhealthy containers. To monitor and restart unhealthy containers you can use [Docker Autoheal](https://github.com/willfarrell/docker-autoheal).


### PR DESCRIPTION
Since Martin gives us `/health` endpoint we could use it by default in the Dockerfile.

I've added extra info to the doc about https://github.com/willfarrell/docker-autoheal but not sure if that's ok. I can remove it.