### PR TITLE
chore: snapshots on sorted test output

### DIFF
--- a/martin/tests/pg_table_source_test.rs
+++ b/martin/tests/pg_table_source_test.rs
@@ -15,6 +15,7 @@ fn init() {
 #[actix_rt::test]
 async fn table_source() {
     let mock = mock_sources(mock_pgcfg("connection_string: $DATABASE_URL")).await;
+    insta::with_settings!({sort_maps => true}, {
     assert_yaml_snapshot!(mock.0.tiles.get_catalog(), @r#"
     "-function.withweired---_-characters":
       content_type: application/x-protobuf
@@ -88,6 +89,7 @@ async fn table_source() {
       content_type: application/x-protobuf
       description: public.table_source_multiple_geom.geom2
     "#);
+    });
 
     let source = table(&mock, "table_source");
     assert_yaml_snapshot!(source, @r"

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -1,4 +1,29 @@
 {
+  "fonts": {
+    "Overpass Mono Light": {
+      "end": 64258,
+      "family": "Overpass Mono",
+      "glyphs": 931,
+      "start": 0,
+      "style": "Light"
+    },
+    "Overpass Mono Regular": {
+      "end": 64258,
+      "family": "Overpass Mono",
+      "glyphs": 931,
+      "start": 0,
+      "style": "Regular"
+    }
+  },
+  "sprites": {
+    "src1": {
+      "images": [
+        "another_bicycle",
+        "bear",
+        "sub/circle"
+      ]
+    }
+  },
   "tiles": {
     "-function.withweired---_-characters": {
       "content_type": "application/x-protobuf",
@@ -69,28 +94,28 @@
     },
     "geography-class-jpg": {
       "content_type": "image/jpeg",
-      "name": "Geography Class",
-      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. "
+      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. ",
+      "name": "Geography Class"
     },
     "geography-class-jpg-diff": {
       "content_type": "image/jpeg",
-      "name": "Geography Class",
-      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. "
+      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. ",
+      "name": "Geography Class"
     },
     "geography-class-jpg-modified": {
       "content_type": "image/jpeg",
-      "name": "Geography Class",
-      "description": "A modified version of one of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips."
+      "description": "A modified version of one of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips.",
+      "name": "Geography Class"
     },
     "geography-class-png": {
       "content_type": "image/png",
-      "name": "Geography Class",
-      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. "
+      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. ",
+      "name": "Geography Class"
     },
     "geography-class-png-no-bounds": {
       "content_type": "image/png",
-      "name": "Geography Class",
-      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. "
+      "description": "One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. ",
+      "name": "Geography Class"
     },
     "json": {
       "content_type": "application/json",
@@ -105,9 +130,9 @@
       "description": "public.points1.geom"
     },
     "points1_vw": {
+      "attribution": "some attribution from SQL comment",
       "content_type": "application/x-protobuf",
-      "description": "description from SQL comment",
-      "attribution": "some attribution from SQL comment"
+      "description": "description from SQL comment"
     },
     "points2": {
       "content_type": "application/x-protobuf",
@@ -141,8 +166,8 @@
     },
     "uncompressed_mvt": {
       "content_type": "application/x-protobuf",
-      "name": "Major cities from Natural Earth data",
-      "description": "Major cities from Natural Earth data"
+      "description": "Major cities from Natural Earth data",
+      "name": "Major cities from Natural Earth data"
     },
     "webp": {
       "content_type": "image/webp",
@@ -153,53 +178,28 @@
       "name": "ne2sr"
     },
     "world_cities": {
-      "content_type": "application/x-protobuf",
       "content_encoding": "gzip",
-      "name": "Major cities from Natural Earth data",
-      "description": "Major cities from Natural Earth data"
+      "content_type": "application/x-protobuf",
+      "description": "Major cities from Natural Earth data",
+      "name": "Major cities from Natural Earth data"
     },
     "world_cities_diff": {
-      "content_type": "application/x-protobuf",
       "content_encoding": "gzip",
-      "name": "Major cities from Natural Earth data",
-      "description": "Major cities from Natural Earth data"
+      "content_type": "application/x-protobuf",
+      "description": "Major cities from Natural Earth data",
+      "name": "Major cities from Natural Earth data"
     },
     "world_cities_modified": {
-      "content_type": "application/x-protobuf",
       "content_encoding": "gzip",
-      "name": "Major cities from Natural Earth data",
-      "description": "A modified version of major cities from Natural Earth data"
+      "content_type": "application/x-protobuf",
+      "description": "A modified version of major cities from Natural Earth data",
+      "name": "Major cities from Natural Earth data"
     },
     "zoomed_world_cities": {
-      "content_type": "application/x-protobuf",
       "content_encoding": "gzip",
-      "name": "Major cities from Natural Earth data",
-      "description": "Major cities from Natural Earth data"
-    }
-  },
-  "sprites": {
-    "src1": {
-      "images": [
-        "another_bicycle",
-        "bear",
-        "sub/circle"
-      ]
-    }
-  },
-  "fonts": {
-    "Overpass Mono Light": {
-      "family": "Overpass Mono",
-      "style": "Light",
-      "glyphs": 931,
-      "start": 0,
-      "end": 64258
-    },
-    "Overpass Mono Regular": {
-      "family": "Overpass Mono",
-      "style": "Regular",
-      "glyphs": 931,
-      "start": 0,
-      "end": 64258
+      "content_type": "application/x-protobuf",
+      "description": "Major cities from Natural Earth data",
+      "name": "Major cities from Natural Earth data"
     }
   }
 }

--- a/tests/expected/auto/cmp.json
+++ b/tests/expected/auto/cmp.json
@@ -1,28 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/table_source,points1,points2/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "table_source",
-      "fields": {
-        "gid": "int4"
-      }
-    },
-    {
-      "id": "points1",
-      "fields": {
-        "gid": "int4"
-      }
-    },
-    {
-      "id": "points2",
-      "fields": {
-        "gid": "int4"
-      }
-    }
-  ],
   "bounds": [
     -179.27313970132585,
     -80.46177157848345,
@@ -30,5 +6,29 @@
     84.93092095128937
   ],
   "description": "public.points1.geom\npublic.points2.geom",
-  "name": "table_source,points1,points2"
+  "name": "table_source,points1,points2",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/table_source,points1,points2/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "table_source"
+    },
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "points1"
+    },
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "points2"
+    }
+  ]
 }

