### PR TITLE
fix: make docker-`HEALTHCHECK` only query ipv4 by default 

### DIFF
--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -4,5 +4,5 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 
-HEALTHCHECK CMD wget --spider http://localhost:3000/health || exit 1
+HEALTHCHECK CMD wget --spider http://127.0.0.1:3000/health || exit 1
 ENTRYPOINT ["/usr/local/bin/martin"]


### PR DESCRIPTION
This PR changes the docker-`HEALTHCHECK` only query ipv4 by default.

Thanks @SmallhillCZ for the report ❤️
Resolves: #1674