### PR TITLE
chore(core): unify how we handle errors in modules

### DIFF
--- a/martin/src/cog/source.rs
+++ b/martin/src/cog/source.rs
@@ -14,7 +14,7 @@ use tilejson::{TileJSON, tilejson};
 use super::CogError;
 use super::image::Image;
 use super::model::ModelInfo;
-use crate::file_config::{FileError, FileResult};
+use crate::file_config::FileError;
 use crate::{MartinResult, Source, TileData, UrlQuery};
 
 #[derive(Clone, Debug)]
@@ -36,7 +36,7 @@ pub struct CogSource {
 
 impl CogSource {
     #[expect(clippy::cast_possible_truncation)]
-    pub fn new(id: String, path: PathBuf) -> FileResult<Self> {
+    pub fn new(id: String, path: PathBuf) -> MartinResult<Self> {
         let tileinfo = TileInfo::new(Format::Png, martin_tile_utils::Encoding::Uncompressed);
         let tif_file =
             File::open(&path).map_err(|e: std::io::Error| FileError::IoError(e, path.clone()))?;
@@ -255,7 +255,7 @@ fn get_image(
     decoder: &mut Decoder<File>,
     path: &Path,
     ifd_index: usize,
-) -> Result<Image, FileError> {
+) -> Result<Image, CogError> {
     let (tile_width, tile_height) = (decoder.chunk_dimensions().0, decoder.chunk_dimensions().1);
     let (image_width, image_length) = dimensions_in_pixel(decoder, path, ifd_index)?;
     let tiles_across = image_width.div_ceil(tile_width);
@@ -269,7 +269,7 @@ fn dimensions_in_pixel(
     decoder: &mut Decoder<File>,
     path: &Path,
     ifd_index: usize,
-) -> Result<(u32, u32), FileError> {
+) -> Result<(u32, u32), CogError> {
     let (image_width, image_length) = decoder.dimensions().map_err(|e| {
         CogError::TagsNotFound(
             e,
@@ -289,11 +289,10 @@ fn dimensions_in_model(
     ifd_index: usize,
     pixel_scale: Option<&[f64]>,
     transformation: Option<&[f64]>,
-) -> Result<(f64, f64), FileError> {
+) -> Result<(f64, f64), CogError> {
     let (image_width_pixel, image_length_pixel) = dimensions_in_pixel(decoder, path, ifd_index)?;
 
-    let full_resolution =
-        get_full_resolution(pixel_scale, transformation, path).map_err(FileError::from)?;
+    let full_resolution = get_full_resolution(pixel_scale, transformation, path)?;
 
     let width_in_model = f64::from(image_width_pixel) * full_resolution[0].abs();
     let length_in_model = f64::from(image_length_pixel) * full_resolution[1].abs();

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -32,10 +32,6 @@ pub enum FileError {
     #[error("Source {0} uses bad file {1}")]
     InvalidSourceFilePath(String, PathBuf),
 
-    #[cfg(any(feature = "webui", feature = "styles"))]
-    #[error("Walk directory error {0}: {1}")]
-    DirectoryWalking(walkdir::Error, PathBuf),
-
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidMetadata(String, PathBuf),
 }

--- a/martin/src/file_config.rs
+++ b/martin/src/file_config.rs
@@ -3,12 +3,10 @@ use std::fmt::Debug;
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use futures::TryFutureExt;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::MartinResult;
 use crate::OptOneMany::{Many, One};
 use crate::config::{UnrecognizedValues, copy_unrecognized_config};
 use crate::file_config::FileError::{
@@ -16,6 +14,7 @@ use crate::file_config::FileError::{
 };
 use crate::source::{TileInfoSource, TileInfoSources};
 use crate::utils::{IdResolver, OptMainCache, OptOneMany};
+use crate::{MartinError, MartinResult};
 
 pub type FileResult<T> = Result<T, FileError>;
 
@@ -39,23 +38,6 @@ pub enum FileError {
 
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidMetadata(String, PathBuf),
-
-    #[error(r"Unable to parse metadata in file {1}: {0}")]
-    InvalidUrlMetadata(String, Url),
-
-    #[error(r"Error occurred in processing S3 source uri: {0}")]
-    S3SourceError(String),
-
-    #[error(r"Unable to acquire connection to file: {0}")]
-    AcquireConnError(String),
-
-    #[cfg(feature = "pmtiles")]
-    #[error(r"PMTiles error {0:?} processing {1}")]
-    PmtError(pmtiles::PmtError, String),
-
-    #[cfg(feature = "cog")]
-    #[error(transparent)]
-    CogError(#[from] crate::cog::CogError),
 }
 
 pub trait ConfigExtras: Clone + Debug + Default + PartialEq + Send {
@@ -81,13 +63,13 @@ pub trait SourceConfigExtras: ConfigExtras {
         &self,
         id: String,
         path: PathBuf,
-    ) -> impl Future<Output = FileResult<TileInfoSource>> + Send;
+    ) -> impl Future<Output = MartinResult<TileInfoSource>> + Send;
 
     fn new_sources_url(
         &self,
         id: String,
         url: Url,
-    ) -> impl Future<Output = FileResult<TileInfoSource>> + Send;
+    ) -> impl Future<Output = MartinResult<TileInfoSource>> + Send;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -244,9 +226,7 @@ pub async fn resolve_files<T: SourceConfigExtras>(
     cache: OptMainCache,
     extension: &[&str],
 ) -> MartinResult<TileInfoSources> {
-    resolve_int(config, idr, cache, extension)
-        .map_err(crate::MartinError::from)
-        .await
+    resolve_int(config, idr, cache, extension).await
 }
 
 async fn resolve_int<T: SourceConfigExtras>(
@@ -254,7 +234,7 @@ async fn resolve_int<T: SourceConfigExtras>(
     idr: &IdResolver,
     cache: OptMainCache,
     extension: &[&str],
-) -> FileResult<TileInfoSources> {
+) -> MartinResult<TileInfoSources> {
     let Some(cfg) = config.extract_file_config(cache)? else {
         return Ok(TileInfoSources::default());
     };
@@ -277,7 +257,10 @@ async fn resolve_int<T: SourceConfigExtras>(
                 let can = source.abs_path()?;
                 if !can.is_file() {
                     // todo: maybe warn instead?
-                    return Err(InvalidSourceFilePath(id.to_string(), can));
+                    return Err(MartinError::FileError(InvalidSourceFilePath(
+                        id.to_string(),
+                        can,
+                    )));
                 }
 
                 let dup = !files.insert(can.clone());
@@ -320,7 +303,9 @@ async fn resolve_int<T: SourceConfigExtras>(
             } else if path.is_file() {
                 vec![path]
             } else {
-                return Err(InvalidFilePath(path.canonicalize().unwrap_or(path)));
+                return Err(MartinError::from(InvalidFilePath(
+                    path.canonicalize().unwrap_or(path),
+                )));
             };
             for path in dir_files {
                 let can = path.canonicalize().map_err(|e| IoError(e, path.clone()))?;

--- a/martin/src/fonts/error.rs
+++ b/martin/src/fonts/error.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use pbf_font_tools::PbfFontError;
+
+use super::CP_RANGE_SIZE;
+
+#[derive(thiserror::Error, Debug)]
+pub enum FontError {
+    #[error("Font {0} not found")]
+    FontNotFound(String),
+
+    #[error("Font range start ({0}) must be <= end ({1})")]
+    InvalidFontRangeStartEnd(u32, u32),
+
+    #[error("Font range start ({0}) must be multiple of {CP_RANGE_SIZE} (e.g. 0, 256, 512, ...)")]
+    InvalidFontRangeStart(u32),
+
+    #[error(
+        "Font range end ({0}) must be multiple of {CP_RANGE_SIZE} - 1 (e.g. 255, 511, 767, ...)"
+    )]
+    InvalidFontRangeEnd(u32),
+
+    #[error(
+        "Given font range {0}-{1} is invalid. It must be {CP_RANGE_SIZE} characters long (e.g. 0-255, 256-511, ...)"
+    )]
+    InvalidFontRange(u32, u32),
+
+    #[error(transparent)]
+    FreeType(#[from] pbf_font_tools::freetype::Error),
+
+    #[error("IO error accessing {1}: {0}")]
+    IoError(std::io::Error, PathBuf),
+
+    #[error("Invalid font file {0}")]
+    InvalidFontFilePath(PathBuf),
+
+    #[error("No font files found in {0}")]
+    NoFontFilesFound(PathBuf),
+
+    #[error("Font {0} is missing a family name")]
+    MissingFamilyName(PathBuf),
+
+    #[error(transparent)]
+    PbfFontError(#[from] PbfFontError),
+
+    #[error(transparent)]
+    ErrorSerializingProtobuf(#[from] pbf_font_tools::prost::DecodeError),
+}

--- a/martin/src/mbtiles/config.rs
+++ b/martin/src/mbtiles/config.rs
@@ -4,31 +4,26 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::source::CogSource;
+use crate::MartinResult;
 use crate::config::UnrecognizedValues;
 use crate::file_config::{ConfigExtras, SourceConfigExtras};
-use crate::{MartinResult, TileInfoSource};
+use crate::source::TileInfoSource;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct CogConfig {
+pub struct MbtConfig {
     #[serde(flatten)]
     pub unrecognized: UnrecognizedValues,
 }
 
-impl ConfigExtras for CogConfig {
+impl ConfigExtras for MbtConfig {
     fn get_unrecognized(&self) -> &UnrecognizedValues {
         &self.unrecognized
     }
 }
 
-impl SourceConfigExtras for CogConfig {
-    fn parse_urls() -> bool {
-        false
-    }
-
+impl SourceConfigExtras for MbtConfig {
     async fn new_sources(&self, id: String, path: PathBuf) -> MartinResult<TileInfoSource> {
-        let cog = CogSource::new(id, path)?;
-        Ok(Box::new(cog))
+        Ok(Box::new(super::MbtSource::new(id, path).await?))
     }
 
     async fn new_sources_url(&self, _id: String, _url: Url) -> MartinResult<TileInfoSource> {

--- a/martin/src/mbtiles/error.rs
+++ b/martin/src/mbtiles/error.rs
@@ -1,0 +1,8 @@
+#[derive(thiserror::Error, Debug)]
+pub enum MbtilesError {
+    #[error(r"Unable to acquire connection to file: {0}")]
+    AcquireConnError(String),
+
+    #[error(transparent)]
+    MbtilesLibraryError(#[from] mbtiles::MbtError),
+}

--- a/martin/src/pmtiles/config.rs
+++ b/martin/src/pmtiles/config.rs
@@ -8,12 +8,8 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::config::UnrecognizedValues;
-use crate::config::UnrecognizedValues;
-use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
 use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
 use crate::pmtiles::{PmtCache, PmtFileSource, PmtHttpSource, PmtS3Source};
-use crate::pmtiles::{PmtFileSource, PmtHttpSource, PmtS3Source};
-use crate::utils::OptMainCache;
 use crate::utils::OptMainCache;
 use crate::{MartinResult, TileInfoSource};
 
@@ -67,8 +63,8 @@ impl Clone for PmtConfig {
 impl PmtConfig {
     /// Create a new cache object for a source, giving it a unique internal ID
     /// and a reference to the global cache.
-    pub fn new_cached_source(&self) -> super::PmtCache {
-        super::PmtCache::new(self.next_cache_id.fetch_add(1, Relaxed), self.cache.clone())
+    pub fn new_cached_source(&self) -> PmtCache {
+        PmtCache::new(self.next_cache_id.fetch_add(1, Relaxed), self.cache.clone())
     }
 }
 

--- a/martin/src/pmtiles/config.rs
+++ b/martin/src/pmtiles/config.rs
@@ -1,0 +1,152 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use log::warn;
+use pmtiles::reqwest::Client;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
+use crate::pmtiles::{PmtFileSource, PmtHttpSource, PmtS3Source};
+use crate::utils::OptMainCache;
+use crate::{MartinResult, TileInfoSource};
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct PmtConfig {
+    /// Force path style URLs for S3 buckets
+    ///
+    /// A path style URL is a URL that uses the bucket name as part of the path like `example.org/some_bucket` instead of the hostname `some_bucket.example.org`.
+    /// If `None` (the default), this will look at `AWS_S3_FORCE_PATH_STYLE` or default to `false`.
+    #[serde(default, alias = "aws_s3_force_path_style")]
+    pub force_path_style: Option<bool>,
+    /// Skip loading credentials for S3 buckets
+    ///
+    /// Set this to `true` to request anonymously for publicly available buckets.
+    /// If `None` (the default), this will look at `AWS_SKIP_CREDENTIALS` and `AWS_NO_CREDENTIALS` or default to `false`.
+    #[serde(default, alias = "aws_skip_credentials")]
+    pub skip_credentials: Option<bool>,
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+
+    //
+    // The rest are internal state, not serialized
+    //
+    #[serde(skip)]
+    pub client: Option<Client>,
+
+    #[serde(skip)]
+    pub next_cache_id: AtomicUsize,
+
+    #[serde(skip)]
+    pub cache: OptMainCache,
+}
+
+impl PartialEq for PmtConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.unrecognized == other.unrecognized
+    }
+}
+
+impl Clone for PmtConfig {
+    fn clone(&self) -> Self {
+        // State is not shared between clones, only the serialized config
+        Self {
+            unrecognized: self.unrecognized.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+impl PmtConfig {
+    /// Create a new cache object for a source, giving it a unique internal ID
+    /// and a reference to the global cache.
+    pub fn new_cached_source(&self) -> super::PmtCache {
+        super::PmtCache::new(
+            self.next_cache_id.fetch_add(1, Ordering::Relaxed),
+            self.cache.clone(),
+        )
+    }
+}
+
+impl ConfigExtras for PmtConfig {
+    fn init_parsing(&mut self, cache: OptMainCache) -> FileResult<()> {
+        assert!(self.client.is_none());
+        assert!(self.cache.is_none());
+
+        self.client = Some(Client::new());
+        self.cache = cache;
+
+        if self.unrecognized.contains_key("dir_cache_size_mb") {
+            warn!(
+                "dir_cache_size_mb is no longer used. Instead, use cache_size_mb param in the root of the config file."
+            );
+        }
+
+        Ok(())
+    }
+
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}
+
+impl SourceConfigExtras for PmtConfig {
+    fn parse_urls() -> bool {
+        true
+    }
+
+    async fn new_sources(&self, id: String, path: PathBuf) -> MartinResult<TileInfoSource> {
+        Ok(Box::new(
+            PmtFileSource::new(self.new_cached_source(), id, path).await?,
+        ))
+    }
+
+    async fn new_sources_url(&self, id: String, url: Url) -> MartinResult<TileInfoSource> {
+        match url.scheme() {
+            "s3" => {
+                let force_path_style = self.force_path_style.unwrap_or_else(|| {
+                    get_env_as_bool("AWS_S3_FORCE_PATH_STYLE").unwrap_or_default()
+                });
+                let skip_credentials = self.skip_credentials.unwrap_or_else(|| {
+                    get_env_as_bool("AWS_SKIP_CREDENTIALS").unwrap_or_else(|| {
+                        // `AWS_NO_CREDENTIALS` was the name in some early documentation of this feature
+                        get_env_as_bool("AWS_NO_CREDENTIALS").unwrap_or_default()
+                    })
+                });
+                Ok(Box::new(
+                    PmtS3Source::new(
+                        self.new_cached_source(),
+                        id,
+                        url,
+                        skip_credentials,
+                        force_path_style,
+                    )
+                    .await?,
+                ))
+            }
+            _ => Ok(Box::new(
+                PmtHttpSource::new(
+                    self.client.clone().unwrap(),
+                    self.new_cached_source(),
+                    id,
+                    url,
+                )
+                .await?,
+            )),
+        }
+    }
+}
+
+/// Interpret an environment variable as a [`bool`]
+///
+/// This ignores casing and treats bad utf8 encoding as `false`.
+fn get_env_as_bool(key: &'static str) -> Option<bool> {
+    let val = std::env::var_os(key)?.to_ascii_lowercase();
+    Some(val.to_str().is_some_and(|val| val == "1" || val == "true"))
+}

--- a/martin/src/pmtiles/error.rs
+++ b/martin/src/pmtiles/error.rs
@@ -1,0 +1,17 @@
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+pub enum PmtilesError {
+    #[error(r"Error occurred in processing S3 source uri: {0}")]
+    S3SourceError(String),
+
+    #[cfg(feature = "pmtiles")]
+    #[error(r"PMTiles error {0:?} processing {1}")]
+    PmtilesLibraryError(pmtiles::PmtError, String),
+
+    #[error(r"Unable to parse metadata in file {1}: {0}")]
+    InvalidUrlMetadata(String, Url),
+
+    #[error(r"Invalid tile coordinates")]
+    InvalidTileCoordinates,
+}

--- a/martin/src/pmtiles/mod.rs
+++ b/martin/src/pmtiles/mod.rs
@@ -25,12 +25,10 @@ use crate::{MartinError, MartinResult, Source, TileData};
 
 mod config;
 pub use config::PmtConfig;
+
 mod error;
 pub use error::PmtilesError;
 use error::PmtilesError::InvalidUrlMetadata;
-
-mod config;
-pub use config::PmtConfig;
 
 #[derive(Clone, Debug)]
 pub struct PmtCache {

--- a/martin/src/sprites/config.rs
+++ b/martin/src/sprites/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::ConfigExtras;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SpriteConfig {
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigExtras for SpriteConfig {
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}

--- a/martin/src/sprites/error.rs
+++ b/martin/src/sprites/error.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use spreet::SpreetError;
+use spreet::resvg::usvg::Error as ResvgError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SpriteError {
+    #[error("Sprite {0} not found")]
+    SpriteNotFound(String),
+
+    #[error("IO error {0}: {1}")]
+    IoError(std::io::Error, PathBuf),
+
+    #[error("Sprite path is not a file: {0}")]
+    InvalidFilePath(PathBuf),
+
+    #[error("Sprite {0} uses bad file {1}")]
+    InvalidSpriteFilePath(String, PathBuf),
+
+    #[error("No sprite files found in {0}")]
+    NoSpriteFilesFound(PathBuf),
+
+    #[error("Sprite {0} could not be loaded")]
+    UnableToReadSprite(PathBuf),
+
+    #[error("{0} in file {1}")]
+    SpriteProcessingError(SpreetError, PathBuf),
+
+    #[error("{0} in file {1}")]
+    SpriteParsingError(ResvgError, PathBuf),
+
+    #[error("Unable to generate spritesheet")]
+    UnableToGenerateSpritesheet,
+
+    #[error("Unable to create a sprite from file {0}")]
+    SpriteInstError(PathBuf),
+}

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -19,9 +19,6 @@ pub use config::SpriteConfig;
 mod error;
 pub use error::SpriteError;
 
-mod config;
-pub use config::SpriteConfig;
-
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CatalogSpriteEntry {
     pub images: Vec<String>,

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -6,50 +6,18 @@ use dashmap::{DashMap, Entry};
 use futures::future::try_join_all;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use spreet::resvg::usvg::{Error as ResvgError, Options, Tree, TreeParsing};
-use spreet::{
-    SpreetError, Sprite, Spritesheet, SpritesheetBuilder, get_svg_input_paths, sprite_name,
-};
+use spreet::resvg::usvg::{Options, Tree, TreeParsing};
+use spreet::{Sprite, Spritesheet, SpritesheetBuilder, get_svg_input_paths, sprite_name};
 use tokio::io::AsyncReadExt;
 
 use self::SpriteError::{SpriteInstError, SpriteParsingError, SpriteProcessingError};
-use crate::config::UnrecognizedValues;
-use crate::file_config::{ConfigExtras, FileConfigEnum, FileResult};
+use crate::file_config::{FileConfigEnum, FileResult};
 
-pub type SpriteResult<T> = Result<T, SpriteError>;
+mod error;
+pub use error::SpriteError;
 
-#[derive(thiserror::Error, Debug)]
-pub enum SpriteError {
-    #[error("Sprite {0} not found")]
-    SpriteNotFound(String),
-
-    #[error("IO error {0}: {1}")]
-    IoError(std::io::Error, PathBuf),
-
-    #[error("Sprite path is not a file: {0}")]
-    InvalidFilePath(PathBuf),
-
-    #[error("Sprite {0} uses bad file {1}")]
-    InvalidSpriteFilePath(String, PathBuf),
-
-    #[error("No sprite files found in {0}")]
-    NoSpriteFilesFound(PathBuf),
-
-    #[error("Sprite {0} could not be loaded")]
-    UnableToReadSprite(PathBuf),
-
-    #[error("{0} in file {1}")]
-    SpriteProcessingError(SpreetError, PathBuf),
-
-    #[error("{0} in file {1}")]
-    SpriteParsingError(ResvgError, PathBuf),
-
-    #[error("Unable to generate spritesheet")]
-    UnableToGenerateSpritesheet,
-
-    #[error("Unable to create a sprite from file {0}")]
-    SpriteInstError(PathBuf),
-}
+mod config;
+pub use config::SpriteConfig;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CatalogSpriteEntry {
@@ -57,18 +25,6 @@ pub struct CatalogSpriteEntry {
 }
 
 pub type SpriteCatalog = HashMap<String, CatalogSpriteEntry>;
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct SpriteConfig {
-    #[serde(flatten)]
-    pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigExtras for SpriteConfig {
-    fn get_unrecognized(&self) -> &UnrecognizedValues {
-        &self.unrecognized
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct SpriteSources(DashMap<String, SpriteSource>);
@@ -107,7 +63,7 @@ impl SpriteSources {
         Ok(results)
     }
 
-    pub fn get_catalog(&self) -> SpriteResult<SpriteCatalog> {
+    pub fn get_catalog(&self) -> Result<SpriteCatalog, SpriteError> {
         // TODO: all sprite generation should be pre-cached
         let mut entries = SpriteCatalog::new();
         for source in &self.0 {
@@ -149,7 +105,7 @@ impl SpriteSources {
 
     /// Given a list of IDs in a format "id1,id2,id3", return a spritesheet with them all.
     /// `ids` may optionally end with "@2x" to request a high-DPI spritesheet.
-    pub async fn get_sprites(&self, ids: &str, as_sdf: bool) -> SpriteResult<Spritesheet> {
+    pub async fn get_sprites(&self, ids: &str, as_sdf: bool) -> Result<Spritesheet, SpriteError> {
         let (ids, dpi) = if let Some(ids) = ids.strip_suffix("@2x") {
             (ids, 2)
         } else {
@@ -159,12 +115,12 @@ impl SpriteSources {
         let sprite_ids = ids
             .split(',')
             .map(|id| self.get(id))
-            .collect::<SpriteResult<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, SpriteError>>()?;
 
         get_spritesheet(sprite_ids.iter(), dpi, as_sdf).await
     }
 
-    fn get(&self, id: &str) -> SpriteResult<SpriteSource> {
+    fn get(&self, id: &str) -> Result<SpriteSource, SpriteError> {
         match self.0.get(id) {
             Some(v) => Ok(v.clone()),
             None => Err(SpriteError::SpriteNotFound(id.to_string())),
@@ -182,7 +138,7 @@ async fn parse_sprite(
     path: PathBuf,
     pixel_ratio: u8,
     as_sdf: bool,
-) -> SpriteResult<(String, Sprite)> {
+) -> Result<(String, Sprite), SpriteError> {
     let on_err = |e| SpriteError::IoError(e, path.clone());
 
     let mut file = tokio::fs::File::open(&path).await.map_err(on_err)?;
@@ -207,7 +163,7 @@ pub async fn get_spritesheet(
     sources: impl Iterator<Item = &SpriteSource>,
     pixel_ratio: u8,
     as_sdf: bool,
-) -> SpriteResult<Spritesheet> {
+) -> Result<Spritesheet, SpriteError> {
     // Asynchronously load all SVG files from the given sources
     let mut futures = Vec::new();
     for source in sources {

--- a/martin/src/styles/config.rs
+++ b/martin/src/styles/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::ConfigExtras;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StyleConfig {
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigExtras for StyleConfig {
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}

--- a/martin/src/styles/error.rs
+++ b/martin/src/styles/error.rs
@@ -1,0 +1,7 @@
+use std::path::PathBuf;
+
+#[derive(thiserror::Error, Debug)]
+pub enum StyleError {
+    #[error("Walk directory error {0}: {1}")]
+    DirectoryWalking(walkdir::Error, PathBuf),
+}

--- a/martin/src/styles/mod.rs
+++ b/martin/src/styles/mod.rs
@@ -6,8 +6,10 @@ use dashmap::{DashMap, Entry};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
-use crate::config::UnrecognizedValues;
-use crate::file_config::{ConfigExtras, FileConfigEnum, FileError, FileResult};
+use crate::file_config::{FileConfigEnum, FileError, FileResult};
+
+mod config;
+pub use config::StyleConfig;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CatalogStyleEntry {
@@ -15,18 +17,6 @@ pub struct CatalogStyleEntry {
 }
 
 pub type StyleCatalog = HashMap<String, CatalogStyleEntry>;
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct StyleConfig {
-    #[serde(flatten)]
-    pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigExtras for StyleConfig {
-    fn get_unrecognized(&self) -> &UnrecognizedValues {
-        &self.unrecognized
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(test, serde_with::skip_serializing_none, derive(serde::Serialize))]

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -81,6 +81,10 @@ pub enum MartinError {
     #[error(transparent)]
     FontError(#[from] crate::fonts::FontError),
 
+    #[cfg(feature = "styles")]
+    #[error(transparent)]
+    StyleError(#[from] crate::styles::StyleError),
+
     #[error(transparent)]
     WebError(#[from] actix_web::Error),
 

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -60,11 +60,11 @@ pub enum MartinError {
 
     #[cfg(feature = "pmtiles")]
     #[error(transparent)]
-    PmtilesError(#[from] pmtiles::PmtError),
+    PmtilesError(#[from] crate::pmtiles::PmtilesError),
 
     #[cfg(feature = "mbtiles")]
     #[error(transparent)]
-    MbtilesError(#[from] mbtiles::MbtError),
+    MbtilesError(#[from] crate::mbtiles::MbtilesError),
 
     #[cfg(feature = "cog")]
     #[error(transparent)]


### PR DESCRIPTION
One thing that has been consistently complicated is how we handle errors.
It is complicated to learn for others, it is complicated to learn for me.
This needs to go.

Currently, there are 3 (roughly) different styles:
- bubble them up
- wrap them in `FileError`, then bubble up via that
- handle in module level errror, bubble up in that.

This is hard to manage and leads to a nearly circular (not actually) dependency when factoring out things.

This PR proposes:
- one `error.rs` per module
- if unification of errors is nessesary, MartinError is directly chosen, no convoluted skippable "inheritance" via `FileError`

=> less coupling and more cohesion
