### PR TITLE
fix(ui): fix infinte loop on the dasboad metrics section

### DIFF
--- a/martin/martin-ui/src/Dashboard.tsx
+++ b/martin/martin-ui/src/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { AnalyticsSection } from '@/components/analytics-section';
 import { useAsyncOperation } from '@/hooks/use-async-operation';
 import { buildMartinUrl } from '@/lib/api';
@@ -58,6 +58,7 @@ export default function MartinTileserverDashboard() {
   });
 
   // Load analytics data and set up auto-refresh
+  // biome-ignore lint/correctness/useExhaustiveDependencies: if we list analyticsOperation.execute below, this is an infinte loop
   useEffect(() => {
     // Initial load
     analyticsOperation.execute();
@@ -68,7 +69,7 @@ export default function MartinTileserverDashboard() {
     }, 15 * 1000);
 
     return () => clearInterval(interval);
-  }, [analyticsOperation.execute]);
+  }, []);
 
   return (
     <div className="container mx-auto px-6 py-8">


### PR DESCRIPTION
during one of the merges of #1897, I seem to have mismerged.

This PR restores us to the state that I wanted #1942 to be

<img width="1528" height="650" alt="image" src="https://github.com/user-attachments/assets/a2a5a136-03ee-4a94-9a23-e538767e9fda" />
