### PR TITLE
feat(new-dockerfile): try annotating both at index and manifest level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
             org.opencontainers.image.description=Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.source=https://github.com/maplibre/martin
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build linux/arm64 Docker image
         uses: docker/build-push-action@v6
         # https://github.com/docker/build-push-action


### PR DESCRIPTION
this is a followup to 
- #1877 

Apparently, github does not accept the metadata being there.. ridiculous.
lets add it to the manifest,index

this is the last PR tampering with docker metadata, I swear.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYXp0bmZ2aGRuZzJ6NnFyYXM4M3p3Z2FibGQ1bWt3ZG1keW9zb2VlMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IPlurp1TLz8rrJHZwj/giphy.gif"/>