--- a/tests/expected/auto/fnc.json
+++ b/tests/expected/auto/fnc.json
@@ -1,10 +1,10 @@
 {
+  "foo": {
+    "bar": "foo"
+  },
+  "name": "function_zxy_query",
   "tilejson": "3.0.0",
   "tiles": [
     "http://localhost:3111/function_zxy_query/{z}/{x}/{y}"
-  ],
-  "name": "function_zxy_query",
-  "foo": {
-    "bar": "foo"
-  }
+  ]
 }

--- a/tests/expected/auto/fnc_b.json
+++ b/tests/expected/auto/fnc_b.json
@@ -1,8 +1,8 @@
 {
+  "description": "public.function_zxy_query_jsonb",
+  "name": "function_zxy_query_jsonb",
   "tilejson": "3.0.0",
   "tiles": [
     "http://localhost:3111/function_zxy_query_jsonb/{z}/{x}/{y}"
-  ],
-  "description": "public.function_zxy_query_jsonb",
-  "name": "function_zxy_query_jsonb"
+  ]
 }

--- a/tests/expected/auto/fnc_comment.json
+++ b/tests/expected/auto/fnc_comment.json
@@ -1,17 +1,17 @@
 {
+  "description": "a function source with MixedCase name",
+  "name": "function_Mixed_Name",
   "tilejson": "3.0.0",
   "tiles": [
     "http://localhost:3111/function_Mixed_Name/{z}/{x}/{y}"
   ],
   "vector_layers": [
     {
-      "id": "MixedCase.function_Mixed_Name",
       "fields": {
         "Geom": "",
         "TABLE": ""
-      }
+      },
+      "id": "MixedCase.function_Mixed_Name"
     }
-  ],
-  "description": "a function source with MixedCase name",
-  "name": "function_Mixed_Name"
+  ]
 }

--- a/tests/expected/auto/fnc_token.json
+++ b/tests/expected/auto/fnc_token.json
@@ -1,8 +1,8 @@
 {
+  "description": "public.function_zxy_query_test",
+  "name": "function_zxy_query_test",
   "tilejson": "3.0.0",
   "tiles": [
     "http://localhost:3111/function_zxy_query_test/{z}/{x}/{y}"
-  ],
-  "description": "public.function_zxy_query_test",
-  "name": "function_zxy_query_test"
+  ]
 }

