### PR TITLE
feat: remove wastefull `Dashmap` from the catalog

### DIFF
--- a/martin/src/fonts/mod.rs
+++ b/martin/src/fonts/mod.rs
@@ -12,6 +12,7 @@ use pbf_font_tools::protobuf::Message;
 use pbf_font_tools::{Fontstack, Glyphs, PbfFontError, render_sdf_glyph};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::OptOneMany;
 
@@ -108,7 +109,7 @@ pub struct FontSources {
     masks: Vec<BitSet>,
 }
 
-pub type FontCatalog = DashMap<String, CatalogFontEntry>;
+pub type FontCatalog = HashMap<String, CatalogFontEntry>;
 
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 use actix_web::error::ErrorNotFound;
@@ -7,6 +6,7 @@ use dashmap::DashMap;
 use log::debug;
 use martin_tile_utils::{TileCoord, TileInfo};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tilejson::TileJSON;
 
 use crate::MartinResult;
@@ -20,7 +20,7 @@ pub type TileInfoSources = Vec<TileInfoSource>;
 
 #[derive(Default, Clone)]
 pub struct TileSources(DashMap<String, TileInfoSource>);
-pub type TileCatalog = DashMap<String, CatalogSourceEntry>;
+pub type TileCatalog = HashMap<String, CatalogSourceEntry>;
 
 impl TileSources {
     #[must_use]

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
 
@@ -56,7 +57,7 @@ pub struct CatalogSpriteEntry {
     pub images: Vec<String>,
 }
 
-pub type SpriteCatalog = DashMap<String, CatalogSpriteEntry>;
+pub type SpriteCatalog = HashMap<String, CatalogSpriteEntry>;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct SpriteConfig {
@@ -109,7 +110,7 @@ impl SpriteSources {
 
     pub fn get_catalog(&self) -> SpriteResult<SpriteCatalog> {
         // TODO: all sprite generation should be pre-cached
-        let entries = SpriteCatalog::new();
+        let mut entries = SpriteCatalog::new();
         for source in &self.0 {
             let paths = get_svg_input_paths(&source.path, true)
                 .map_err(|e| SpriteProcessingError(e, source.path.clone()))?;

--- a/martin/src/styles/mod.rs
+++ b/martin/src/styles/mod.rs
@@ -1,7 +1,7 @@
 use dashmap::{DashMap, Entry};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
@@ -13,7 +13,7 @@ pub struct CatalogStyleEntry {
     pub path: PathBuf,
 }
 
-pub type StyleCatalog = DashMap<String, CatalogStyleEntry>;
+pub type StyleCatalog = HashMap<String, CatalogStyleEntry>;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct StyleConfig {
@@ -99,7 +99,7 @@ impl StyleSources {
     /// an external representation of the internal catalog
     #[must_use]
     pub fn get_catalog(&self) -> StyleCatalog {
-        let entries = StyleCatalog::new();
+        let mut entries = StyleCatalog::new();
         for source in &self.0 {
             entries.insert(
                 source.key().clone(),


### PR DESCRIPTION
Change the wastefull dashmap::Dashmap from the catalog to `std::collections::HashMap`.
We are only using it to return values, so concurency here is just waste.