### PR TITLE
chore(ci): merged docker load step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,25 @@ jobs:
         env:
           PGPORT: ${{ job.services.postgres.ports[5432] }}
 
+      # we want to test our docker images before we push them to the registry
+      # this is done by
+      # - building multi-arch images
+      # - executing the test script against each arch via docker
+      # - pushing them to the registry
+      #
+      # We need the containerd image store, as otherwise multi-arch cannot be loaded => https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
+      # > The default image store in Docker Engine doesn't support loading multi-platform images.
+      # > You can enable the containerd image store, or push multi-platform images is to directly push to a registry
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # https://github.com/docker/setup-qemu-action
@@ -202,15 +221,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/maplibre/martin
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-      # we want to test our docker images before we push them to the registry
-      # this is done by
-      # - building single-arch images
-      # - and  executing the test script against said docker container
-      #
-      # using single-arch images here is intentional, because multi-arch cannot be loaded => https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
-      # > The default image store in Docker Engine doesn't support loading multi-platform images.
-      # > You can enable the containerd image store, or push multi-platform images is to directly push to a registry
-      - name: Build linux/arm64 Docker image
+      - name: Build linux/arm64,linux/amd64 Docker image
         uses: docker/build-push-action@v6
         # https://github.com/docker/build-push-action
         with:
@@ -218,13 +229,13 @@ jobs:
           file: .github/files/multi-platform.Dockerfile
           push: false
           load: true
-          tags: ${{ github.repository }}:linux-arm64
-          platforms: linux/arm64
+          tags: ${{ github.repository }}:linux
+          platforms: linux/arm64,linux/amd64
 
       - name: Test linux/arm64 Docker image
         run: |
           PLATFORM=linux/arm64
-          TAG=${{ github.repository }}:linux-arm64
+          TAG=${{ github.repository }}:linux
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"
@@ -233,20 +244,10 @@ jobs:
         env:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=require
 
-      - name: Build linux/amd64 Docker image
-        uses: docker/build-push-action@v6
-        # https://github.com/docker/build-push-action
-        with:
-          context: .
-          file: .github/files/multi-platform.Dockerfile
-          push: false
-          load: true
-          tags: ${{ github.repository }}:linux-amd64
-          platforms: linux/amd64
       - name: Test linux/amd64 Docker image
         run: |
           PLATFORM=linux/amd64
-          TAG=${{ github.repository }}:linux-amd64
+          TAG=${{ github.repository }}:linux
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
         with:
           daemon-config: |
             {
-              "debug": true,
               "features": {
                 "containerd-snapshotter": true
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         with:
           context: .
           file: .github/files/multi-platform.Dockerfile
+          push: false
           load: true
           tags: ${{ github.repository }}:linux-arm64
           platforms: linux/arm64
@@ -238,6 +239,7 @@ jobs:
         with:
           context: .
           file: .github/files/multi-platform.Dockerfile
+          push: false
           load: true
           tags: ${{ github.repository }}:linux-amd64
           platforms: linux/amd64
@@ -279,6 +281,7 @@ jobs:
           context: .
           file: .github/files/multi-platform.Dockerfile
           push: true
+          load: false
           tags: ${{ steps.docker_meta.outputs.tags }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,14 @@ jobs:
             org.opencontainers.image.source=https://github.com/maplibre/martin
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+      # we want to test our docker images before we push them to the registry
+      # this is done by
+      # - building single-arch images
+      # - and  executing the test script against said docker container
+      #
+      # using single-arch images here is intentional, because multi-arch cannot be loaded => https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
+      # > The default image store in Docker Engine doesn't support loading multi-platform images.
+      # > You can enable the containerd image store, or push multi-platform images is to directly push to a registry
       - name: Build linux/arm64 Docker image
         uses: docker/build-push-action@v6
         # https://github.com/docker/build-push-action
@@ -210,8 +218,6 @@ jobs:
           file: .github/files/multi-platform.Dockerfile
           load: true
           tags: ${{ github.repository }}:linux-arm64
-          annotations: ${{ steps.docker_meta.outputs.annotations }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/arm64
 
       - name: Test linux/arm64 Docker image
@@ -234,8 +240,6 @@ jobs:
           file: .github/files/multi-platform.Dockerfile
           load: true
           tags: ${{ github.repository }}:linux-amd64
-          annotations: ${{ steps.docker_meta.outputs.annotations }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64
       - name: Test linux/amd64 Docker image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,15 +209,15 @@ jobs:
           context: .
           file: .github/files/multi-platform.Dockerfile
           load: true
-          tags: ${{ github.repository }}:linux-arm64
+          tags: ${{ github.repository }}:linux
           annotations: ${{ steps.docker_meta.outputs.annotations }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
 
       - name: Test linux/arm64 Docker image
         run: |
           PLATFORM=linux/arm64
-          TAG=${{ github.repository }}:linux-arm64
+          TAG=${{ github.repository }}:linux
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"
@@ -226,21 +226,10 @@ jobs:
         env:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=require
 
-      - name: Build linux/amd64 Docker image
-        uses: docker/build-push-action@v6
-        # https://github.com/docker/build-push-action
-        with:
-          context: .
-          file: .github/files/multi-platform.Dockerfile
-          load: true
-          tags: ${{ github.repository }}:linux-amd64
-          annotations: ${{ steps.docker_meta.outputs.annotations }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          platforms: linux/amd64
       - name: Test linux/amd64 Docker image
         run: |
           PLATFORM=linux/amd64
-          TAG=${{ github.repository }}:linux-amd64
+          TAG=${{ github.repository }}:linux
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"
@@ -267,7 +256,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Push the Docker image
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,15 +209,15 @@ jobs:
           context: .
           file: .github/files/multi-platform.Dockerfile
           load: true
-          tags: ${{ github.repository }}:linux
+          tags: ${{ github.repository }}:linux-arm64
           annotations: ${{ steps.docker_meta.outputs.annotations }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/arm64
 
       - name: Test linux/arm64 Docker image
         run: |
           PLATFORM=linux/arm64
-          TAG=${{ github.repository }}:linux
+          TAG=${{ github.repository }}:linux-arm64
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"
@@ -226,10 +226,21 @@ jobs:
         env:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=require
 
+      - name: Build linux/amd64 Docker image
+        uses: docker/build-push-action@v6
+        # https://github.com/docker/build-push-action
+        with:
+          context: .
+          file: .github/files/multi-platform.Dockerfile
+          load: true
+          tags: ${{ github.repository }}:linux-amd64
+          annotations: ${{ steps.docker_meta.outputs.annotations }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: linux/amd64
       - name: Test linux/amd64 Docker image
         run: |
           PLATFORM=linux/amd64
-          TAG=${{ github.repository }}:linux
+          TAG=${{ github.repository }}:linux-amd64
           export MARTIN_BUILD_ALL=-
           export MARTIN_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests $TAG"
           export MARTIN_CP_BIN="docker run --rm --net host --platform $PLATFORM -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -v $PWD/tests:/tests --entrypoint /usr/local/bin/martin-cp $TAG"
@@ -256,6 +267,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push the Docker image
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
           push: false
           load: true
           tags: ${{ github.repository }}:linux
+          annotations: ${{ steps.docker_meta.outputs.annotations }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/arm64,linux/amd64
 
       - name: Test linux/arm64 Docker image


### PR DESCRIPTION
This PR merges this into one multiarch docker image build by using the `contained local store`

The reason is in part
- breaking apart #1876 and that
- #1879 does apparently not work on single-arch images.