### PR TITLE
feat: Made the configuration options for web_ui more lenient

### DIFF
--- a/martin/src/args/mod.rs
+++ b/martin/src/args/mod.rs
@@ -13,4 +13,6 @@ mod root;
 pub use root::{Args, ExtraArgs, MetaArgs};
 
 mod srv;
-pub use srv::{PreferredEncoding, SrvArgs, WebUiMode};
+#[cfg(feature = "webui")]
+pub use srv::WebUiMode;
+pub use srv::{PreferredEncoding, SrvArgs};

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -29,6 +29,7 @@ pub struct SrvArgs {
     pub web_ui: Option<WebUiMode>,
 }
 
+#[cfg(feature = "webui")]
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Default, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum WebUiMode {
@@ -41,6 +42,8 @@ pub enum WebUiMode {
     // #[serde(alias = "true")]
     // Enable,
     /// Enable Web UI interface on all connections
+    #[serde(alias = "enable-for-all")]
+    #[clap(alias("enable-for-all"))]
     EnableForAll,
 }
 


### PR DESCRIPTION
During experimentation I noticed that the lowercased `enableforall`-value has a very narrow value range.
Being a bit more lenient with this value might be better