### PR TITLE
docs: document `postgres.auto_publish.functions.from_schemas`

### DIFF
--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -127,6 +127,10 @@ postgres:
       # Tile extent in tile coordinate space, optional, default to 4096
       extent: 4096
     functions:
+      # Optionally limit to just these schemas
+      from_schemas:
+        - public
+        - my_schema
       # Optionally set how source ID should be generated based on the function's name and schema
       source_id_format: '{schema}.{function}'
 


### PR DESCRIPTION
We somehow forgot to document this aspect of the config file in the reference