### PR TITLE
feat(ui): Add the font catalog to the dashboard

### DIFF
--- a/martin/martin-ui/__tests__/components/catalogs/font.test.tsx
+++ b/martin/martin-ui/__tests__/components/catalogs/font.test.tsx
@@ -61,7 +61,7 @@ jest.mock('@/components/ui/card', () => ({
   ),
 }));
 
-jest.mock('@/components/ui/disabledNonInteractiveButton', () => ({
+jest.mock('@/components/ui/disabled-non-interactive-button', () => ({
   DisabledNonInteractiveButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
     <button {...props} disabled>
       {children}

--- a/martin/martin-ui/__tests__/components/catalogs/font.test.tsx
+++ b/martin/martin-ui/__tests__/components/catalogs/font.test.tsx
@@ -1,0 +1,293 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type React from 'react';
+import { FontCatalog } from '@/components/catalogs/font';
+import type { Font } from '@/lib/types';
+
+// Mock all UI components
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/copy-link-button', () => ({
+  CopyLinkButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button data-testid="copy-link-button" {...props}>
+      {children ?? 'Copy Link'}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: React.ComponentProps<'span'>) => (
+    <span data-slot="badge" {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+jest.mock('@/components/ui/input', () => ({
+  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+}));
+
+jest.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: React.ComponentProps<'div'>) => (
+    <div data-testid="card-content" {...props}>
+      {children}
+    </div>
+  ),
+  CardDescription: ({ children, ...props }: React.ComponentProps<'div'>) => (
+    <div data-testid="card-description" {...props}>
+      {children}
+    </div>
+  ),
+  CardHeader: ({ children, ...props }: React.ComponentProps<'div'>) => (
+    <div data-testid="card-header" {...props}>
+      {children}
+    </div>
+  ),
+  CardTitle: ({ children, ...props }: React.ComponentProps<'div'>) => (
+    <div data-testid="card-title" {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('@/components/ui/disabledNonInteractiveButton', () => ({
+  DisabledNonInteractiveButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button {...props} disabled>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className, ...props }: React.ComponentProps<'div'>) => (
+    <div className={className} data-testid="skeleton" {...props} />
+  ),
+}));
+
+jest.mock('@/components/loading/catalog-skeleton', () => ({
+  CatalogSkeleton: ({ title, description }: { title: string; description: string }) => (
+    <div data-testid="catalog-skeleton">
+      <div data-testid="skeleton-title">{title}</div>
+      <div data-testid="skeleton-description">{description}</div>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/error/error-state', () => ({
+  ErrorState: ({ title, description }: { title: string; description: string }) => (
+    <div data-testid="error-state">
+      <div data-testid="error-title">{title}</div>
+      <div data-testid="error-description">{description}</div>
+    </div>
+  ),
+}));
+
+jest.mock('lucide-react', () => ({
+  Download: () => <div data-testid="download-icon">Download</div>,
+  Eye: () => <div data-testid="eye-icon">Eye</div>,
+  Search: () => <div data-testid="search-icon">Search</div>,
+  Type: () => <div data-testid="type-icon">Type</div>,
+}));
+
+// Mock the toast hook
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
+// Mock the API
+jest.mock('@/lib/api', () => ({
+  buildMartinUrl: jest.fn((path: string) => `http://localhost:3000${path}`),
+}));
+
+describe('FontCatalog Component', () => {
+  const mockFonts: { [name: string]: Font } = {
+    'Noto Sans Bold': {
+      end: 255,
+      family: 'Noto Sans',
+      format: 'ttf',
+      glyphs: 380,
+      lastModifiedAt: new Date('2023-03-20'),
+      start: 0,
+      style: 'Bold',
+    },
+    'Open Sans Regular': {
+      end: 255,
+      family: 'Open Sans',
+      format: 'otf',
+      glyphs: 420,
+      lastModifiedAt: new Date('2023-02-15'),
+      start: 0,
+      style: 'Regular',
+    },
+    'Roboto Medium': {
+      end: 255,
+      family: 'Roboto',
+      format: 'ttf',
+      glyphs: 350,
+      lastModifiedAt: new Date('2023-01-01'),
+      start: 0,
+      style: 'Medium',
+    },
+  };
+
+  const defaultProps = {
+    error: null,
+    fonts: mockFonts,
+    isLoading: false,
+    isRetrying: false,
+    onRetry: jest.fn(),
+    onSearchChangeAction: jest.fn(),
+    searchQuery: '',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders loading skeleton when isLoading is true', () => {
+    render(<FontCatalog {...defaultProps} isLoading={true} />);
+    expect(screen.getByText('Font Catalog')).toBeInTheDocument();
+    expect(screen.getByText('Preview all available font assets')).toBeInTheDocument();
+    // Check that skeleton elements are rendered
+    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0); // Multiple skeleton elements
+  });
+
+  it('renders error state when there is an error', () => {
+    const error = new Error('Test error');
+    render(<FontCatalog {...defaultProps} error={error} />);
+    expect(screen.getByText('Failed to Load Fonts')).toBeInTheDocument();
+    expect(screen.getByText('Unable to fetch font catalog from the server')).toBeInTheDocument();
+    expect(screen.getByText('Test error')).toBeInTheDocument();
+    expect(screen.getByText('Try Again')).toBeInTheDocument();
+  });
+
+  it('renders font catalog correctly', () => {
+    render(<FontCatalog {...defaultProps} />);
+
+    // Check title and description
+    expect(screen.getByText('Font Catalog')).toBeInTheDocument();
+    expect(screen.getByText('Preview all available font assets')).toBeInTheDocument();
+
+    // Check that all fonts are rendered
+    expect(screen.getByText('Roboto Medium')).toBeInTheDocument();
+    expect(screen.getByText('Open Sans Regular')).toBeInTheDocument();
+    expect(screen.getByText('Noto Sans Bold')).toBeInTheDocument();
+
+    // Check family and style information
+    expect(screen.getByText('Family: Roboto • Style: Medium')).toBeInTheDocument();
+    expect(screen.getByText('Family: Open Sans • Style: Regular')).toBeInTheDocument();
+    expect(screen.getByText('Family: Noto Sans • Style: Bold')).toBeInTheDocument();
+
+    // Check glyph counts
+    expect(screen.getByText('350')).toBeInTheDocument();
+    expect(screen.getByText('420')).toBeInTheDocument();
+    expect(screen.getByText('380')).toBeInTheDocument();
+
+    // Check format badges - badges should be rendered with uppercase format
+    const badges = document.querySelectorAll('[data-slot="badge"]');
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveTextContent('ttf');
+    expect(badges[1]).toHaveTextContent('otf');
+    expect(badges[2]).toHaveTextContent('ttf');
+  });
+
+  it('filters fonts based on search query', () => {
+    render(<FontCatalog {...defaultProps} searchQuery="roboto" />);
+
+    // Should only show the Roboto font
+    expect(screen.getByText('Roboto Medium')).toBeInTheDocument();
+    expect(screen.queryByText('Open Sans Regular')).not.toBeInTheDocument();
+    expect(screen.queryByText('Noto Sans Bold')).not.toBeInTheDocument();
+
+    // Should have only one badge
+    const badges = document.querySelectorAll('[data-slot="badge"]');
+    expect(badges).toHaveLength(1);
+  });
+
+  it('filters fonts based on font family', () => {
+    render(<FontCatalog {...defaultProps} searchQuery="open" />);
+
+    // Should only show the Open Sans font
+    expect(screen.queryByText('Roboto Medium')).not.toBeInTheDocument();
+    expect(screen.getByText('Open Sans Regular')).toBeInTheDocument();
+    expect(screen.queryByText('Noto Sans Bold')).not.toBeInTheDocument();
+  });
+
+  it('filters fonts based on style', () => {
+    render(<FontCatalog {...defaultProps} searchQuery="bold" />);
+
+    // Should only show the Noto Sans Bold font
+    expect(screen.queryByText('Roboto Medium')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open Sans Regular')).not.toBeInTheDocument();
+    expect(screen.getByText('Noto Sans Bold')).toBeInTheDocument();
+  });
+
+  it('shows no results message when search has no matches', () => {
+    render(<FontCatalog {...defaultProps} searchQuery="nonexistent" />);
+    expect(screen.getByText(/No fonts found matching "nonexistent"/i)).toBeInTheDocument();
+
+    // Should not render any badges
+    const badges = document.querySelectorAll('[data-slot="badge"]');
+    expect(badges).toHaveLength(0);
+  });
+
+  it('calls onSearchChangeAction when search input changes', () => {
+    render(<FontCatalog {...defaultProps} />);
+    const searchInput = screen.getByPlaceholderText('Search fonts...');
+
+    fireEvent.change(searchInput, { target: { value: 'new search' } });
+    expect(defaultProps.onSearchChangeAction).toHaveBeenCalledWith('new search');
+  });
+
+  it('renders copy link buttons for each font', () => {
+    render(<FontCatalog {...defaultProps} />);
+
+    // Should have 3 copy link buttons (one for each font) - they render as buttons with specific classes
+    const copyLinkButtons = document.querySelectorAll('button[class*="bg-transparent"]');
+    expect(copyLinkButtons).toHaveLength(3);
+  });
+
+  it('renders details buttons for each font', () => {
+    render(<FontCatalog {...defaultProps} />);
+
+    // Should have 3 details buttons (one for each font)
+    const detailsButtons = screen.getAllByText('Details');
+    expect(detailsButtons).toHaveLength(3);
+  });
+
+  it('renders with empty fonts object', () => {
+    render(<FontCatalog {...defaultProps} fonts={{}} />);
+
+    expect(screen.getByText('Font Catalog')).toBeInTheDocument();
+    expect(screen.getByText('No fonts found.')).toBeInTheDocument();
+  });
+
+  it('renders with undefined fonts', () => {
+    render(<FontCatalog {...defaultProps} fonts={undefined} />);
+
+    expect(screen.getByText('Font Catalog')).toBeInTheDocument();
+    expect(screen.getByText('No fonts found.')).toBeInTheDocument();
+  });
+
+  it('case insensitive search works correctly', () => {
+    render(<FontCatalog {...defaultProps} searchQuery="ROBOTO" />);
+
+    // Should still show the Roboto font despite case difference
+    expect(screen.getByText('Roboto Medium')).toBeInTheDocument();
+    expect(screen.queryByText('Open Sans Regular')).not.toBeInTheDocument();
+    expect(screen.queryByText('Noto Sans Bold')).not.toBeInTheDocument();
+  });
+});

--- a/martin/martin-ui/src/Dashboard.tsx
+++ b/martin/martin-ui/src/Dashboard.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { Suspense, useCallback, useEffect } from 'react';
 import { AnalyticsSection } from '@/components/analytics-section';
+import { DashboardContent } from '@/components/dashboard-content';
 import { useAsyncOperation } from '@/hooks/use-async-operation';
 import { buildMartinUrl } from '@/lib/api';
 import {
@@ -78,7 +79,9 @@ export default function MartinTileserverDashboard() {
         isLoading={analyticsOperation.isLoading}
       />
 
-      <DashboardLoading />
+      <Suspense fallback={<DashboardLoading />}>
+        <DashboardContent />
+      </Suspense>
     </div>
   );
 }

--- a/martin/martin-ui/src/Dashboard.tsx
+++ b/martin/martin-ui/src/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { AnalyticsSection } from '@/components/analytics-section';
 import { useAsyncOperation } from '@/hooks/use-async-operation';
 import { buildMartinUrl } from '@/lib/api';
@@ -58,6 +58,7 @@ export default function MartinTileserverDashboard() {
   });
 
   // Load analytics data and set up auto-refresh
+  // biome-ignore lint/correctness/useExhaustiveDependencies: if we list analyticsOperation.execute below, this is an infinte loop
   useEffect(() => {
     // Initial load
     analyticsOperation.execute();
@@ -68,7 +69,7 @@ export default function MartinTileserverDashboard() {
     }, 15 * 1000);
 
     return () => clearInterval(interval);
-  }, [analyticsOperation.execute]);
+  }, []);
 
   return (
     <div className="container mx-auto px-6 py-8">

--- a/martin/martin-ui/src/components/catalogs/font.tsx
+++ b/martin/martin-ui/src/components/catalogs/font.tsx
@@ -1,0 +1,168 @@
+import { Eye, Search, Type } from 'lucide-react';
+
+import { ErrorState } from '@/components/error/error-state';
+import { CatalogSkeleton } from '@/components/loading/catalog-skeleton';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { buildMartinUrl } from '@/lib/api';
+import type { Font } from '@/lib/types';
+import { CopyLinkButton } from '../ui/copy-link-button';
+import { DisabledNonInteractiveButton } from '../ui/disabled-non-interactive-button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+
+interface FontCatalogProps {
+  fonts?: { [name: string]: Font };
+  searchQuery?: string;
+  onSearchChangeAction?: (query: string) => void;
+  isLoading?: boolean;
+  error?: Error | null;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}
+
+export function FontCatalog({
+  fonts,
+  searchQuery = '',
+  onSearchChangeAction = () => {},
+  isLoading,
+  error = null,
+  onRetry,
+  isRetrying = false,
+}: FontCatalogProps) {
+  if (isLoading) {
+    return <CatalogSkeleton description="Preview all available font assets" title="Font Catalog" />;
+  }
+
+  if (error) {
+    return (
+      <ErrorState
+        description="Unable to fetch font catalog from the server"
+        error={error}
+        isRetrying={isRetrying}
+        onRetry={onRetry}
+        showDetails={true}
+        title="Failed to Load Fonts"
+        variant="server"
+      />
+    );
+  }
+
+  const filteredFonts = Object.entries(fonts || {}).filter(
+    ([name, font]) =>
+      name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      font.family.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      font.style.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row md:items-center items-start justify-between gap-5">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Font Catalog</h2>
+          <p className="text-muted-foreground">Preview all available font assets</p>
+        </div>
+        <div className="relative w-full md:w-64">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+          <Input
+            className="pl-10 md:w-64 w-full bg-card"
+            onChange={(e) => onSearchChangeAction(e.target.value)}
+            placeholder="Search fonts..."
+            value={searchQuery}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {filteredFonts.map(([name, font]) => (
+          <Card className="hover:shadow-lg transition-shadow" key={name}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <Type className="w-5 h-5 text-primary" />
+                  <CardTitle className="text-lg font-mono">{name}</CardTitle>
+                </div>
+                {font.format && (
+                  <Badge className="uppercase" variant="secondary">
+                    {font.format}
+                  </Badge>
+                )}
+              </div>
+              <CardDescription>
+                Family: {font.family} • Style: {font.style}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div className="p-3 bg-gray-50 text-gray-900 rounded-lg">
+                  <p className="text-sm font-medium mb-2 text-gray-900">Preview:</p>
+                  <Tooltip>
+                    <TooltipTrigger className="cursor-help">
+                      <p
+                        className="text-base text-gray-900 blur-sm animate-pulse"
+                        style={{ fontFamily: font.family, fontWeight: 500 }}
+                      >
+                        The quick brown fox jumps over the lazy dog
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Not currently implemented in the frontend</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <div className="space-y-2 text-sm text-muted-foreground">
+                  <div className="flex justify-between">
+                    <span>Glyph count:</span>
+                    <span>{font.glyphs}</span>
+                  </div>
+                </div>
+                <div className="flex flex-col md:flex-row items-center gap-2 mt-4">
+                  <CopyLinkButton
+                    className="flex-1 bg-transparent w-full"
+                    link={buildMartinUrl(`/font/${name}/{range}`)}
+                    size="sm"
+                    toastMessage="Font link copied!"
+                    variant="outline"
+                  />
+                  <Tooltip>
+                    <TooltipTrigger className="flex-1 flex cursor-help w-full">
+                      <DisabledNonInteractiveButton
+                        className="flex-1 grow w-full"
+                        disabled
+                        size="sm"
+                      >
+                        <Eye className="w-4 h-4 mr-2" />
+                        Details
+                      </DisabledNonInteractiveButton>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Not currently implemented in the frontend</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {filteredFonts.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground mb-2">
+            {searchQuery ? <>No fonts found matching "{searchQuery}".</> : 'No fonts found.'}
+          </p>
+          <Button asChild size="lg" variant="link">
+            <a
+              href="https://maplibre.org/martin/sources-fonts.html"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn how to configure Font Sources
+            </a>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/martin/martin-ui/src/components/dashboard-content.tsx
+++ b/martin/martin-ui/src/components/dashboard-content.tsx
@@ -1,0 +1,104 @@
+import { type ErrorInfo, useEffect, useState } from 'react';
+import { FontCatalog } from '@/components/catalogs/font';
+import { ErrorBoundary } from '@/components/error/error-boundary';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Toaster } from '@/components/ui/toaster';
+import { useAsyncOperation } from '@/hooks/use-async-operation';
+import { useToast } from '@/hooks/use-toast';
+import { buildMartinUrl } from '@/lib/api';
+import type { CatalogSchema } from '@/lib/types';
+import { CatalogSkeleton } from './loading/catalog-skeleton';
+
+const fetchCatalog = async (): Promise<CatalogSchema> => {
+  const res = await fetch(buildMartinUrl('/catalog'));
+  if (!res.ok) {
+    throw new Error(`Failed to fetch catalog: ${res.statusText}`);
+  }
+  return res.json();
+};
+
+export function DashboardContent() {
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState('tiles');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Catalog operation
+  const catalogOperation = useAsyncOperation<CatalogSchema>(fetchCatalog, {
+    onError: (error: Error) => console.error('Catalog fetch failed:', error),
+    showErrorToast: false,
+  });
+
+  // Load catalog data
+  useEffect(() => {
+    catalogOperation.execute();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogOperation.execute]);
+
+  return (
+    <ErrorBoundary
+      onError={(error: Error, errorInfo: ErrorInfo) => {
+        console.error('Application error:', error, errorInfo);
+        toast({
+          description: 'An unexpected error occurred. The page will reload automatically.',
+          title: 'Application Error',
+          variant: 'destructive',
+        });
+
+        // Auto-reload after 3 seconds
+        setTimeout(() => {
+          window.location.reload();
+        }, 3000);
+      }}
+    >
+      <Tabs className="space-y-6" onValueChange={(value) => setActiveTab(value)} value={activeTab}>
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="tiles">
+            Tiles<span className="md:block hidden ms-1">Catalog</span>
+          </TabsTrigger>
+          <TabsTrigger value="styles">
+            Styles<span className="md:block hidden ms-1">Catalog</span>
+          </TabsTrigger>
+          <TabsTrigger value="fonts">
+            Fonts<span className="md:block hidden ms-1">Catalog</span>
+          </TabsTrigger>
+          <TabsTrigger value="sprites">
+            Sprites<span className="md:block hidden ms-1">Catalog</span>
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="tiles">
+          <CatalogSkeleton
+            description="Explore all available tile sources"
+            title="Tiles Sources Catalog"
+          />
+        </TabsContent>
+
+        <TabsContent value="styles">
+          <CatalogSkeleton
+            description="Preview all available map styles and themes"
+            title="Styles Catalog"
+          />
+        </TabsContent>
+
+        <TabsContent value="fonts">
+          <FontCatalog
+            error={catalogOperation.error}
+            fonts={catalogOperation.data?.fonts}
+            isLoading={catalogOperation.isLoading}
+            onSearchChangeAction={setSearchQuery}
+            searchQuery={searchQuery}
+          />
+        </TabsContent>
+
+        <TabsContent value="sprites">
+          <CatalogSkeleton
+            description="Preview all available sprite sheets and icons"
+            title="Sprite Catalog"
+          />
+        </TabsContent>
+      </Tabs>
+
+      <Toaster />
+    </ErrorBoundary>
+  );
+}

--- a/martin/martin-ui/src/components/dashboard-content.tsx
+++ b/martin/martin-ui/src/components/dashboard-content.tsx
@@ -29,10 +29,10 @@ export function DashboardContent() {
   });
 
   // Load catalog data
+  // biome-ignore lint/correctness/useExhaustiveDependencies: if we list analyticsOperation.execute below, this is an infinte loop
   useEffect(() => {
     catalogOperation.execute();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [catalogOperation.execute]);
+  }, []);
 
   return (
     <ErrorBoundary

--- a/martin/martin-ui/src/components/ui/copy-link-button.tsx
+++ b/martin/martin-ui/src/components/ui/copy-link-button.tsx
@@ -1,0 +1,71 @@
+import { Clipboard } from 'lucide-react';
+import * as React from 'react';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from './button';
+
+/**
+ * Props for CopyLinkButton
+ * @param link The string to copy to clipboard (required)
+ * @param children Optional label or content for the button (defaults to "Copy Link")
+ * @param className Optional additional class names for the button
+ * @param toastMessage Optional custom toast message (defaults to "Link copied!")
+ * @param size Button size (defaults to "sm")
+ * @param variant Button variant (defaults to "outline")
+ * @param iconPosition "left" or "right" (defaults to "left")
+ * @param ...props Any other Button props
+ */
+export interface CopyLinkButtonProps extends React.ComponentProps<typeof Button> {
+  link: string;
+  children?: React.ReactNode;
+  className?: string;
+  toastMessage?: string;
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+  iconPosition?: 'left' | 'right';
+}
+
+export function CopyLinkButton({
+  link,
+  children,
+  className,
+  toastMessage = 'Link copied!',
+  size = 'sm',
+  variant = 'outline',
+  iconPosition = 'left',
+  ...props
+}: CopyLinkButtonProps) {
+  const { toast } = useToast();
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+      toast({ description: toastMessage });
+      setTimeout(() => setCopied(false), 3000);
+    } catch {
+      toast({ description: 'Failed to copy link', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Button
+      aria-label="Copy link"
+      className={className}
+      onClick={handleCopy}
+      size={size}
+      type="button"
+      variant={variant}
+      {...props}
+    >
+      {iconPosition === 'left' && (
+        <Clipboard aria-hidden="true" className="w-4 h-4 mr-2" data-testid="clipboard-icon" />
+      )}
+      {children ?? (copied ? 'Copied!' : 'Copy Link')}
+      {iconPosition === 'right' && (
+        <Clipboard aria-hidden="true" className="w-4 h-4 ml-2" data-testid="clipboard-icon" />
+      )}
+    </Button>
+  );
+}

--- a/martin/martin-ui/src/components/ui/disabled-non-interactive-button.tsx
+++ b/martin/martin-ui/src/components/ui/disabled-non-interactive-button.tsx
@@ -1,0 +1,48 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all pointer-events-none opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
+    variants: {
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        icon: 'size-9',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+      },
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+      },
+    },
+  },
+);
+
+export function DisabledNonInteractiveButton({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return <Comp className={cn(buttonVariants({ className, size, variant }))} {...props} />;
+}

--- a/martin/martin-ui/src/components/ui/input.tsx
+++ b/martin/martin-ui/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className,
+        )}
+        ref={ref}
+        type={type}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };


### PR DESCRIPTION
This breaks the font catalog out of #1897 

Yes, this seems also quite heavy in terms of lines chaneged, but this is the smallest version of this feature sadly.
I hope that from a reviewer load, this is still acceptable though.

It WIP since I still need to do my own review

<img width="1470" height="953" alt="image" src="https://github.com/user-attachments/assets/3bfed819-cbba-4f18-8435-21235ca164b4" />
