### PR TITLE
chore(tests): update `thiserror` to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -2424,7 +2424,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2547,7 +2547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2686,7 +2686,7 @@ dependencies = [
  "static-files",
  "subst",
  "testcontainers-modules",
- "thiserror",
+ "thiserror 2.0.3",
  "tilejson",
  "tokio",
  "tokio-postgres-rustls",
@@ -2731,7 +2731,7 @@ dependencies = [
  "sqlite-compressions",
  "sqlite-hashes",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.3",
  "tilejson",
  "tokio",
  "xxhash-rust",
@@ -2856,7 +2856,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.69",
  "triomphe",
  "uuid",
 ]
@@ -3168,7 +3168,7 @@ dependencies = [
  "protobuf-codegen",
  "protoc-bin-vendored",
  "sdf_glyph_renderer",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3311,7 +3311,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tilejson",
  "tokio",
  "varint-rs",
@@ -3413,7 +3413,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3471,7 +3471,7 @@ checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3486,7 +3486,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3501,7 +3501,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "which",
 ]
 
@@ -3511,7 +3511,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3608,7 +3608,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3625,7 +3625,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
 ]
@@ -4118,7 +4118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef220f6a4fff0c984e9fb3ab12cb5c86960b5bb6ec3b30dd7173e3bf603d94f"
 dependencies = [
  "freetype-rs",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4420,7 +4420,7 @@ dependencies = [
  "sdf_glyph_renderer",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4501,7 +4501,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4583,7 +4583,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -4621,7 +4621,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -4883,7 +4883,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tar",
@@ -4906,7 +4906,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -4914,6 +4923,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4929,7 +4949,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tuple",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio"] }
 static-files = "0.2"
 subst = { version = "0.3", features = ["yaml"] }
 testcontainers-modules = { version = "0.11.4", features = ["postgres"] }
