### PR TITLE
feat: add a preprocessor for alerts

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
         with:
-          mdbook-version: '0.4.40'
+          mdbook-version: '0.4.51'
+      - name: Install mdbook-alerts
+        run: cargo install mdbook-alerts
 
       - run: mdbook build docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ The documentation of `maplibre/martin` is available at <https://maplibre.org/mar
 To build/develop this documentation locally, you can install `mdbook` and `mdbook-linkcheck`.
 
 ```bash
-cargo install mdbook
+cargo install mdbook mdbook-alerts
 ```
 
 ## Development

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,3 +12,5 @@ build-dir = "../target/book"
 curly-quotes = true
 git-repository-url = "https://github.com/maplibre/martin"
 edit-url-template = "https://github.com/maplibre/martin/edit/main/docs/{path}"
+
+[preprocessor.alerts]

--- a/docs/src/using-with-renderer.md
+++ b/docs/src/using-with-renderer.md
@@ -1,4 +1,7 @@
 # Map renderer specific
 
 Martin is mostly a general purpose tileserver.
-The exception is style serving, as it is specific to [maplibre](https://maplibre.org).
+It can thus be used in conjunction with renderers that are not [maplibre](https://maplibre.org).
+
+> [!WARNING]
+> Style serving, as it is specific to [maplibre](https://maplibre.org).

--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ bless-int:
     rm -rf tests/expected && mv tests/output tests/expected
 
 # Build and open mdbook documentation
-book:  (cargo-install 'mdbook')
+book:  (cargo-install 'mdbook') (cargo-install 'mdbook-alerts')
     mdbook serve docs --open --port 8321
 
 # Quick compile without building a binary


### PR DESCRIPTION
For a few parts of our docs, I would like to have alerts.

this looks like this:
<img width="1247" height="450" alt="image" src="https://github.com/user-attachments/assets/384b150f-15ae-415f-b590-223ec28c0edb" />

Related to
- https://github.com/maplibre/martin/pull/1922