### PR TITLE
Fix minor typo in API Endpoints header docs page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,7 +28,7 @@
     - [Sprites](sources-sprites.md)
     - [Styles](sources-styles.md)
     - [Fonts](sources-fonts.md)
-- [Avaliable API Endpoints](using.md)
+- [Available API Endpoints](using.md)
 - [Guides](using-guides.md)
   - [Map renderer specific](using-with-renderer.md)
     - [MapLibre](using-with-maplibre.md)


### PR DESCRIPTION
Adjust `Avaliable` => `Available` for API Endpoints docs page.