### PR TITLE
fix: `trivially_copy_pass_by_ref` lint

### DIFF
--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -57,8 +57,8 @@ impl Format {
 
     /// Get the `format` value as it should be stored in the `MBTiles` metadata table
     #[must_use]
-    pub fn metadata_format_value(&self) -> &'static str {
-        match *self {
+    pub fn metadata_format_value(self) -> &'static str {
+        match self {
             Self::Gif => "gif",
             Self::Jpeg => "jpeg",
             Self::Json => "json",
@@ -82,8 +82,8 @@ impl Format {
     }
 
     #[must_use]
-    pub fn is_detectable(&self) -> bool {
-        match *self {
+    pub fn is_detectable(self) -> bool {
+        match self {
             Self::Png | Self::Jpeg | Self::Gif | Self::Webp => true,
             // TODO: Json can be detected, but currently we only detect it
             //       when it's not compressed, so to avoid a warning, keeping it as false for now.
@@ -143,8 +143,8 @@ impl Encoding {
     }
 
     #[must_use]
-    pub fn is_encoded(&self) -> bool {
-        match *self {
+    pub fn is_encoded(self) -> bool {
+        match self {
             Self::Uncompressed | Self::Internal => false,
             Self::Gzip | Self::Zlib | Self::Brotli | Self::Zstd => true,
         }


### PR DESCRIPTION
As noticed in https://github.com/maplibre/martin/pull/1649, this lint fails if chainging the default and thus making it run.

For `Copy`-enums this should basically be the same thing, should as far as I understood not even be an API-breaking change.

Perf-wise, the compiler should be able to optimise it the same way in the end
=> sadly likely won't have a performance impact