### PR TITLE
add a version warning for Postgis<3.5

### DIFF
--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -50,15 +50,19 @@ impl PgPool {
         if pg_ver < MINIMUM_POSTGRES_VERSION {
             return Err(PostgresqlTooOld(pg_ver, MINIMUM_POSTGRES_VERSION));
         }
-        if pg_ver < RECOMMENDED_POSTGRES_VERSION {
-            warn!(
-                "PostgreSQL {pg_ver} is older than the recommended {RECOMMENDED_POSTGRES_VERSION}."
-            );
-        }
 
         let postgis_ver = get_postgis_version(&conn).await?;
         if postgis_ver < MINIMUM_POSTGIS_VERSION {
             return Err(PostgisTooOld(postgis_ver, MINIMUM_POSTGIS_VERSION));
+        }
+
+        // In the warning cases below, we could technically run.
+        // This is not ideal for reasons explained in the warnings
+
+        if pg_ver < RECOMMENDED_POSTGRES_VERSION {
+            warn!(
+                "PostgreSQL {pg_ver} is older than the recommended minimum {RECOMMENDED_POSTGRES_VERSION}."
+            );
         }
         let margin_not_supported = postgis_ver < ST_TILE_ENVELOPE_POSTGIS_VERSION;
         if margin_not_supported {

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -33,7 +33,7 @@ pub struct PgPool {
     /// Indicates if `ST_TileEnvelope` supports the margin parameter.
     ///
     /// `true` if running postgis >= 3.1
-    /// This being `False` indicates that tiles may be cut off at the edges.
+    /// This being `false` indicates that tiles may be cut off at the edges.
     supports_tile_margin: bool,
 }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -70,7 +70,7 @@ impl PgPool {
             warn!("PostGIS {postgis_ver} is older than {ST_TILE_ENVELOPE_POSTGIS_VERSION}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
         }
         if postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION {
-            warn!("PostGIS {postgis_ver} is older than the recommended minimum {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
+            warn!("PostGIS {postgis_ver} is older than the recommended minimum {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In the used version, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
         }
 
         info!("Connected to PostgreSQL {pg_ver} / PostGIS {postgis_ver} for source {id}");

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -70,7 +70,7 @@ impl PgPool {
         }
         let tiles_could_be_missing_geometry = postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION;
         if tiles_could_be_missing_geometry {
-            warn!("PostGIS {postgis_ver} is older than the recommended {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
+            warn!("PostGIS {postgis_ver} is older than the recommended minimum {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
         }
 
         info!("Connected to PostgreSQL {pg_ver} / PostGIS {postgis_ver} for source {id}");

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -65,8 +65,8 @@ impl PgPool {
                 "PostgreSQL {pg_ver} is older than the recommended minimum {RECOMMENDED_POSTGRES_VERSION}."
             );
         }
-        let margin_not_supported = postgis_ver < ST_TILE_ENVELOPE_POSTGIS_VERSION;
-        if margin_not_supported {
+        let supports_tile_margin = postgis_ver >= ST_TILE_ENVELOPE_POSTGIS_VERSION;
+        if !supports_tile_margin {
             warn!("PostGIS {postgis_ver} is older than {ST_TILE_ENVELOPE_POSTGIS_VERSION}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
         }
         if postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION {
@@ -78,7 +78,7 @@ impl PgPool {
         Ok(Self {
             id,
             pool,
-            supports_tile_margin: !margin_not_supported,
+            supports_tile_margin,
         })
     }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -65,7 +65,7 @@ impl PgPool {
             warn!("PostGIS {postgis_ver} is older than {ST_TILE_ENVELOPE_POSTGIS_VERSION}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
         }
         let tiles_could_be_missing_geometry = postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION;
-        if !tiles_could_be_missing_geometry {
+        if tiles_could_be_missing_geometry {
             warn!("PostGIS {postgis_ver} is older than the recommended {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
         }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -30,10 +30,11 @@ const RECOMMENDED_POSTGRES_VERSION: Version = Version::new(12, 0, 0);
 pub struct PgPool {
     id: String,
     pool: Pool,
-    /// Indicates if the margin parameter in `ST_TileEnvelope` is supported.
+    /// Indicates if `ST_TileEnvelope` supports the margin parameter.
     ///
+    /// `True` if running postgis >= 3.1
     /// This being `False` indicates that tiles may be cut off at the edges.
-    st_envelope_margin_is_supported: bool,
+    supports_tile_margin: bool,
 }
 
 impl PgPool {
@@ -78,7 +79,7 @@ impl PgPool {
         Ok(Self {
             id,
             pool,
-            st_envelope_margin_is_supported: !margin_not_supported,
+            supports_tile_margin: !margin_not_supported,
         })
     }
 
@@ -127,13 +128,13 @@ impl PgPool {
         self.id.as_str()
     }
 
-    /// Indicates if the margin parameter in `ST_TileEnvelope` is supported.
+    /// Indicates if `ST_TileEnvelope` supports the margin parameter.
     ///
-    /// `True` if running postgis >= 3.1
+    /// `True` if running postgis >= `3.1`
     /// This being false indicates that tiles may be cut off at the edges.
     #[must_use]
     pub fn supports_tile_margin(&self) -> bool {
-        self.st_envelope_margin_is_supported
+        self.supports_tile_margin
     }
 }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -129,7 +129,7 @@ impl PgPool {
 
     /// Indicates if `ST_TileEnvelope` supports the margin parameter.
     ///
-    /// `True` if running postgis >= `3.1`
+    /// `true` if running postgis >= `3.1`
     /// This being false indicates that tiles may be cut off at the edges.
     #[must_use]
     pub fn supports_tile_margin(&self) -> bool {

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -32,7 +32,7 @@ pub struct PgPool {
     pool: Pool,
     /// Indicates if `ST_TileEnvelope` supports the margin parameter.
     ///
-    /// `True` if running postgis >= 3.1
+    /// `true` if running postgis >= 3.1
     /// This being `False` indicates that tiles may be cut off at the edges.
     supports_tile_margin: bool,
 }

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -69,8 +69,7 @@ impl PgPool {
         if margin_not_supported {
             warn!("PostGIS {postgis_ver} is older than {ST_TILE_ENVELOPE_POSTGIS_VERSION}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
         }
-        let tiles_could_be_missing_geometry = postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION;
-        if tiles_could_be_missing_geometry {
+        if postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION {
             warn!("PostGIS {postgis_ver} is older than the recommended minimum {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
         }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -15,13 +15,16 @@ pub const POOL_SIZE_DEFAULT: usize = 20;
 
 /// We require `ST_TileEnvelope` that was added in [`PostGIS 3.0.0`](https://postgis.net/2019/10/PostGIS-3.0.0/)
 /// See <https://postgis.net/docs/ST_TileEnvelope.html>
-const MINIMUM_POSTGIS_VER: Version = Version::new(3, 0, 0);
-/// Minimum version of postgres required for [`MINIMUM_POSTGIS_VER`] according to the [Support Matrix](https://trac.osgeo.org/postgis/wiki/UsersWikiPostgreSQLPostGIS)
-const MINIMUM_POSTGRES_VER: Version = Version::new(11, 0, 0);
+const MINIMUM_POSTGIS_VERSION: Version = Version::new(3, 0, 0);
+/// Minimum version of postgres required for [`MINIMUM_POSTGIS_VERSION`] according to the [Support Matrix](https://trac.osgeo.org/postgis/wiki/UsersWikiPostgreSQLPostGIS)
+const MINIMUM_POSTGRES_VERSION: Version = Version::new(11, 0, 0);
 /// After this [`PostGIS`](https://postgis.net/) version we can use margin parameter in `ST_TileEnvelope`
-const RECOMMENDED_POSTGIS_VER: Version = Version::new(3, 1, 0);
-/// Minimum version of postgres required for [`RECOMMENDED_POSTGIS_VER`] according to the [Support Matrix](https://trac.osgeo.org/postgis/wiki/UsersWikiPostgreSQLPostGIS)
-const RECOMMENDED_POSTGRES_VER: Version = Version::new(12, 0, 0);
+const ST_TILE_ENVELOPE_POSTGIS_VERSION: Version = Version::new(3, 1, 0);
+/// Before this [`PostGIS`](https://postgis.net/) version, some geometry was missing in some cases.
+/// One example is lines not drawing at zoom level 0, but every other level for very long lines.
+const MISSING_GEOM_FIXED_POSTGIS_VERSION: Version = Version::new(3, 5, 0);
+/// Minimum version of postgres required for [`RECOMMENDED_POSTGIS_VERSION`] according to the [Support Matrix](https://trac.osgeo.org/postgis/wiki/UsersWikiPostgreSQLPostGIS)
+const RECOMMENDED_POSTGRES_VERSION: Version = Version::new(12, 0, 0);
 
 #[derive(Clone, Debug)]
 pub struct PgPool {
@@ -42,21 +45,26 @@ impl PgPool {
 
         let conn = get_conn(&pool, &id).await?;
         let pg_ver = get_postgres_version(&conn).await?;
-        if pg_ver < MINIMUM_POSTGRES_VER {
-            return Err(PostgresqlTooOld(pg_ver, MINIMUM_POSTGRES_VER));
+        if pg_ver < MINIMUM_POSTGRES_VERSION {
+            return Err(PostgresqlTooOld(pg_ver, MINIMUM_POSTGRES_VERSION));
         }
-        if pg_ver < RECOMMENDED_POSTGRES_VER {
-            warn!("PostgreSQL {pg_ver} is older than the recommended {RECOMMENDED_POSTGRES_VER}.");
+        if pg_ver < RECOMMENDED_POSTGRES_VERSION {
+            warn!("PostgreSQL {pg_ver} is older than the recommended {RECOMMENDED_POSTGRES_VERSION}.");
         }
 
         let postgis_ver = get_postgis_version(&conn).await?;
-        if postgis_ver < MINIMUM_POSTGIS_VER {
-            return Err(PostgisTooOld(postgis_ver, MINIMUM_POSTGIS_VER));
+        if postgis_ver < MINIMUM_POSTGIS_VERSION {
+            return Err(PostgisTooOld(postgis_ver, MINIMUM_POSTGIS_VERSION));
         }
-        let margin = postgis_ver >= RECOMMENDED_POSTGIS_VER;
-        if !margin {
-            warn!("PostGIS {postgis_ver} is older than the recommended {RECOMMENDED_POSTGIS_VER}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
+        let margin_not_supported = postgis_ver < ST_TILE_ENVELOPE_POSTGIS_VERSION;
+        if margin_not_supported {
+            warn!("PostGIS {postgis_ver} is older than {ST_TILE_ENVELOPE_POSTGIS_VERSION}. Margin parameter in ST_TileEnvelope is not supported, so tiles may be cut off at the edges.");
         }
+        let tiles_could_be_missing_geometry = postgis_ver < MISSING_GEOM_FIXED_POSTGIS_VERSION;
+        if !tiles_could_be_missing_geometry {
+            warn!("PostGIS {postgis_ver} is older than the recommended {MISSING_GEOM_FIXED_POSTGIS_VERSION}. In prior versions, some geometry may be hidden on some zoom levels. If You encounter this bug, please consider updating your postgis installation. For further details please refer to https://github.com/maplibre/martin/issues/1651#issuecomment-2628674788");
+        }
+
 
         info!("Connected to PostgreSQL {pg_ver} / PostGIS {postgis_ver} for source {id}");
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -186,7 +186,8 @@ validate_log() {
   # Older versions of PostGIS don't support the margin parameter, so we need to remove it from the log
   remove_line "$LOG_FILE" 'Margin parameter in ST_TileEnvelope is not supported'
   remove_line "$LOG_FILE" 'Source IDs must be unique'
-  remove_line "$LOG_FILE" 'PostgreSQL 11.10.0 is older than the recommended 12.0.0'
+  remove_line "$LOG_FILE" 'PostgreSQL 11.10.0 is older than the recommended minimum 12.0.0'
+  remove_line "$LOG_FILE" 'In the used version, some geometry may be hidden on some zoom levels.'
 
   echo "Checking for no other warnings or errors in the log"
   if grep -e ' ERROR ' -e ' WARN ' "$LOG_FILE"; then


### PR DESCRIPTION
could not go to sleep, so PR instead.. insomnia is a bitch ^^

This adds a version warning for postgis<3.5

Yes, it might be a bit too early too tell, but all signs point to older versions being buggy.
Lets keep https://github.com/maplibre/martin/issues/1651 open to keep tabs on weather the upstream issue changes.