### PR TITLE
chore(ci): don't cache `cargo build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-zigbuild }
       - run: rustup target add ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Build ${{ matrix.target }}
         run: |
           export "CARGO_TARGET_$(echo ${{ matrix.target }} | tr 'a-z-' 'A-Z_')_RUSTFLAGS"='-C strip=debuginfo'
@@ -348,10 +346,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Rust Versions
         run: rustc --version && cargo --version
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.os }}
-        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Install NASM for rustls/aws-lc-rs on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
@@ -581,7 +575,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2 # for the unit-test to be run against postgres
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Run NGINX
         uses: nyurik/action-setup-nginx@v1.1


### PR DESCRIPTION
This is another artefact of last week.
We examined if we are cache-efficent and given that we are trying to push a 50GB cube into a 10GB hole.. => hell no.

We need to reduce where we cache to a minimum, i.e. where it is in the critical path and blocking.
Since we need to reduce, it makes sense to take this away from the builds and keep it for the unit tests.