--- a/tests/expected/auto/mb_jpg.json
+++ b/tests/expected/auto/mb_jpg.json
@@ -1,8 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/geography-class-jpg/{z}/{x}/{y}"
-  ],
   "bounds": [
     -180,
     -85.0511,
@@ -15,5 +11,9 @@
   "minzoom": 0,
   "name": "Geography Class",
   "template": "{{#__location__}}{{/__location__}}{{#__teaser__}}<div style=\"text-align:center;\">\n\n<img src=\"data:image/png;base64,{{flag_png}}\" style=\"-moz-box-shadow:0px 1px 3px #222;-webkit-box-shadow:0px 1px 5px #222;box-shadow:0px 1px 3px #222;\"><br>\n<strong>{{admin}}</strong>\n\n</div>{{/__teaser__}}{{#__full__}}{{/__full__}}",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/geography-class-jpg/{z}/{x}/{y}"
+  ],
   "version": "1.0.0"
 }

--- a/tests/expected/auto/mb_mvt.json
+++ b/tests/expected/auto/mb_mvt.json
@@ -1,19 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/world_cities/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "cities",
-      "fields": {
-        "name": "String"
-      },
-      "description": "",
-      "maxzoom": 6,
-      "minzoom": 0
-    }
-  ],
   "bounds": [
     -123.12359,
     -37.818085,
@@ -26,9 +11,24 @@
     6
   ],
   "description": "Major cities from Natural Earth data",
+  "format": "pbf",
   "maxzoom": 6,
   "minzoom": 0,
   "name": "Major cities from Natural Earth data",
-  "version": "2",
-  "format": "pbf"
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/world_cities/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "description": "",
+      "fields": {
+        "name": "String"
+      },
+      "id": "cities",
+      "maxzoom": 6,
+      "minzoom": 0
+    }
+  ],
+  "version": "2"
 }

--- a/tests/expected/auto/mb_png.json
+++ b/tests/expected/auto/mb_png.json
@@ -1,8 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/geography-class-png/{z}/{x}/{y}"
-  ],
   "bounds": [
     -180,
     -85.0511,
@@ -20,5 +16,9 @@
   "minzoom": 0,
   "name": "Geography Class",
   "template": "{{#__location__}}{{/__location__}}{{#__teaser__}}<div style=\"text-align:center;\">\n\n<img src=\"data:image/png;base64,{{flag_png}}\" style=\"-moz-box-shadow:0px 1px 3px #222;-webkit-box-shadow:0px 1px 5px #222;box-shadow:0px 1px 3px #222;\"><br>\n<strong>{{admin}}</strong>\n\n</div>{{/__teaser__}}{{#__full__}}{{/__full__}}",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/geography-class-png/{z}/{x}/{y}"
+  ],
   "version": "1.0.0"
 }

--- a/tests/expected/auto/pmt.json
+++ b/tests/expected/auto/pmt.json
@@ -1,8 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/stamen_toner__raster_CC-BY-ODbL_z3/{z}/{x}/{y}"
-  ],
   "bounds": [
     -180,
     -85,
@@ -15,5 +11,9 @@
     0
   ],
   "maxzoom": 3,
-  "minzoom": 0
+  "minzoom": 0,
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/stamen_toner__raster_CC-BY-ODbL_z3/{z}/{x}/{y}"
+  ]
 }

--- a/tests/expected/auto/points3857_srid.json
+++ b/tests/expected/auto/points3857_srid.json
@@ -1,16 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/points3857/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "points3857",
-      "fields": {
-        "gid": "int4"
-      }
-    }
-  ],
   "bounds": [
     -161.40590777554058,
     -81.50727021609012,
@@ -18,5 +6,17 @@
     84.2440187164111
   ],
   "description": "public.points3857.geom",
-  "name": "points3857"
+  "name": "points3857",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/points3857/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "points3857"
+    }
+  ]
 }

--- a/tests/expected/auto/table_source.json
+++ b/tests/expected/auto/table_source.json
@@ -1,24 +1,24 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/table_source/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "table_source",
-      "fields": {
-        "gid": "int4"
-      }
-    }
-  ],
   "bounds": [
     -2,
     -1,
     142.84131509869133,
     45
   ],
-  "name": "table_source",
   "foo": {
     "bar": "foo"
-  }
+  },
+  "name": "table_source",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/table_source/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "table_source"
+    }
+  ]
 }

--- a/tests/expected/auto/tbl_comment.json
+++ b/tests/expected/auto/tbl_comment.json
@@ -1,17 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/MixPoints/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "MixPoints",
-      "fields": {
-        "Gid": "int4",
-        "TABLE": "text"
-      }
-    }
-  ],
   "bounds": [
     -170.94984639004662,
     -84.20025580733805,
@@ -19,5 +6,18 @@
     74.23573284753762
   ],
   "description": "a description from comment on table",