-thiserror = "1"
+thiserror = "2"
 tile-grid = "0.6"
 tilejson = "0.4"
 tokio = { version = "1", features = ["macros"] }

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -21,19 +21,19 @@ pub type FileResult<T> = Result<T, FileError>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum FileError {
-    #[error("IO error {0}: {}", .1.display())]
+    #[error("IO error {0}: {1}")]
     IoError(std::io::Error, PathBuf),
 
-    #[error("Source path is not a file: {}", .0.display())]
+    #[error("Source path is not a file: {0}")]
     InvalidFilePath(PathBuf),
 
     #[error("Error {0} while parsing URL {1}")]
     InvalidSourceUrl(url::ParseError, String),
 
-    #[error("Source {0} uses bad file {}", .1.display())]
+    #[error("Source {0} uses bad file {1}")]
     InvalidSourceFilePath(String, PathBuf),
 
-    #[error(r"Unable to parse metadata in file {}: {0}", .1.display())]
+    #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidMetadata(String, PathBuf),
 
     #[error(r"Unable to parse metadata in file {1}: {0}")]

--- a/martin/src/fonts/mod.rs
+++ b/martin/src/fonts/mod.rs
@@ -52,13 +52,13 @@ pub enum FontError {
     #[error(transparent)]
     FreeType(#[from] pbf_font_tools::freetype::Error),
 
-    #[error("IO error accessing {}: {0}", .1.display())]
+    #[error("IO error accessing {1}: {0}")]
     IoError(std::io::Error, PathBuf),
 
-    #[error("Invalid font file {}", .0.display())]
+    #[error("Invalid font file {0}")]
     InvalidFontFilePath(PathBuf),
 
-    #[error("No font files found in {}", .0.display())]
+    #[error("No font files found in {0}")]
     NoFontFilesFound(PathBuf),
 
     #[error("Font {0} is missing a family name")]

--- a/martin/src/pg/errors.rs
+++ b/martin/src/pg/errors.rs
@@ -16,16 +16,16 @@ pub enum PgError {
     #[error("Cannot load platform root certificates: {0:?}")]
     CannotLoadRoots(Vec<rustls_native_certs::Error>),
 
-    #[error("Cannot open certificate file {}: {0}", .1.display())]
+    #[error("Cannot open certificate file {1}: {0}")]
     CannotOpenCert(#[source] io::Error, PathBuf),
 
-    #[error("Cannot parse certificate file {}: {0}", .1.display())]
+    #[error("Cannot parse certificate file {1}: {0}")]
     CannotParseCert(#[source] io::Error, PathBuf),
 
-    #[error("Unable to parse PEM RSA key file {}", .0.display())]
+    #[error("Unable to parse PEM RSA key file {0}")]
     InvalidPrivateKey(PathBuf),
 
-    #[error("Unable to use client certificate pair {} / {}: {0}", .1.display(), .2.display())]
+    #[error("Unable to use client certificate pair {1} / {2}: {0}")]
     CannotUseClientKey(#[source] rustls::Error, PathBuf, PathBuf),
 
     #[error(transparent)]
@@ -67,7 +67,7 @@ pub enum PgError {
     #[error(r#"Unable to get tile {2:#} from {1}: {0}"#)]
     GetTileError(#[source] TokioPgError, String, TileCoord),
 
-    #[error(r#"Unable to get tile {2:#} with {:?} params from {1}: {0}"#, query_to_json(.3.as_ref()))]
+    #[error(r#"Unable to get tile {2:#} with {json_query:?} params from {1}: {0}"#, json_query=query_to_json(.3.as_ref()))]
     GetTileWithQueryError(#[source] TokioPgError, String, TileCoord, Option<UrlQuery>),
 
     #[error("Configuration error: {0}")]

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -23,31 +23,31 @@ pub enum SpriteError {
     #[error("Sprite {0} not found")]
     SpriteNotFound(String),
 
-    #[error("IO error {0}: {}", .1.display())]
+    #[error("IO error {0}: {1}")]
     IoError(std::io::Error, PathBuf),
 
-    #[error("Sprite path is not a file: {}", .0.display())]
+    #[error("Sprite path is not a file: {0}")]
     InvalidFilePath(PathBuf),
 
-    #[error("Sprite {0} uses bad file {}", .1.display())]
+    #[error("Sprite {0} uses bad file {1}")]
     InvalidSpriteFilePath(String, PathBuf),
 
-    #[error("No sprite files found in {}", .0.display())]
+    #[error("No sprite files found in {0}")]
     NoSpriteFilesFound(PathBuf),
 
-    #[error("Sprite {} could not be loaded", .0.display())]
+    #[error("Sprite {0} could not be loaded")]
     UnableToReadSprite(PathBuf),
 
-    #[error("{0} in file {}", .1.display())]
+    #[error("{0} in file {1}")]
     SpriteProcessingError(SpreetError, PathBuf),
 
-    #[error("{0} in file {}", .1.display())]
+    #[error("{0} in file {1}")]
     SpriteParsingError(ResvgError, PathBuf),
 
     #[error("Unable to generate spritesheet")]
     UnableToGenerateSpritesheet,
 
-    #[error("Unable to create a sprite from file {}", .0.display())]
+    #[error("Unable to create a sprite from file {0}")]
     SpriteInstError(PathBuf),
 }
 

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -37,13 +37,13 @@ pub enum MartinError {
     #[error("Base path must be a valid URL path, and must begin with a '/' symbol, but is '{0}'")]
     BasePathError(String),
 
-    #[error("Unable to load config file {}: {0}", .1.display())]
+    #[error("Unable to load config file {1}: {0}")]
     ConfigLoadError(io::Error, PathBuf),
 
-    #[error("Unable to parse config file {}: {0}", .1.display())]
+    #[error("Unable to parse config file {1}: {0}")]
     ConfigParseError(subst::yaml::Error, PathBuf),
 
-    #[error("Unable to write config file {}: {0}", .1.display())]
+    #[error("Unable to write config file {1}: {0}")]
     ConfigWriteError(io::Error, PathBuf),
 
     #[error("No tile sources found. Set sources by giving a database connection string on command line, env variable, or a config file.")]

--- a/mbtiles/src/errors.rs
+++ b/mbtiles/src/errors.rs
@@ -7,10 +7,10 @@ use crate::{MbtType, AGG_TILES_HASH, AGG_TILES_HASH_AFTER_APPLY, AGG_TILES_HASH_
 
 #[derive(thiserror::Error, Debug)]
 pub enum MbtError {
-    #[error("The source and destination MBTiles files are the same: {}", .0.display())]
+    #[error("The source and destination MBTiles files are the same: {0}")]
     SameSourceAndDestination(PathBuf),
 
-    #[error("The diff file and source or destination MBTiles files are the same: {}", .0.display())]
+    #[error("The diff file and source or destination MBTiles files are the same: {0}")]
     SameDiffAndSourceOrDestination(PathBuf),
 
     #[error(transparent)]
@@ -22,7 +22,7 @@ pub enum MbtError {
     #[error(transparent)]
     JsonSerdeError(#[from] serde_json::Error),
 
-    #[error("MBTile filepath contains unsupported characters: {}", .0.display())]
+    #[error("MBTile filepath contains unsupported characters: {0}")]
     UnsupportedCharsInFilepath(PathBuf),
 
     #[error("Inconsistent tile formats detected: {0} vs {1}")]
@@ -72,7 +72,7 @@ pub enum MbtError {
     #[error("The MBTiles file {0} has data of type {1}, but the desired type was set to {2}")]
     MismatchedTargetType(PathBuf, MbtType, MbtType),
 
-    #[error("Unless  --on-duplicate (override|ignore|abort)  is set, writing tiles to an existing non-empty MBTiles file is disabled. Either set --on-duplicate flag, or delete {}", .0.display())]
+    #[error("Unless  --on-duplicate (override|ignore|abort)  is set, writing tiles to an existing non-empty MBTiles file is disabled. Either set --on-duplicate flag, or delete {0}")]
     DestinationFileExists(PathBuf),
 
     #[error("Invalid zoom value {0}={1}, expecting an integer between 0..{MAX_ZOOM}")]


### PR DESCRIPTION
This mainly follows https://github.com/dtolnay/thiserror/releases/tag/2.0.0 and should be fairly straightforeward