### PR TITLE
fix: `clippy::uninlined_format_args`

### DIFF
--- a/martin/src/cog/source.rs
+++ b/martin/src/cog/source.rs
@@ -598,7 +598,7 @@ mod tests {
                 // Both are None, which is expected
             }
             _ => {
-                panic!("Origin {:?} does not match expected {:?}", origin, expected);
+                panic!("Origin {origin:?} does not match expected {expected:?}");
             }
         }
     }


### PR DESCRIPTION
somehow this sneaked into main. Maybe due to the new rust release.