### PR TITLE
chore(deps): bump from `macos-14` to `macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-14  # M1 CPU
+            os: macos-latest  # M-series CPU
           - target: debian-x86_64
             os: ubuntu-latest
           - target: x86_64-apple-darwin


### PR DESCRIPTION
not related to the actual macos CI failour, but we might want to bump the secondary macos test up to `-latest`

On the related note:
I could not get to the bottom to the actual `macos-13` issue. Would it be possible to just drop it and replace it with `macos-latest`?