### PR TITLE
fix(ui): improve subpath deployment support

### DIFF
--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -20,7 +20,7 @@ describe('getMartinBaseUrl', () => {
 
     // window.location.href is "http://localhost"
     const result = getMartinBaseUrl();
-    expect(result).toBe("http://localhost/");
+    expect(result).toBe('http://localhost/');
   });
 });
 
@@ -44,7 +44,7 @@ describe('buildMartinUrl', () => {
     const result = buildMartinUrl('/catalog');
 
     // Should use window.location.href as fallback
-    expect(result).toBe("http://localhost/catalog");
+    expect(result).toBe('http://localhost/catalog');
   });
 
   it('handles paths without leading slash', () => {

--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -15,16 +15,12 @@ describe('getMartinBaseUrl', () => {
     expect(getMartinBaseUrl()).toBe('https://api.example.com');
   });
 
-  it('returns window.location.origin when VITE_MARTIN_BASE is not set', () => {
+  it('returns window.location.href when VITE_MARTIN_BASE is not set', () => {
     delete process.env.VITE_MARTIN_BASE;
 
-    // In Jest/jsdom environment, window.location.origin is "http://localhost"
-    // This is set up in jest.setup.js
+    // window.location.href is "http://localhost"
     const result = getMartinBaseUrl();
-    expect(result).toBeDefined();
-    expect(typeof result).toBe('string');
-    // The actual value depends on the Jest setup, but it should be a valid URL origin
-    expect(result).toMatch(/^https?:\/\/[^/]+$/);
+    expect(result).toBe("http://localhost/");
   });
 });
 
@@ -47,8 +43,8 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    // Should use window.location.origin as fallback
-    expect(result).toMatch(/^https?:\/\/[^/]+\/catalog$/);
+    // Should use window.location.href as fallback
+    expect(result).toBe("http://localhost/catalog");
   });
 
   it('handles paths without leading slash', () => {

--- a/martin/martin-ui/src/lib/api.ts
+++ b/martin/martin-ui/src/lib/api.ts
@@ -3,7 +3,7 @@
  * Uses VITE_MARTIN_BASE environment variable if set, otherwise defaults to current origin
  */
 export function getMartinBaseUrl(): string {
-  return import.meta.env.VITE_MARTIN_BASE ?? window.location.origin ?? '';
+  return import.meta.env.VITE_MARTIN_BASE ?? window.location.href ?? '';
 }
 
 /**


### PR DESCRIPTION
This improves https://github.com/maplibre/martin/issues/1977 a bit and makes this at least work on the baseline for people running martin on a base-path:

```diff
-      - "traefik.http.routers.navigatum-martin.rule=Host(`nav.tum.de`) && (PathPrefix(`/tiles`) || PathPrefix(`/_/`) || PathPrefix(`/catalog`))"
+      - "traefik.http.routers.navigatum-martin.rule=Host(`nav.tum.de`) && (PathPrefix(`/tiles`) || PathPrefix(`/_/`))"
```

The issue is mainly, that otherwise one would need to confiugre every source in traefik.. not pheasable for lots of our users.
By using `href` instead of `origin` this works as users expect.