### PR TITLE
fix(ui): fix path handling again, but maybe this time finaly (3/1)

### DIFF
--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -84,6 +84,6 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    expect(result).toBe('/catalog');
+    expect(result).toBe('http://localhost/catalog');
   });
 });

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -17,16 +17,19 @@ export function Header() {
                 MARTIN
               </h1>
             </a>
-            
-              <Badge asChild className="hover:bg-purple-700 hidden md:block" variant="default">
-                {import.meta.env.VITE_MARTIN_VERSION ? (<a
+
+            <Badge asChild className="hover:bg-purple-700 hidden md:block" variant="default">
+              {import.meta.env.VITE_MARTIN_VERSION ? (
+                <a
                   className="p-1"
                   href={`https://github.com/maplibre/martin/releases/tag/${import.meta.env.VITE_MARTIN_VERSION}`}
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
-                  </a>
-                ) : "dev"}
-              </Badge>
+                </a>
+              ) : (
+                'dev'
+              )}
+            </Badge>
           </div>
           <div className="flex items-center space-x-4">
             <HoverCard>

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -17,16 +17,16 @@ export function Header() {
                 MARTIN
               </h1>
             </a>
-            {import.meta.env.VITE_MARTIN_VERSION && (
+            
               <Badge asChild className="hover:bg-purple-700 hidden md:block" variant="default">
-                <a
+                {import.meta.env.VITE_MARTIN_VERSION ? (<a
                   className="p-1"
                   href={`https://github.com/maplibre/martin/releases/tag/${import.meta.env.VITE_MARTIN_VERSION}`}
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
-                </a>
+                  </a>
+                ) : "dev"}
               </Badge>
-            )}
           </div>
           <div className="flex items-center space-x-4">
             <HoverCard>

--- a/martin/martin-ui/src/lib/api.ts
+++ b/martin/martin-ui/src/lib/api.ts
@@ -3,18 +3,7 @@
  * Uses VITE_MARTIN_BASE environment variable if set, otherwise defaults to current origin
  */
 export function getMartinBaseUrl(): string {
-  // grumble grumble
-  // Belows try-except is the poor mans `import.meta.env?.VITE_MARTIN_BASE`
-  //
-  // - `import.meta.env` is `undefined` after building and
-  // - `import.meta.env.VITE_MARTIN_BASE` is not replaced with a value if not set.
-  //
-  // We have to do this like this as jest does not understand `import.meta.env?.VITE_MARTIN_BASE`
-  let importedBase: string | undefined;
-  try {
-    importedBase = import.meta.env.VITE_MARTIN_BASE;
-  } catch (_error) {}
-  return importedBase ?? window.location.href ?? '';
+  return import.meta.env.VITE_MARTIN_BASE || window.location.href;
 }
 
 /**

--- a/martin/martin-ui/src/vite-env.d.ts
+++ b/martin/martin-ui/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_MARTIN_VERSION?: string;
-  readonly VITE_MARTIN_BASE?: string;
+  readonly VITE_MARTIN_VERSION: string;
+  readonly VITE_MARTIN_BASE: string;
   // more env variables...
 }


### PR DESCRIPTION
I am loosing my mind on this one a bit, but I think I finally found the ACTUAL issue.

Rather than the previous TWO cases, I now have something which is more likely to work.
Because of the history of this issue, I am not claiming that this is the soution, but rather.. a thing which might.

In chrome, `import.meta.env.VITE_MARTIN_VERSION` is undefined. Chrome has typescript support.
So why does `window.location.href` still get ignored, even though `importedBase` shows as undefined in the debugger?

Fun!
In the underlying js, it is `''`, as vite has replaced this.

So the nullish coalessing `importedBase ?? window.location.href ?? '';` won't ever trigger.
The debugger still thinks that `importedBase` is null, so shows unrelated ***.

I hate this!

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNHdzb2VubnFvdXN2MHFrOTd6dzdlNDZsZGc2ZGl3N2Y2YzZocHluNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/5XPb0FvIqylqg/giphy.gif"/>

The real reason why these are 3 PRs not one is that I test these issues in the debugger, so I am reliant on the debugger being accurate. Apparently this is a false hope.