### PR TITLE
feat(docker): add labels, pin alpine tag to the latest version

### DIFF
--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -7,6 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/maplibre/martin"
 LABEL org.opencontainers.image.licenses="Apache-2.0 OR MIT"
 LABEL org.opencontainers.image.documentation="https://maplibre.org/martin/"
 LABEL org.opencontainers.image.vendor="maplibre"
+LABEL org.opencontainers.image.authors="Yuri Astrakhan, Stepan Kuzmin and MapLibre contributors"
 
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 

--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -5,6 +5,8 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 LABEL org.opencontainers.image.source="https://github.com/maplibre/martin"
 LABEL org.opencontainers.image.licenses="Apache-2.0 OR MIT"
+LABEL org.opencontainers.image.documentation="https://maplibre.org/martin/"
+LABEL org.opencontainers.image.vendor="maplibre"
 
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 

--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
-LABEL org.opencontainers.image.source="https://github.com/maplibre/martin" 
+LABEL org.opencontainers.image.source="https://github.com/maplibre/martin"
 LABEL org.opencontainers.image.licenses="Apache-2.0 OR MIT"
 
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin

--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.21
 
 ARG TARGETPLATFORM
 

--- a/.github/files/multi-platform.Dockerfile
+++ b/.github/files/multi-platform.Dockerfile
@@ -1,7 +1,11 @@
-FROM alpine
+FROM alpine:latest
+
 ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.description="Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
+LABEL org.opencontainers.image.source="https://github.com/maplibre/martin" 
+LABEL org.opencontainers.image.licenses="Apache-2.0 OR MIT"
+
 COPY target_releases/$TARGETPLATFORM/* /usr/local/bin
 
 HEALTHCHECK CMD wget --spider http://127.0.0.1:3000/health || exit 1


### PR DESCRIPTION
Just a few minimal `Dockerfile` improvements.

---

Adds the following standardized `Dockerfile` Labels: 
```dockerfile
LABEL org.opencontainers.image.source="https://github.com/maplibre/martin" 
LABEL org.opencontainers.image.licenses="Apache-2.0 OR MIT"
```

I've noticed that some dependency upgrade tools (`renovate`, `dependabot`, ...) can't fetch the martin changelog when creating Bump MRs.  `org.opencontainers.image.source` should alleviate that..
Providing the licenses also doesn't hurt. 

---

Furthermore I've pinned the tag to `latest`, which makes it a bit cleaner. (same behavior as not pinning the tag at all).
Pinning to a fixed version would be better - but without some sort of automation, keeping the tag up-to-date can be a hassle. 

Seems like there are no problems regarding CI image caching however, as `martin` is already using the newest alpine version:

```bash
docker run --entrypoint /bin/sh ghcr.io/maplibre/martin:v0.16.0 -c "cat /etc/os-release""
```
```
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.21.3
PRETTY_NAME="Alpine Linux v3.21"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
```