-  "name": "MixPoints"
+  "name": "MixPoints",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/MixPoints/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "Gid": "int4",
+        "TABLE": "text"
+      },
+      "id": "MixPoints"
+    }
+  ]
 }

--- a/tests/expected/auto_mini/catalog_auto.json
+++ b/tests/expected/auto_mini/catalog_auto.json
@@ -1,10 +1,10 @@
 {
+  "fonts": {},
+  "sprites": {},
   "tiles": {
     "webp2": {
       "content_type": "image/webp",
       "name": "ne2sr"
     }
-  },
-  "sprites": {},
-  "fonts": {}
+  }
 }

--- a/tests/expected/configured/catalog_cfg.json
+++ b/tests/expected/configured/catalog_cfg.json
@@ -1,4 +1,34 @@
 {
+  "fonts": {
+    "Overpass Mono Light": {
+      "end": 64258,
+      "family": "Overpass Mono",
+      "glyphs": 931,
+      "start": 0,
+      "style": "Light"
+    },
+    "Overpass Mono Regular": {
+      "end": 64258,
+      "family": "Overpass Mono",
+      "glyphs": 931,
+      "start": 0,
+      "style": "Regular"
+    }
+  },
+  "sprites": {
+    "mysrc": {
+      "images": [
+        "bicycle"
+      ]
+    },
+    "src1": {
+      "images": [
+        "another_bicycle",
+        "bear",
+        "sub/circle"
+      ]
+    }
+  },
   "tiles": {
     "MixPoints": {
       "content_type": "application/x-protobuf",
@@ -48,36 +78,6 @@
     "webp2": {
       "content_type": "image/webp",
       "name": "ne2sr"
-    }
-  },
-  "sprites": {
-    "mysrc": {
-      "images": [
-        "bicycle"
-      ]
-    },
-    "src1": {
-      "images": [
-        "another_bicycle",
-        "bear",
-        "sub/circle"
-      ]
-    }
-  },
-  "fonts": {
-    "Overpass Mono Light": {
-      "family": "Overpass Mono",
-      "style": "Light",
-      "glyphs": 931,
-      "start": 0,
-      "end": 64258
-    },
-    "Overpass Mono Regular": {
-      "family": "Overpass Mono",
-      "style": "Regular",
-      "glyphs": 931,
-      "start": 0,
-      "end": 64258
     }
   }
 }

--- a/tests/expected/configured/cmp.json
+++ b/tests/expected/configured/cmp.json
@@ -1,28 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/table_source,points1,points2/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "table_source",
-      "fields": {
-        "gid": "int4"
-      }
-    },
-    {
-      "id": "abc",
-      "fields": {
-        "gid": "int4"
-      }
-    },
-    {
-      "id": "points2",
-      "fields": {
-        "gid": "int4"
-      }
-    }
-  ],
   "bounds": [
     -180,
     -90,
@@ -32,5 +8,29 @@
   "description": "public.points1.geom\npublic.points2.geom",
   "maxzoom": 30,
   "minzoom": 0,
-  "name": "table_source,points1,points2"
+  "name": "table_source,points1,points2",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/table_source,points1,points2/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "table_source"
+    },
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "abc"
+    },
+    {
+      "fields": {
+        "gid": "int4"
+      },
+      "id": "points2"
+    }
+  ]
 }

--- a/tests/expected/configured/fnc_comment_cfg.json
+++ b/tests/expected/configured/fnc_comment_cfg.json
@@ -1,17 +1,17 @@
 {
+  "description": "a function source with MixedCase name",
+  "name": "fnc_Mixed_Name",
   "tilejson": "3.0.0",
   "tiles": [
     "http://localhost:3111/fnc_Mixed_Name/{z}/{x}/{y}"
   ],
   "vector_layers": [
     {
-      "id": "MixedCase.function_Mixed_Name",
       "fields": {
         "Geom": "",
         "TABLE": ""
-      }
+      },
+      "id": "MixedCase.function_Mixed_Name"
     }
-  ],
-  "description": "a function source with MixedCase name",
-  "name": "fnc_Mixed_Name"
+  ]
 }

