### PR TITLE
chore: don't build webclient for docs.rs

### DIFF
--- a/martin/build.rs
+++ b/martin/build.rs
@@ -103,5 +103,7 @@ fn webui() {
 
 fn main() {
     #[cfg(feature = "webui")]
-    webui();
+    if std::env::var_os("RUSTDOC").is_none() {
+        webui();
+    }
 }


### PR DESCRIPTION
Resolves #1784

This was tested by
- adding a panic inside the if-clause and seeing it not get triggered for `cargo doc` and
- by `cargo run` producing a working frontend