### PR TITLE
docs: fix security policy linking and add citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+
+# Parser settings.
+cff-version: 1.2.0
+message: Please cite this crate using these information.
+
+# Version information.
+date-released: 2024-11-29
+version: 4.5.21
+
+# Project information.
+abstract: Vector Tiles from Large Databases on the Fly
+authors:
+  - alias: nyurik
+    family-names: Astrakhan
+    given-names: Yuri
+  - name: The maplibre Community
+license:
+  - MIT
+  - Apache-2.0
+repository-artifact: https://martin.maplibre.org
+repository-code: https://github.com/maplibre/martin
+title: Martin
+url: https://martin.maplibre.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Security Policy
 
 For an up-to-date policy refer to
-https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt
+<https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,4 @@
+# Security Policy
+
 For an up-to-date policy refer to
 https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt


### PR DESCRIPTION
Github currently does not recognise the security policy => lets rename said file to something that I know works.

![image](https://github.com/user-attachments/assets/2d4180a6-3f68-455c-8ce0-6088c4ac25f9)

This PR also adds a citation badge, which might be nice (we can drop said commit if you don't like it)