### PR TITLE
chore(core): unify where we handle config

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -18,7 +18,6 @@ use martin::srv::{DynTileSource, merge_tilejson};
 use martin::{
     Config, MartinError, MartinResult, ServerState, TileData, TileInfoSource, read_config,
 };
-
 use martin_tile_utils::{TileCoord, TileInfo, TileRect, append_rect, bbox_to_xyz};
 use mbtiles::UpdateZoomType::GrowOnly;
 use mbtiles::sqlx::SqliteConnection;

--- a/martin/src/mbtiles/config.rs
+++ b/martin/src/mbtiles/config.rs
@@ -6,6 +6,7 @@ use url::Url;
 
 use crate::config::UnrecognizedValues;
 use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
+use crate::mbtiles::MbtSource;
 use crate::source::TileInfoSource;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -22,7 +23,7 @@ impl ConfigExtras for MbtConfig {
 
 impl SourceConfigExtras for MbtConfig {
     async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<TileInfoSource> {
-        Ok(Box::new(super::MbtSource::new(id, path).await?))
+        Ok(Box::new(MbtSource::new(id, path).await?))
     }
 
     async fn new_sources_url(&self, _id: String, _url: Url) -> FileResult<TileInfoSource> {

--- a/martin/src/mbtiles/config.rs
+++ b/martin/src/mbtiles/config.rs
@@ -1,0 +1,31 @@
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
+use crate::source::TileInfoSource;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct MbtConfig {
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigExtras for MbtConfig {
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}
+
+impl SourceConfigExtras for MbtConfig {
+    async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<TileInfoSource> {
+        Ok(Box::new(super::MbtSource::new(id, path).await?))
+    }
+
+    async fn new_sources_url(&self, _id: String, _url: Url) -> FileResult<TileInfoSource> {
+        unreachable!()
+    }
+}

--- a/martin/src/mbtiles/mod.rs
+++ b/martin/src/mbtiles/mod.rs
@@ -7,40 +7,15 @@ use async_trait::async_trait;
 use log::trace;
 use martin_tile_utils::{TileCoord, TileInfo};
 use mbtiles::MbtilesPool;
-use serde::{Deserialize, Serialize};
 use tilejson::TileJSON;
-use url::Url;
 
-use crate::config::UnrecognizedValues;
 use crate::file_config::FileError::{AcquireConnError, InvalidMetadata, IoError};
-use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
+use crate::file_config::FileResult;
 use crate::source::{TileData, TileInfoSource, UrlQuery};
 use crate::{MartinResult, Source};
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct MbtConfig {
-    #[serde(flatten)]
-    pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigExtras for MbtConfig {
-    fn get_unrecognized(&self) -> &UnrecognizedValues {
-        &self.unrecognized
-    }
-}
-
-impl SourceConfigExtras for MbtConfig {
-    async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<TileInfoSource> {
-        Ok(Box::new(MbtSource::new(id, path).await?))
-    }
-
-    // TODO: Remove #[allow] after switching to Rust/Clippy v1.78+ in CI
-    //       See https://github.com/rust-lang/rust-clippy/pull/12323
-    #[allow(clippy::no_effect_underscore_binding)]
-    async fn new_sources_url(&self, _id: String, _url: Url) -> FileResult<TileInfoSource> {
-        unreachable!()
-    }
-}
+mod config;
+pub use config::MbtConfig;
 
 #[derive(Clone)]
 pub struct MbtSource {

--- a/martin/src/pmtiles/config.rs
+++ b/martin/src/pmtiles/config.rs
@@ -1,0 +1,150 @@
+use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+
+use log::warn;
+use pmtiles::reqwest::Client;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::TileInfoSource;
+use crate::config::UnrecognizedValues;
+use crate::file_config::{ConfigExtras, FileResult, SourceConfigExtras};
+use crate::pmtiles::{PmtCache, PmtFileSource, PmtHttpSource, PmtS3Source};
+use crate::utils::OptMainCache;
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct PmtConfig {
+    /// Force path style URLs for S3 buckets
+    ///
+    /// A path style URL is a URL that uses the bucket name as part of the path like `example.org/some_bucket` instead of the hostname `some_bucket.example.org`.
+    /// If `None` (the default), this will look at `AWS_S3_FORCE_PATH_STYLE` or default to `false`.
+    #[serde(default, alias = "aws_s3_force_path_style")]
+    pub force_path_style: Option<bool>,
+    /// Skip loading credentials for S3 buckets
+    ///
+    /// Set this to `true` to request anonymously for publicly available buckets.
+    /// If `None` (the default), this will look at `AWS_SKIP_CREDENTIALS` and `AWS_NO_CREDENTIALS` or default to `false`.
+    #[serde(default, alias = "aws_skip_credentials")]
+    pub skip_credentials: Option<bool>,
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+
+    //
+    // The rest are internal state, not serialized
+    //
+    #[serde(skip)]
+    pub client: Option<Client>,
+
+    #[serde(skip)]
+    pub next_cache_id: AtomicUsize,
+
+    #[serde(skip)]
+    pub cache: OptMainCache,
+}
+
+impl PartialEq for PmtConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.unrecognized == other.unrecognized
+    }
+}
+
+impl Clone for PmtConfig {
+    fn clone(&self) -> Self {
+        // State is not shared between clones, only the serialized config
+        Self {
+            unrecognized: self.unrecognized.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+impl PmtConfig {
+    /// Create a new cache object for a source, giving it a unique internal ID
+    /// and a reference to the global cache.
+    pub fn new_cached_source(&self) -> PmtCache {
+        PmtCache::new(self.next_cache_id.fetch_add(1, Relaxed), self.cache.clone())
+    }
+}
+
+impl ConfigExtras for PmtConfig {
+    fn init_parsing(&mut self, cache: OptMainCache) -> FileResult<()> {
+        assert!(self.client.is_none());
+        assert!(self.cache.is_none());
+
+        self.client = Some(Client::new());
+        self.cache = cache;
+
+        if self.unrecognized.contains_key("dir_cache_size_mb") {
+            warn!(
+                "dir_cache_size_mb is no longer used. Instead, use cache_size_mb param in the root of the config file."
+            );
+        }
+
+        Ok(())
+    }
+
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}
+
+impl SourceConfigExtras for PmtConfig {
+    fn parse_urls() -> bool {
+        true
+    }
+
+    async fn new_sources(&self, id: String, path: PathBuf) -> FileResult<TileInfoSource> {
+        Ok(Box::new(
+            PmtFileSource::new(self.new_cached_source(), id, path).await?,
+        ))
+    }
+
+    async fn new_sources_url(&self, id: String, url: Url) -> FileResult<TileInfoSource> {
+        match url.scheme() {
+            "s3" => {
+                let force_path_style = self.force_path_style.unwrap_or_else(|| {
+                    get_env_as_bool("AWS_S3_FORCE_PATH_STYLE").unwrap_or_default()
+                });
+                let skip_credentials = self.skip_credentials.unwrap_or_else(|| {
+                    get_env_as_bool("AWS_SKIP_CREDENTIALS").unwrap_or_else(|| {
+                        // `AWS_NO_CREDENTIALS` was the name in some early documentation of this feature
+                        get_env_as_bool("AWS_NO_CREDENTIALS").unwrap_or_default()
+                    })
+                });
+                Ok(Box::new(
+                    PmtS3Source::new(
+                        self.new_cached_source(),
+                        id,
+                        url,
+                        skip_credentials,
+                        force_path_style,
+                    )
+                    .await?,
+                ))
+            }
+            _ => Ok(Box::new(
+                PmtHttpSource::new(
+                    self.client.clone().unwrap(),
+                    self.new_cached_source(),
+                    id,
+                    url,
+                )
+                .await?,
+            )),
+        }
+    }
+}
+
+/// Interpret an environment variable as a [`bool`]
+///
+/// This ignores casing and treats bad utf8 encoding as `false`.
+fn get_env_as_bool(key: &'static str) -> Option<bool> {
+    let val = std::env::var_os(key)?.to_ascii_lowercase();
+    Some(val.to_str().is_some_and(|val| val == "1" || val == "true"))
+}

--- a/martin/src/sprites/config.rs
+++ b/martin/src/sprites/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::ConfigExtras;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SpriteConfig {
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigExtras for SpriteConfig {
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}

--- a/martin/src/sprites/mod.rs
+++ b/martin/src/sprites/mod.rs
@@ -13,8 +13,10 @@ use spreet::{
 use tokio::io::AsyncReadExt;
 
 use self::SpriteError::{SpriteInstError, SpriteParsingError, SpriteProcessingError};
-use crate::config::UnrecognizedValues;
-use crate::file_config::{ConfigExtras, FileConfigEnum, FileResult};
+use crate::file_config::{FileConfigEnum, FileResult};
+
+mod config;
+pub use config::SpriteConfig;
 
 pub type SpriteResult<T> = Result<T, SpriteError>;
 
@@ -57,18 +59,6 @@ pub struct CatalogSpriteEntry {
 }
 
 pub type SpriteCatalog = HashMap<String, CatalogSpriteEntry>;
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct SpriteConfig {
-    #[serde(flatten)]
-    pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigExtras for SpriteConfig {
-    fn get_unrecognized(&self) -> &UnrecognizedValues {
-        &self.unrecognized
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct SpriteSources(DashMap<String, SpriteSource>);

--- a/martin/src/styles/config.rs
+++ b/martin/src/styles/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::UnrecognizedValues;
+use crate::file_config::ConfigExtras;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StyleConfig {
+    #[serde(flatten)]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigExtras for StyleConfig {
+    fn get_unrecognized(&self) -> &UnrecognizedValues {
+        &self.unrecognized
+    }
+}

--- a/martin/src/styles/mod.rs
+++ b/martin/src/styles/mod.rs
@@ -6,8 +6,10 @@ use dashmap::{DashMap, Entry};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
-use crate::config::UnrecognizedValues;
-use crate::file_config::{ConfigExtras, FileConfigEnum, FileError, FileResult};
+use crate::file_config::{FileConfigEnum, FileError, FileResult};
+
+mod config;
+pub use config::StyleConfig;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CatalogStyleEntry {
@@ -15,18 +17,6 @@ pub struct CatalogStyleEntry {
 }
 
 pub type StyleCatalog = HashMap<String, CatalogStyleEntry>;
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct StyleConfig {
-    #[serde(flatten)]
-    pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigExtras for StyleConfig {
-    fn get_unrecognized(&self) -> &UnrecognizedValues {
-        &self.unrecognized
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(test, serde_with::skip_serializing_none, derive(serde::Serialize))]


### PR DESCRIPTION
I noticed that https://github.com/maplibre/martin/pull/1949 is likely too large to get a simple review.

This PR splits out the config file moving.
This way, the other PR is much simpler to review