### PR TITLE
fix:added the latency-correction option to `oha`

### DIFF
--- a/justfile
+++ b/justfile
@@ -119,12 +119,12 @@ bench-server: start
 bench-http: (cargo-install "oha")
     @echo "ATTENTION: Make sure Martin was started with    just bench-server"
     @echo "Warming up..."
-    oha -z 5s --no-tui http://localhost:3000/function_zxy_query/18/235085/122323 > /dev/null
-    oha -z 60s  http://localhost:3000/function_zxy_query/18/235085/122323
-    oha -z 5s --no-tui http://localhost:3000/png/0/0/0 > /dev/null
-    oha -z 60s  http://localhost:3000/png/0/0/0
-    oha -z 5s --no-tui http://localhost:3000/stamen_toner__raster_CC-BY-ODbL_z3/0/0/0 > /dev/null
-    oha -z 60s  http://localhost:3000/stamen_toner__raster_CC-BY-ODbL_z3/0/0/0
+    oha --latency-correction -z 5s --no-tui http://localhost:3000/function_zxy_query/18/235085/122323 > /dev/null
+    oha --latency-correction -z 60s         http://localhost:3000/function_zxy_query/18/235085/122323
+    oha --latency-correction -z 5s --no-tui http://localhost:3000/png/0/0/0 > /dev/null
+    oha --latency-correction -z 60s         http://localhost:3000/png/0/0/0
+    oha --latency-correction -z 5s --no-tui http://localhost:3000/stamen_toner__raster_CC-BY-ODbL_z3/0/0/0 > /dev/null
+    oha --latency-correction -z 60s         http://localhost:3000/stamen_toner__raster_CC-BY-ODbL_z3/0/0/0
 
 # Run all tests using a test database
 test: start (test-cargo "--all-targets") test-doc test-int


### PR DESCRIPTION
This fixes this issue in our benchmarking via `oha`

> `--latency-correction`
> Correct latency to avoid coordinated omission problem.
  
=> explained here https://youtu.be/lJ8ydIuPFeU?si=mBPFMMeZyLTk3cOV&t=953