### PR TITLE
Improved glyph url handling: accept arbitrary suffixes after {end} #1443

### DIFF
--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -1,5 +1,5 @@
-use std::string::ToString;
 use std::str::FromStr;
+use std::string::ToString;
 
 use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use actix_web::web::{Data, Path};
@@ -41,9 +41,7 @@ impl FontRequest {
 )]
 #[allow(clippy::unused_async)]
 async fn get_font(path: Path<FontRequest>, fonts: Data<FontSources>) -> ActixResult<HttpResponse> {
-    let (start, end) = path.parse().map_err(|e| {
-        ErrorBadRequest(e.to_string())
-    })?;
+    let (start, end) = path.parse().map_err(|e| ErrorBadRequest(e.to_string()))?;
 
     let data = fonts
         .get_font_range(&path.fontstack, start, end)

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -25,7 +25,7 @@ impl FontRequest {
     }
 
     fn parse_leading_digits(input: &str) -> Result<u32, &'static str> {
-        let digits: String = input.chars().take_while(|c| c.is_digit(10)).collect();
+        let digits: String = input.chars().take_while(|c| c.is_ascii_digit()).collect();
         if digits.is_empty() {
             Err("No leading digits found")
         } else {

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -25,7 +25,7 @@ impl FontRequest {
     }
 
     fn parse_leading_digits(input: &str) -> Result<u32, &'static str> {
-        let digits: String = input.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let digits: String = input.chars().take_while(char::is_ascii_digit).collect();
         if digits.is_empty() {
             Err("No leading digits found")
         } else {

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -1,4 +1,5 @@
 use std::string::ToString;
+use std::str::FromStr;
 
 use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use actix_web::web::{Data, Path};
@@ -11,19 +12,41 @@ use crate::srv::server::map_internal_error;
 #[derive(Deserialize, Debug)]
 struct FontRequest {
     fontstack: String,
-    start: u32,
-    end: u32,
+    start: String,
+    end: String,
+}
+
+impl FontRequest {
+    fn parse(&self) -> Result<(u32, u32), &'static str> {
+        let start = u32::from_str(&self.start).map_err(|_| "Invalid start value")?;
+        let end = FontRequest::parse_leading_digits(&self.end)?;
+
+        Ok((start, end))
+    }
+
+    fn parse_leading_digits(input: &str) -> Result<u32, &'static str> {
+        let digits: String = input.chars().take_while(|c| c.is_digit(10)).collect();
+        if digits.is_empty() {
+            Err("No leading digits found")
+        } else {
+            digits.parse::<u32>().map_err(|_| "Failed to parse number")
+        }
+    }
 }
 
 #[route(
-    "/font/{fontstack}/{start}-{end}",
+    "/font/{fontstack}/{start}-{end}*",
     method = "GET",
     wrap = "middleware::Compress::default()"
 )]
 #[allow(clippy::unused_async)]
 async fn get_font(path: Path<FontRequest>, fonts: Data<FontSources>) -> ActixResult<HttpResponse> {
+    let (start, end) = path.parse().map_err(|e| {
+        ErrorBadRequest(e.to_string())
+    })?;
+
     let data = fonts
-        .get_font_range(&path.fontstack, path.start, path.end)
+        .get_font_range(&path.fontstack, start, end)
         .map_err(map_font_error)?;
     Ok(HttpResponse::Ok()
         .content_type("application/x-protobuf")


### PR DESCRIPTION
I have attempted to fix #1443 for myself just to challenge myself to write some Rust. I'm a total Rust newbie so please review with care.

This pull requests attempts to solve the problem that many styles out there add suffixes like '.pbf' to the glyph url at the end (see #1443 for examples). The change adds some parsing code to FontRequest that allows arbitrary suffixes after {{end}} and only returns the the leading digits of {{end}} as number for get_font_range. Everything after that is discarded. 

I hope that this way, the font server "just works" for most people and don't hit the issue that I did.