### PR TITLE
chore(ci): don't accidentally automerge due to skipped checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,7 +791,6 @@ jobs:
     needs: [ package, docker-build-test ]
     if: always()
     steps:
+      - run: echo "${{ toJSON(needs) }}"
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
-      - name: Finished
-        run: echo "CI finished successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           postgis/postgis:16-3.5
           -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
+      - run: exit 1
       - run: rustup update stable && rustup default stable
       - uses: taiki-e/install-action@v2
         with: { tool: just }
@@ -90,6 +91,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
           - target: x86_64-unknown-linux-musl
     steps:
+      - run: exit 1
       - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -339,6 +341,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
+      - run: exit 1
       - name: Checkout sources
         uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
           postgis/postgis:16-3.5
           -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
-      - run: exit 1
       - run: rustup update stable && rustup default stable
       - uses: taiki-e/install-action@v2
         with: { tool: just }
@@ -91,7 +90,6 @@ jobs:
           - target: aarch64-unknown-linux-musl
           - target: x86_64-unknown-linux-musl
     steps:
-      - run: exit 1
       - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -341,7 +339,6 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
-      - run: exit 1
       - name: Checkout sources
         uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,5 +790,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ package, docker-build-test ]
     steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
       - name: Finished
         run: echo "CI finished successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,6 +789,7 @@ jobs:
     name: CI Finished
     runs-on: ubuntu-latest
     needs: [ package, docker-build-test ]
+    if: always()
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
           - target: x86_64-unknown-linux-musl
     steps:
       - run: rustup update stable && rustup default stable
-      - run: exit 1
       - name: Checkout sources
         uses: actions/checkout@v4
         with: { set-safe-directory: false }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
     steps:
       - run: rustup update stable && rustup default stable
+      - run: exit 1
       - name: Checkout sources
         uses: actions/checkout@v4
         with: { set-safe-directory: false }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,6 +791,8 @@ jobs:
     needs: [ package, docker-build-test ]
     if: always()
     steps:
-      - run: echo "${{ toJSON(needs) }}"
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - name: Result of the needed steps
+        run: echo "${{ toJSON(needs) }}"
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        name: CI Result
         run: exit 1


### PR DESCRIPTION
This fixes the stupid problem that our CI allows skipping it in some circumstances

> [!NOTE]
> A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.

https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution

It turns out the reason a lot of people do this is more underlying

Resolves #1811