### PR TITLE
Ignore `DANGER_ACCEPT_INVALID_CERTS` env var

### DIFF
--- a/martin/src/args/pg.rs
+++ b/martin/src/args/pg.rs
@@ -140,7 +140,6 @@ impl PgArgs {
         }
 
         for v in &[
-            "DANGER_ACCEPT_INVALID_CERTS",
             "DATABASE_URL",
             "DEFAULT_SRID",
             "PGSSLCERT",
@@ -283,7 +282,6 @@ mod tests {
             vec![
                 ("DATABASE_URL", os("postgres://localhost:5432")),
                 ("DEFAULT_SRID", os("10")),
-                ("DANGER_ACCEPT_INVALID_CERTS", os("1")),
                 ("PGSSLROOTCERT", os("file")),
             ]
             .into_iter()


### PR DESCRIPTION
Remove any special handling of the obsolete `DANGER_ACCEPT_INVALID_CERTS` env var. It was used a while ago, but I don't think we have any usage of it now.