### PR TITLE
chore(ci): make sure that `rustup update stable` is called at the start of CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           postgis/postgis:16-3.5
           -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
+      - run: rustup update stable && rustup default stable
       - uses: taiki-e/install-action@v2
         with: { tool: just }
       - name: Checkout sources
@@ -84,6 +85,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
           - target: x86_64-unknown-linux-musl
     steps:
+      - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
@@ -346,6 +348,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
       - name: Rust Versions
         run: rustc --version && cargo --version
       - uses: Swatinem/rust-cache@v2
@@ -579,6 +582,7 @@ jobs:
           postgis/postgis:${{ matrix.img_ver }}
           -c "exec docker-entrypoint.sh ${{ matrix.args }}"
     steps:
+      - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
During FOSS4G I and @nyurik talked and he brought up that our rust version not being well defined is a think which might fuck us over some time in the future.

We should have a more consistent rust version in CI.

And yes, this is not strictly the solution.. but hey.. what is the likelyhood of a rust release happening during the 20m of the CI => fairly low.