### PR TITLE
Update run-with-docker-compose.md to support styles serving

### DIFF
--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:v0.13.0
+    image: ghcr.io/maplibre/martin:v0.16.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -16,7 +16,7 @@ services:
       - db
 
   db:
-    image: postgis/postgis:16-3.4-alpine
+    image: postgis/postgis:17-3.5-alpine
     restart: unless-stopped
     environment:
       - POSTGRES_DB=db


### PR DESCRIPTION
I have lost a couple hours this morning trying to serve my styles, after tracing your pull request where you add this features i find out that i was using the wrong version of martin (copied from this file of the docs).

Maybe you could add a conf file validation when the server start, to check if there are some incompatible values.