### PR TITLE
Remove cog doc

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,7 +20,7 @@
   - [PostgreSQL Table Sources](sources-pg-tables.md)
   - [PostgreSQL Function Sources](sources-pg-functions.md)
   - [MBTiles and PMTiles File Sources](sources-files.md)
-  - [Cloud Optimized GeoTIFF File Sources](sources-cog-files.md)
+  <!-- - [Cloud Optimized GeoTIFF File Sources](sources-cog-files.md) -->
   - [Composite Sources](sources-composite.md)
   - [Sprite Sources](sources-sprites.md)
   - [Font Sources](sources-fonts.md)


### PR DESCRIPTION
To load tiles from COG the fields in  #1676  is required. To make the users not confusing, I suggested to remove the doc of cog before
* find generally way to support non web mercator tile grid in martin
* find the way to tell user the fields in #1676 


Let's see cog as a nightly feature I will keep working on this.

And I've pinned the #343 , get more inspiration form other repos and talk more there!

@nyurik 