--- a/tests/expected/configured/sdf_spr_cmp.json
+++ b/tests/expected/configured/sdf_spr_cmp.json
@@ -2,33 +2,33 @@
   "another_bicycle": {
     "height": 21,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 21,
     "x": 26,
-    "y": 22,
-    "sdf": true
+    "y": 22
   },
   "bear": {
     "height": 22,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 22,
     "x": 26,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "bicycle": {
     "height": 21,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 21,
     "x": 0,
-    "y": 26,
-    "sdf": true
+    "y": 26
   },
   "sub/circle": {
     "height": 26,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 26,
     "x": 0,
-    "y": 0,
-    "sdf": true
+    "y": 0
   }
 }

--- a/tests/expected/configured/sdf_spr_cmp_2.json
+++ b/tests/expected/configured/sdf_spr_cmp_2.json
@@ -2,33 +2,33 @@
   "another_bicycle": {
     "height": 36,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 36,
     "x": 84,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "bear": {
     "height": 38,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 38,
     "x": 46,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "bicycle": {
     "height": 36,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 36,
     "x": 84,
-    "y": 36,
-    "sdf": true
+    "y": 36
   },
   "sub/circle": {
     "height": 46,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 46,
     "x": 0,
-    "y": 0,
-    "sdf": true
+    "y": 0
   }
 }

--- a/tests/expected/configured/sdf_spr_mysrc.json
+++ b/tests/expected/configured/sdf_spr_mysrc.json
@@ -2,9 +2,9 @@
   "bicycle": {
     "height": 36,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 36,
     "x": 0,
-    "y": 0,
-    "sdf": true
+    "y": 0
   }
 }

--- a/tests/expected/configured/sdf_spr_src1.json
+++ b/tests/expected/configured/sdf_spr_src1.json
@@ -2,25 +2,25 @@
   "another_bicycle": {
     "height": 21,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 21,
     "x": 26,
-    "y": 22,
-    "sdf": true
+    "y": 22
   },
   "bear": {
     "height": 22,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 22,
     "x": 26,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "sub/circle": {
     "height": 26,
     "pixelRatio": 1,
+    "sdf": true,
     "width": 26,
     "x": 0,
-    "y": 0,
-    "sdf": true
+    "y": 0
   }
 }

--- a/tests/expected/configured/sdf_spr_src1_.json
+++ b/tests/expected/configured/sdf_spr_src1_.json
@@ -2,25 +2,25 @@
   "another_bicycle": {
     "height": 36,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 36,
     "x": 84,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "bear": {
     "height": 38,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 38,
     "x": 46,
-    "y": 0,
-    "sdf": true
+    "y": 0
   },
   "sub/circle": {
     "height": 46,
     "pixelRatio": 2,
+    "sdf": true,
     "width": 46,
     "x": 0,
-    "y": 0,
-    "sdf": true
+    "y": 0
   }
 }

--- a/tests/expected/configured/tbl_comment_cfg.json
+++ b/tests/expected/configured/tbl_comment_cfg.json
@@ -1,17 +1,4 @@
 {
-  "tilejson": "3.0.0",
-  "tiles": [
-    "http://localhost:3111/MixPoints/{z}/{x}/{y}"
-  ],
-  "vector_layers": [
-    {
-      "id": "MixPoints",
-      "fields": {
-        "Gid": "int4",
-        "TABLE": "text"
-      }
-    }
-  ],
   "bounds": [
     -170.94984639004662,
     -84.20025580733805,
@@ -19,5 +6,18 @@
     74.23573284753762
   ],
   "description": "a description from comment on table",
-  "name": "MixPoints"
+  "name": "MixPoints",
+  "tilejson": "3.0.0",
+  "tiles": [
+    "http://localhost:3111/MixPoints/{z}/{x}/{y}"
+  ],
+  "vector_layers": [
+    {
+      "fields": {
+        "Gid": "int4",
+        "TABLE": "text"
+      },
+      "id": "MixPoints"
+    }
+  ]
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -83,7 +83,7 @@ test_jsn() {
 
   echo "Testing $(basename "$FILENAME") from $URL"
   # jq before 1.6 had a different float->int behavior, so trying to make it consistent in all
-  $CURL "$URL" | jq -e 'walk(if type == "number" then .+0.0 else . end)' > "$FILENAME"
+  $CURL "$URL" | jq --sort-keys -e 'walk(if type == "number" then .+0.0 else . end)' > "$FILENAME"
 }
 
 test_pbf() {


### PR DESCRIPTION
This PR splits out the test reproducibility fix from #1585

Currently, these fields not being sorted does not pose an issue, but with #1585, it would at least be differnt
=> we likely should not rely upon this in our CI