### PR TITLE
fix(ci): re-enable caches for `x86_64-apple-darwin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch:
 
 defaults:
@@ -96,7 +96,7 @@ jobs:
         with: { set-safe-directory: false }
       - name: Install zig
         uses: korandoru/setup-zig@v1
-        with: { zig-version: "0.14.0" }
+        with: { zig-version: '0.14.0' }
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-zigbuild }
       - run: rustup target add ${{ matrix.target }}
@@ -119,7 +119,7 @@ jobs:
   docker-build-test:
     name: Build and test docker images
     runs-on: ubuntu-latest
-    needs: [musl-build, lint-debug-test]
+    needs: [ musl-build, lint-debug-test ]
     permissions:
       id-token: write
       attestations: write
@@ -182,27 +182,27 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # https://github.com/docker/setup-qemu-action
-        with: { platforms: "linux/amd64,linux/arm64" }
+        with: { platforms: 'linux/amd64,linux/arm64' }
       - name: Set up gdal-bin and sqlite3-tools
         run: sudo apt-get update && sudo apt-get install -y gdal-bin sqlite3-tools
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         # https://github.com/docker/setup-buildx-action
-        with: { install: true, platforms: "linux/amd64,linux/arm64" }
+        with: { install: true, platforms: 'linux/amd64,linux/arm64' }
       - name: Download build artifact build-aarch64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: "build-aarch64-unknown-linux-musl", path: "target_releases/linux/arm64/" }
+        with: { name: 'build-aarch64-unknown-linux-musl', path: 'target_releases/linux/arm64/' }
       - name: Mark target_releases/linux/arm64/* as executable
         run: chmod +x target_releases/linux/arm64/*
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-unknown-linux-musl", path: "target_releases/linux/amd64/" }
+        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target_releases/linux/amd64/' }
       - name: Mark target_releases/linux/amd64/* as executable
         run: chmod +x target_releases/linux/amd64/*
       - name: Start NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: "5412", output-unix-paths: "yes" }
+        with: { port: '5412', output-unix-paths: 'yes' }
       - name: Copy static files
         run: cp -r tests/fixtures/pmtiles2/* ${{ steps.nginx.outputs.html-dir }}
       - name: Docker meta
@@ -335,7 +335,7 @@ jobs:
             os: macos-13 # x64 CPU
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            ext: ".exe"
+            ext: '.exe'
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
@@ -347,7 +347,6 @@ jobs:
       # We cannot cache the others as well because we only have 10GB of cache
       - if: matrix.target == 'x86_64-apple-darwin' && github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@v2
-
       - name: Rust Versions
         run: rustc --version && cargo --version
       - name: Install NASM for rustls/aws-lc-rs on Windows
@@ -383,13 +382,13 @@ jobs:
   test-aws-lambda:
     name: Test AWS Lambda
     runs-on: ubuntu-latest
-    needs: [musl-build]
+    needs: [ musl-build ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-unknown-linux-musl", path: "target/" }
+        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/' }
       - run: tests/test-aws-lambda.sh
         env:
           MARTIN_BIN: target/martin
@@ -397,7 +396,7 @@ jobs:
   test-multi-os:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: [build]
+    needs: [ build ]
     env:
       # PG_* variables are used by psql
       PGDATABASE: test
@@ -667,25 +666,25 @@ jobs:
         uses: actions/checkout@v4
       - name: Download build artifact build-aarch64-apple-darwin
         uses: actions/download-artifact@v4
-        with: { name: "build-aarch64-apple-darwin", path: "target/aarch64-apple-darwin" }
+        with: { name: 'build-aarch64-apple-darwin', path: 'target/aarch64-apple-darwin' }
       - name: Download build artifact build-x86_64-apple-darwin
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-apple-darwin", path: "target/x86_64-apple-darwin" }
+        with: { name: 'build-x86_64-apple-darwin', path: 'target/x86_64-apple-darwin' }
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-unknown-linux-gnu", path: "target/x86_64-unknown-linux-gnu" }
+        with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target/x86_64-unknown-linux-gnu' }
       - name: Download build artifact build-aarch64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: "build-aarch64-unknown-linux-musl", path: "target/aarch64-unknown-linux-musl" }
+        with: { name: 'build-aarch64-unknown-linux-musl', path: 'target/aarch64-unknown-linux-musl' }
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-unknown-linux-musl", path: "target/x86_64-unknown-linux-musl" }
+        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/x86_64-unknown-linux-musl' }
       - name: Download build artifact build-x86_64-pc-windows-msvc
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-pc-windows-msvc", path: "target/x86_64-pc-windows-msvc" }
+        with: { name: 'build-x86_64-pc-windows-msvc', path: 'target/x86_64-pc-windows-msvc' }
       - name: Download build artifact build-debian-x86_64
         uses: actions/download-artifact@v4
-        with: { name: "build-debian-x86_64", path: "target/debian-x86_64" }
+        with: { name: 'build-debian-x86_64', path: 'target/debian-x86_64' }
 
       - name: Package
         run: |
@@ -736,12 +735,12 @@ jobs:
 
       - name: Save Homebrew Config
         uses: actions/upload-artifact@v4
-        with: { name: "homebrew-config", path: "target/homebrew_config.yaml" }
+        with: { name: 'homebrew-config', path: 'target/homebrew_config.yaml' }
 
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
-        with: { files: "target/files/*", generate_release_notes: true }
+        with: { files: 'target/files/*', generate_release_notes: true }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -776,14 +775,14 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }} # See instructions above
-          commit-message: "Update to ${{ github.ref }}"
-          title: "Update to ${{ github.ref }}"
-          body: "Update to ${{ github.ref }}"
-          branch: "update-to-${{ github.ref }}"
+          commit-message: 'Update to ${{ github.ref }}'
+          title: 'Update to ${{ github.ref }}'
+          body: 'Update to ${{ github.ref }}'
+          branch: 'update-to-${{ github.ref }}'
           branch-suffix: timestamp
-          base: "main"
-          labels: "auto-update"
-          assignees: "nyurik"
+          base: 'main'
+          labels: 'auto-update'
+          assignees: 'nyurik'
           draft: false
           delete-branch: true
           path: target/homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
           #   os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            ext: ".exe"
+            ext: '.exe'
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
@@ -424,7 +424,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: nyurik/action-setup-postgis@v2.2
         id: pg
-        with: { username: "postgres", password: "postgres", database: "test", postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
+        with: { username: 'postgres', password: 'postgres', database: 'test', postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
       - name: Install and run Postgis (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -448,7 +448,7 @@ jobs:
       - name: Start NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: "5412", output-unix-paths: "yes" }
+        with: { port: '5412', output-unix-paths: 'yes' }
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Init database
@@ -494,7 +494,7 @@ jobs:
       - name: Download Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions/download-artifact@v4
-        with: { name: "build-debian-x86_64", path: "target/" }
+        with: { name: 'build-debian-x86_64', path: 'target/' }
       - name: Tests Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
@@ -521,7 +521,7 @@ jobs:
   test-with-svc:
     name: Test postgis:${{ matrix.img_ver }} sslmode=${{ matrix.sslmode }}
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [ build ]
     strategy:
       fail-fast: true
       matrix:
@@ -579,7 +579,7 @@ jobs:
       - name: Run NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: "5412", output-unix-paths: "yes" }
+        with: { port: '5412', output-unix-paths: 'yes' }
       - name: Copy static files
         run: cp -r tests/fixtures/pmtiles2/* ${{ steps.nginx.outputs.html-dir }}
       - name: Init database
@@ -595,7 +595,7 @@ jobs:
           docker cp ${{ job.services.postgres.id }}:/etc/ssl/private/ssl-cert-snakeoil.key target/certs/server.key
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@v4
-        with: { name: "build-x86_64-unknown-linux-gnu", path: "target_releases/" }
+        with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target_releases/' }
       - name: Set up gdal-bin and sqlite3-tools
         run: sudo apt update && sudo apt-get install -y gdal-bin sqlite3-tools
       - name: Integration Tests
@@ -616,7 +616,7 @@ jobs:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
       - name: Download Debian package
         uses: actions/download-artifact@v4
-        with: { name: "build-debian-x86_64", path: "target_releases/" }
+        with: { name: 'build-debian-x86_64', path: 'target_releases/' }
       - name: Tests Debian package
         run: |
           sudo dpkg -i target_releases/debian-x86_64.deb
@@ -660,7 +660,7 @@ jobs:
   package:
     name: Package
     runs-on: ubuntu-latest
-    needs: [lint-debug-test, test-multi-os, test-with-svc, test-aws-lambda]
+    needs: [ lint-debug-test, test-multi-os, test-with-svc, test-aws-lambda ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -726,11 +726,11 @@ jobs:
           cd target
 
           cat << EOF > homebrew_config.yaml
-          version: "$MARTIN_VERSION"
-          macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
-          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          version: '$MARTIN_VERSION"
+          macos_arm_sha256: '$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          macos_intel_sha256: '$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          linux_arm_sha256: '$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          linux_intel_sha256: '$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF
 
       - name: Save Homebrew Config
@@ -792,7 +792,7 @@ jobs:
   done:
     name: CI Finished
     runs-on: ubuntu-latest
-    needs: [package, docker-build-test]
+    needs: [ package, docker-build-test ]
     if: always()
     steps:
       - name: Result of the needed steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   release:
-    types: [ published ]
+    types: [published]
   workflow_dispatch:
 
 defaults:
@@ -96,7 +96,7 @@ jobs:
         with: { set-safe-directory: false }
       - name: Install zig
         uses: korandoru/setup-zig@v1
-        with: { zig-version: '0.14.0' }
+        with: { zig-version: "0.14.0" }
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-zigbuild }
       - run: rustup target add ${{ matrix.target }}
@@ -119,7 +119,7 @@ jobs:
   docker-build-test:
     name: Build and test docker images
     runs-on: ubuntu-latest
-    needs: [ musl-build, lint-debug-test ]
+    needs: [musl-build, lint-debug-test]
     permissions:
       id-token: write
       attestations: write
@@ -182,27 +182,27 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # https://github.com/docker/setup-qemu-action
-        with: { platforms: 'linux/amd64,linux/arm64' }
+        with: { platforms: "linux/amd64,linux/arm64" }
       - name: Set up gdal-bin and sqlite3-tools
         run: sudo apt-get update && sudo apt-get install -y gdal-bin sqlite3-tools
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         # https://github.com/docker/setup-buildx-action
-        with: { install: true, platforms: 'linux/amd64,linux/arm64' }
+        with: { install: true, platforms: "linux/amd64,linux/arm64" }
       - name: Download build artifact build-aarch64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: 'build-aarch64-unknown-linux-musl', path: 'target_releases/linux/arm64/' }
+        with: { name: "build-aarch64-unknown-linux-musl", path: "target_releases/linux/arm64/" }
       - name: Mark target_releases/linux/arm64/* as executable
         run: chmod +x target_releases/linux/arm64/*
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target_releases/linux/amd64/' }
+        with: { name: "build-x86_64-unknown-linux-musl", path: "target_releases/linux/amd64/" }
       - name: Mark target_releases/linux/amd64/* as executable
         run: chmod +x target_releases/linux/amd64/*
       - name: Start NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: '5412', output-unix-paths: 'yes' }
+        with: { port: "5412", output-unix-paths: "yes" }
       - name: Copy static files
         run: cp -r tests/fixtures/pmtiles2/* ${{ steps.nginx.outputs.html-dir }}
       - name: Docker meta
@@ -327,21 +327,27 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-latest  # M-series CPU
+            os: macos-latest # M-series CPU
           - target: debian-x86_64
             os: ubuntu-22.04 # downgraded to have lower libc support. Debian-12 (stable at the time of writing) does not support the same version ubuntu does.
             # TODO: update to ubuntu-latest again once debian 13 launches
           - target: x86_64-apple-darwin
-            os: macos-13  # x64 CPU
+            os: macos-13 # x64 CPU
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            ext: '.exe'
+            ext: ".exe"
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
+      # the macos x86 runners are 3x slower than all other runners.
+      # We need to cache here to not spend 30 minutes on each build.
+      # We cannot cache the others as well because we only have 10GB of cache
+      - if: matrix.target == 'x86_64-apple-darwin' && github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+        uses: Swatinem/rust-cache@v2
+
       - name: Rust Versions
         run: rustc --version && cargo --version
       - name: Install NASM for rustls/aws-lc-rs on Windows
@@ -377,22 +383,21 @@ jobs:
   test-aws-lambda:
     name: Test AWS Lambda
     runs-on: ubuntu-latest
-    needs: [ musl-build ]
+    needs: [musl-build]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/' }
+        with: { name: "build-x86_64-unknown-linux-musl", path: "target/" }
       - run: tests/test-aws-lambda.sh
         env:
           MARTIN_BIN: target/martin
 
-
   test-multi-os:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: [ build ]
+    needs: [build]
     env:
       # PG_* variables are used by psql
       PGDATABASE: test
@@ -412,7 +417,7 @@ jobs:
           #   os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            ext: '.exe'
+            ext: ".exe"
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
@@ -420,7 +425,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: nyurik/action-setup-postgis@v2.2
         id: pg
-        with: { username: 'postgres', password: 'postgres', database: 'test',postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
+        with: { username: "postgres", password: "postgres", database: "test", postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
       - name: Install and run Postgis (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -444,7 +449,7 @@ jobs:
       - name: Start NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: '5412', output-unix-paths: 'yes' }
+        with: { port: "5412", output-unix-paths: "yes" }
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Init database
@@ -490,7 +495,7 @@ jobs:
       - name: Download Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions/download-artifact@v4
-        with: { name: 'build-debian-x86_64', path: 'target/' }
+        with: { name: "build-debian-x86_64", path: "target/" }
       - name: Tests Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
@@ -517,7 +522,7 @@ jobs:
   test-with-svc:
     name: Test postgis:${{ matrix.img_ver }} sslmode=${{ matrix.sslmode }}
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [build]
     strategy:
       fail-fast: true
       matrix:
@@ -575,7 +580,7 @@ jobs:
       - name: Run NGINX
         uses: nyurik/action-setup-nginx@v1.1
         id: nginx
-        with: { port: '5412', output-unix-paths: 'yes' }
+        with: { port: "5412", output-unix-paths: "yes" }
       - name: Copy static files
         run: cp -r tests/fixtures/pmtiles2/* ${{ steps.nginx.outputs.html-dir }}
       - name: Init database
@@ -591,7 +596,7 @@ jobs:
           docker cp ${{ job.services.postgres.id }}:/etc/ssl/private/ssl-cert-snakeoil.key target/certs/server.key
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target_releases/' }
+        with: { name: "build-x86_64-unknown-linux-gnu", path: "target_releases/" }
       - name: Set up gdal-bin and sqlite3-tools
         run: sudo apt update && sudo apt-get install -y gdal-bin sqlite3-tools
       - name: Integration Tests
@@ -612,7 +617,7 @@ jobs:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
       - name: Download Debian package
         uses: actions/download-artifact@v4
-        with: { name: 'build-debian-x86_64', path: 'target_releases/' }
+        with: { name: "build-debian-x86_64", path: "target_releases/" }
       - name: Tests Debian package
         run: |
           sudo dpkg -i target_releases/debian-x86_64.deb
@@ -656,31 +661,31 @@ jobs:
   package:
     name: Package
     runs-on: ubuntu-latest
-    needs: [ lint-debug-test, test-multi-os, test-with-svc, test-aws-lambda ]
+    needs: [lint-debug-test, test-multi-os, test-with-svc, test-aws-lambda]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Download build artifact build-aarch64-apple-darwin
         uses: actions/download-artifact@v4
-        with: { name: 'build-aarch64-apple-darwin', path: 'target/aarch64-apple-darwin' }
+        with: { name: "build-aarch64-apple-darwin", path: "target/aarch64-apple-darwin" }
       - name: Download build artifact build-x86_64-apple-darwin
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-apple-darwin', path: 'target/x86_64-apple-darwin' }
+        with: { name: "build-x86_64-apple-darwin", path: "target/x86_64-apple-darwin" }
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target/x86_64-unknown-linux-gnu' }
+        with: { name: "build-x86_64-unknown-linux-gnu", path: "target/x86_64-unknown-linux-gnu" }
       - name: Download build artifact build-aarch64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: 'build-aarch64-unknown-linux-musl', path: 'target/aarch64-unknown-linux-musl' }
+        with: { name: "build-aarch64-unknown-linux-musl", path: "target/aarch64-unknown-linux-musl" }
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/x86_64-unknown-linux-musl' }
+        with: { name: "build-x86_64-unknown-linux-musl", path: "target/x86_64-unknown-linux-musl" }
       - name: Download build artifact build-x86_64-pc-windows-msvc
         uses: actions/download-artifact@v4
-        with: { name: 'build-x86_64-pc-windows-msvc', path: 'target/x86_64-pc-windows-msvc' }
+        with: { name: "build-x86_64-pc-windows-msvc", path: "target/x86_64-pc-windows-msvc" }
       - name: Download build artifact build-debian-x86_64
         uses: actions/download-artifact@v4
-        with: { name: 'build-debian-x86_64', path: 'target/debian-x86_64' }
+        with: { name: "build-debian-x86_64", path: "target/debian-x86_64" }
 
       - name: Package
         run: |
@@ -731,12 +736,12 @@ jobs:
 
       - name: Save Homebrew Config
         uses: actions/upload-artifact@v4
-        with: { name: 'homebrew-config', path: 'target/homebrew_config.yaml' }
+        with: { name: "homebrew-config", path: "target/homebrew_config.yaml" }
 
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
-        with: { files: 'target/files/*', generate_release_notes: true }
+        with: { files: "target/files/*", generate_release_notes: true }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -756,7 +761,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: maplibre/homebrew-martin
-          token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }}  # See instructions above
+          token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }} # See instructions above
           path: target/homebrew
 
       - name: Create Homebrew formula
@@ -770,15 +775,15 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }}  # See instructions above
-          commit-message: 'Update to ${{ github.ref }}'
-          title: 'Update to ${{ github.ref }}'
-          body: 'Update to ${{ github.ref }}'
-          branch: 'update-to-${{ github.ref }}'
+          token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }} # See instructions above
+          commit-message: "Update to ${{ github.ref }}"
+          title: "Update to ${{ github.ref }}"
+          body: "Update to ${{ github.ref }}"
+          branch: "update-to-${{ github.ref }}"
           branch-suffix: timestamp
-          base: 'main'
-          labels: 'auto-update'
-          assignees: 'nyurik'
+          base: "main"
+          labels: "auto-update"
+          assignees: "nyurik"
           draft: false
           delete-branch: true
           path: target/homebrew
@@ -788,7 +793,7 @@ jobs:
   done:
     name: CI Finished
     runs-on: ubuntu-latest
-    needs: [ package, docker-build-test ]
+    needs: [package, docker-build-test]
     if: always()
     steps:
       - name: Result of the needed steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,11 +726,11 @@ jobs:
           cd target
 
           cat << EOF > homebrew_config.yaml
-          version: '$MARTIN_VERSION"
-          macos_arm_sha256: '$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          macos_intel_sha256: '$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          linux_arm_sha256: '$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
-          linux_intel_sha256: '$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          version: "$MARTIN_VERSION"
+          macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
+          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF
 
       - name: Save Homebrew Config


### PR DESCRIPTION
I missed this in the previous PR.

I just assumed that all runners are roughly equivalently fast.
They are not. Not by a long shot. MacOS x86 is lagging behind the others by a lot.

In the previous PR I somehow did not noticed this.

If we enable Caching just for this one, our CI speeds up again.