### PR TITLE
temporary disable macos-13 testcase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - target: x86_64-apple-darwin
-            os: macos-13
+          # temporary disabled due to an issue with homebrew which is difficult to debug
+          # - target: x86_64-apple-darwin
+          #   os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: '.exe'


### PR DESCRIPTION
as noted [here](https://github.com/maplibre/martin/pull/1590#issuecomment-2554888404), this testcase is causing more trouble currently and at least I could not really debug it due to a lack of a macbook ^^