### PR TITLE
fix Changelog.md being chosen as a source for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,9 +653,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
           files: 'target/files/*'
-          body_path: CHANGELOG.md
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
both `body_part` and `draft` override the current text.
That is really annoying and must be a bug, but I don't think we need this functionality (do we?)

I don't know if we want `generate_release_notes`. I have added it, but we might not want this..

(and I should have used my fork, sorry)