### PR TITLE
chore: made sure that the log output from pg-functions is more unified

### DIFF
--- a/tests/fixtures/functions/function_zxy_query.sql
+++ b/tests/fixtures/functions/function_zxy_query.sql
@@ -4,7 +4,7 @@ CREATE OR REPLACE FUNCTION public.function_zxy_query(z integer, x integer, y int
 DECLARE
   mvt bytea;
 BEGIN
-  RAISE NOTICE 'query: %', query;
+  RAISE DEBUG 'function got query: %', query;
 
   SELECT INTO mvt ST_AsMVT(tile, 'public.function_zxy_query', 4096, 'geom') FROM (
     SELECT

--- a/tests/fixtures/functions/function_zxy_query_jsonb.sql
+++ b/tests/fixtures/functions/function_zxy_query_jsonb.sql
@@ -4,7 +4,7 @@ CREATE OR REPLACE FUNCTION public.function_zxy_query_jsonb(z integer, x integer,
 DECLARE
   mvt bytea;
 BEGIN
-  RAISE NOTICE 'query: %', query;
+  RAISE DEBUG 'function got query: %', query;
 
   SELECT INTO mvt ST_AsMVT(tile, 'public.function_zxy_query_jsonb', 4096, 'geom') FROM (
     SELECT

--- a/tests/fixtures/functions/function_zxy_query_test.sql
+++ b/tests/fixtures/functions/function_zxy_query_test.sql
@@ -4,7 +4,7 @@ CREATE OR REPLACE FUNCTION public.function_zxy_query_test(z integer, x integer, 
 DECLARE
   mvt bytea;
 BEGIN
-  RAISE DEBUG 'query_params: %', query_params;
+  RAISE DEBUG 'function got query_params: %', query_params;
 
   IF (query_params->>'token')::varchar IS NULL THEN
     RAISE EXCEPTION 'the `token` json parameter does not exist in `query_params`';


### PR DESCRIPTION
Curetly, these calls are just ignored.
This is because `tracing` is used in `tokio_postgres`.

Quite anoying one, but not a large contributor to tracing being a tad bit slower than `log`