### PR TITLE
docs: change default `max_feature_count` documentation to null

### DIFF
--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -69,8 +69,7 @@ postgres:
   # If the source table has more features than set here, they will not be included in the tile and the result will look "cut off"/incomplete.
   # This feature allows to put a maximum latency bound on tiles with extreme amount of detail at the cost of not returning all data.
   # It is sensible to set this limit if you have user generated/untrusted geodata, e.g. a lot of data points at [Null Island](https://en.wikipedia.org/wiki/Null_Island).
-  # `null` (the default): Unlimited
-  max_feature_count: 100_000
+  max_feature_count: max_feature_count: null # null=unlimited (default), but can also be a positive integer
 
   # Control the automatic generation of bounds for spatial tables [default: quick]
   # 'calc' - compute table geometry bounds on startup.

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -69,7 +69,7 @@ postgres:
   # If the source table has more features than set here, they will not be included in the tile and the result will look "cut off"/incomplete.
   # This feature allows to put a maximum latency bound on tiles with extreme amount of detail at the cost of not returning all data.
   # It is sensible to set this limit if you have user generated/untrusted geodata, e.g. a lot of data points at [Null Island](https://en.wikipedia.org/wiki/Null_Island).
-  max_feature_count: max_feature_count: null # null=unlimited (default), but can also be a positive integer
+  max_feature_count: null # either a positive integer, or null=unlimited (default)
 
   # Control the automatic generation of bounds for spatial tables [default: quick]
   # 'calc' - compute table geometry bounds on startup.


### PR DESCRIPTION
I think `null` is less confusing for users than `~`..
Feel free to overrule ^^

Maybe adding an enum and having `unlimited|null|usize` be the options would be less confusing?

If we were to accept breakage (I don't think we should), `unlimited|NonZeroUsize` would likely be a better choice.