### PR TITLE
chore(ci): simplify the `mdbook-alerts` installation

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -30,9 +30,7 @@ jobs:
           config-file: '.github/files/markdown.links.config.json'
 
       - uses: taiki-e/install-action@v2
-        with: { tool: 'mdbook,cargo-binstall' }
-      - name: Install mdbook-alerts
-        run: cargo binstall mdbook-alerts
+        with: { tool: 'mdbook,mdbook-alerts' }
 
       - run: mdbook build docs
 


### PR DESCRIPTION
This PR changes us to have a simpler `mdbook-alerts` installation.

Requires the following PR to pass CI:
- https://github.com/taiki-e/install-action/pull/1060