### PR TITLE
chore: add additional metadata to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/maplibre/martin"
 rust-version = "1.80"
-readme = "README.md"
 homepage = "https://martin.maplibre.org/"
 
 [workspace.lints.rust]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -16,7 +16,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
-readme = "README.md"
 
 [dependencies]
 brotli.workspace = true

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -15,6 +15,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+homepage.workspace = true
+readme = "README.md"
 
 [dependencies]
 brotli.workspace = true

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -12,7 +12,6 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-readme = "README.md"
 homepage.workspace = true
 
 [package.metadata.deb]

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -12,7 +12,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 homepage = "https://maplibre.org/martin/tools.html#mbtiles"
-readme = "README.md"
 
 [features]
 default = ["cli"]

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -11,6 +11,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+homepage = "https://maplibre.org/martin/tools.html#mbtiles"
+readme = "README.md"
 
 [features]
 default = ["cli"]


### PR DESCRIPTION
During #1720 I noticed that these fields are missing
This PR adds them for completeness ^^