### PR TITLE
chore(martin-cp)!: change the concurrencly of martin-cp to be the number of cpus, not `1`

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -90,8 +90,7 @@ pub struct CopyArgs {
     /// Allow copying to existing files, and indicate what to do if a tile with the same Z/X/Y already exists
     #[arg(long, value_enum)]
     pub on_duplicate: Option<CopyDuplicateMode>,
-    /// Number of concurrent connections to use.
-    #[arg(long, default_value = "1")]
+    #[arg(help = format!("Number of concurrent connections to use. [DEFAULT: {}]", num_cpus::get()), long)]
     pub concurrency: Option<usize>,
     /// Bounds to copy, in the format `min_lon,min_lat,max_lon,max_lat`. Can be specified multiple times. Overlapping regions will be handled correctly.
     #[arg(long)]
@@ -306,7 +305,7 @@ fn check_sources(args: &CopyArgs, state: &ServerState) -> Result<String, MartinC
 #[allow(clippy::too_many_lines)]
 async fn run_tile_copy(args: CopyArgs, state: ServerState) -> MartinCpResult<()> {
     let output_file = &args.output_file;
-    let concurrency = args.concurrency.unwrap_or(1);
+    let concurrency = args.concurrency.unwrap_or(num_cpus::get());
 
     let source = check_sources(&args, &state)?;
 


### PR DESCRIPTION
When I originally looked at martin-cp, I thought it was super slow. The reason is that we by default only use a single thread, somethign that does not really go hand in hand with our goals.

We should really use multiple threads here and I think the number of CPUs is a good bet.

Resolves https://github.com/maplibre/martin/issues/1990

> [!WARNING]
> Yes, this is a breaking change and yes this needs to be put at the top of the release notes with such a warning-alert.