### PR TITLE
chore(core): make sure that dependencys are clearly attributed

### DIFF
--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "martin"
 version = "0.18.0"
-authors = ["Stepan Kuzmin <to.stepan.kuzmin@gmail.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
+authors = [
+  "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
+  "Yuri Astrakhan <YuriAstrakhan@gmail.com>",
+  "MapLibre contributors",
+]
 description = "Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 keywords = ["maps", "tiles", "mbtiles", "pmtiles", "postgis"]
 categories = ["science::geo", "web-programming::http-server"]
@@ -54,12 +58,12 @@ harness = false
 [features]
 default = ["cog", "fonts", "lambda", "mbtiles", "metrics", "pmtiles", "postgres", "sprites", "styles", "webui"]
 cog = ["dep:png", "dep:tiff"]
-fonts = ["dep:bit-set", "dep:pbf_font_tools"]
+fonts = ["dep:bit-set", "dep:pbf_font_tools", "dep:regex"]
 lambda = ["dep:lambda-web"]
 mbtiles = ["dep:mbtiles"]
 metrics = ["dep:actix-web-prom"]
-pmtiles = ["dep:pmtiles"]
-postgres = ["dep:deadpool-postgres", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:semver", "dep:tokio-postgres-rustls"]
+pmtiles = ["dep:aws-config", "dep:pmtiles"]
+postgres = ["dep:deadpool-postgres", "dep:enum-display", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:regex", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:semver", "dep:tokio-postgres-rustls"]
 sprites = ["dep:spreet", "tokio/fs"]
 styles = ["dep:walkdir", "tokio/fs"]
 webui = ["dep:actix-web-static-files", "dep:static-files", "dep:walkdir"]
@@ -73,12 +77,12 @@ actix-web-prom = { workspace = true, optional = true }
 actix-web-static-files = { workspace = true, optional = true }
 actix-web.workspace = true
 async-trait.workspace = true
-aws-config.workspace = true
+aws-config = { workspace = true, optional = true }
 bit-set = { workspace = true, optional = true }
 clap.workspace = true
 dashmap.workspace = true
 deadpool-postgres = { workspace = true, optional = true }
-enum-display.workspace = true
+enum-display = { workspace = true, optional = true }
 env_logger.workspace = true
 futures.workspace = true
 itertools.workspace = true
@@ -95,10 +99,10 @@ png = { workspace = true, optional = true }
 postgis = { workspace = true, optional = true }
 postgres = { workspace = true, optional = true }
 postgres-protocol = { workspace = true, optional = true }
-regex.workspace = true
-rustls-native-certs.workspace = true
-rustls-pemfile.workspace = true
-rustls.workspace = true
+regex = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -63,7 +63,7 @@ lambda = ["dep:lambda-web"]
 mbtiles = ["dep:mbtiles"]
 metrics = ["dep:actix-web-prom"]
 pmtiles = ["dep:aws-config", "dep:pmtiles"]
-postgres = ["dep:deadpool-postgres", "dep:enum-display", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:regex", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:semver", "dep:tokio-postgres-rustls"]
+postgres = ["dep:deadpool-postgres", "dep:enum-display", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:regex", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:semver", "dep:tokio-postgres-rustls"]
 sprites = ["dep:spreet", "tokio/fs"]
 styles = ["dep:walkdir", "tokio/fs"]
 webui = ["dep:actix-web-static-files", "dep:static-files", "dep:walkdir"]
@@ -102,7 +102,7 @@ postgres-protocol = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
-rustls = { workspace = true, optional = true }
+rustls.workspace = true
 semver = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
During the discovery-PR of what the next best step in pulling into `martin-core` is, I discovered, that our dependency-feature gating could be tighter.

The primary motivation behind this PR is that if what feature has which dependency is well-defined, migration is much simpler.

This PR was tested via 

```bash
cargo hack check --each-feature --keep-going --locked
```