### PR TITLE
fix `clippy::unnecessary_semicolon`

### DIFF
--- a/martin/src/cog/source.rs
+++ b/martin/src/cog/source.rs
@@ -94,7 +94,7 @@ impl CogSource {
             tile_idx = idx;
         } else {
             return Ok(Vec::new());
-        };
+        }
         let decode_result = decoder
             .read_chunk(tile_idx)
             .map_err(|e| CogError::ReadChunkFailed(e, tile_idx, *ifd, self.path.clone()))?;
@@ -272,7 +272,7 @@ fn verify_requirments(decoder: &mut Decoder<File>, path: &Path) -> Result<(), Co
             color_type,
             path.to_path_buf(),
         ))?;
-    };
+    }
     Ok(())
 }
 

--- a/martin/src/pg/pool.rs
+++ b/martin/src/pg/pool.rs
@@ -114,7 +114,7 @@ impl PgPool {
                 SslModeOverride::VerifyFull => {
                     info!("Using sslmode=verify-full to connect: {pg_cfg:?}");
                 }
-            };
+            }
             let connector = make_connector(&config.ssl_certificates, ssl_mode)?;
             Manager::from_config(pg_cfg, connector, mgr_config)
         };

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -88,7 +88,7 @@ impl SpriteSources {
                 configs.insert(id.clone(), source.clone());
                 results.add_source(id, source.abs_path()?);
             }
-        };
+        }
 
         for path in cfg.paths {
             let Some(name) = path.file_name() else {

--- a/martin/src/styles/mod.rs
+++ b/martin/src/styles/mod.rs
@@ -57,7 +57,7 @@ impl StyleSources {
                     );
                 }
             }
-        };
+        }
 
         let mut paths_with_names = Vec::new();
         for base_path in cfg.paths {

--- a/mbtiles/src/bindiff.rs
+++ b/mbtiles/src/bindiff.rs
@@ -396,7 +396,7 @@ impl BinDiffer<ApplierBefore, ApplierAfter> for BinDiffPatcher {
 
         if self.patch_type == BinDiffGz {
             new_tile = encode_gzip(&new_tile)?;
-        };
+        }
 
         Ok(ApplierAfter {
             coord: value.coord,

--- a/mbtiles/src/copier.rs
+++ b/mbtiles/src/copier.rs
@@ -264,7 +264,7 @@ impl MbtileCopierInt {
             self.dst_mbt
                 .set_metadata_value(&mut conn, AGG_TILES_HASH_AFTER_APPLY, &hash)
                 .await?;
-        };
+        }
 
         // TODO: perhaps disable all except --copy all when using with diffs, or else is not making much sense
         if self.options.copy.copy_tiles() && !self.options.skip_agg_tiles_hash {
@@ -582,7 +582,7 @@ impl MbtileCopierInt {
             }
         } else {
             init_mbtiles_schema(&mut *conn, dst).await?;
-        };
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Fixes the clippy lint issue from #1774 