### PR TITLE
chore(logging): runtime-reconfigurable trace configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -642,7 +653,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
- "lru",
+ "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
  "sha2",
@@ -2609,6 +2620,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2616,7 +2630,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -3077,7 +3091,7 @@ version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "indexmap 2.10.0",
  "is-terminal",
  "itoa",
@@ -3458,6 +3472,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
@@ -3532,6 +3555,9 @@ dependencies = [
  "tilejson",
  "tokio",
  "tokio-postgres-rustls",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url",
  "walkdir",
  "xxhash-rust",
@@ -6602,8 +6628,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
+ "ahash 0.7.8",
  "log",
+ "lru 0.7.8",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
  "tracing-core",
 ]
 
@@ -6613,16 +6651,20 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ tiff = "0.10.0"
 tilejson = "0.4"
 tokio = { version = "1", features = ["macros"] }
 tokio-postgres-rustls = "0.13"
+tracing = { version = "0.1.41", features = ["log"] }
+tracing-log = { version = "0.2.0", features = ["interest-cache"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json", "fmt", "chrono"] }
 url = "2.5"
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -23,12 +23,36 @@ maintainer = "Yuri Astrakhan <YuriAstrakhan@gmail.com>, Stepan Kuzmin <to.stepan
 maintainer-scripts = "../debian"
 depends = "$auto"
 assets = [
-    ["target/release/martin", "/usr/bin/martin", "755"],
-    ["target/release/martin-cp", "/usr/bin/martin-cp", "755"],
-    ["target/release/mbtiles", "/usr/bin/mbtiles", "755"],
-    ["../README.md", "/usr/share/doc/martin/README.md", "644"],
-    ["../debian/config.yaml", "/usr/share/doc/martin/config.yaml", "644"],
-    ["../debian/config.yaml", "/usr/local/etc/martin/config.yaml", "644"],
+  [
+    "target/release/martin",
+    "/usr/bin/martin",
+    "755",
+  ],
+  [
+    "target/release/martin-cp",
+    "/usr/bin/martin-cp",
+    "755",
+  ],
+  [
+    "target/release/mbtiles",
+    "/usr/bin/mbtiles",
+    "755",
+  ],
+  [
+    "../README.md",
+    "/usr/share/doc/martin/README.md",
+    "644",
+  ],
+  [
+    "../debian/config.yaml",
+    "/usr/share/doc/martin/config.yaml",
+    "644",
+  ],
+  [
+    "../debian/config.yaml",
+    "/usr/local/etc/martin/config.yaml",
+    "644",
+  ],
 ]
 
 # see https://github.com/kornelski/cargo-deb/blob/main/systemd.md#packagemetadatadebsystemd-units-options
@@ -56,14 +80,37 @@ name = "bench"
 harness = false
 
 [features]
-default = ["cog", "fonts", "lambda", "mbtiles", "metrics", "pmtiles", "postgres", "sprites", "styles", "webui"]
+default = [
+  "cog",
+  "fonts",
+  "lambda",
+  "mbtiles",
+  "metrics",
+  "pmtiles",
+  "postgres",
+  "sprites",
+  "styles",
+  "webui",
+]
 cog = ["dep:png", "dep:tiff"]
 fonts = ["dep:bit-set", "dep:pbf_font_tools", "dep:regex"]
 lambda = ["dep:lambda-web"]
 mbtiles = ["dep:mbtiles"]
 metrics = ["dep:actix-web-prom"]
 pmtiles = ["dep:aws-config", "dep:pmtiles"]
-postgres = ["dep:deadpool-postgres", "dep:enum-display", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:regex", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:semver", "dep:tokio-postgres-rustls"]
+postgres = [
+  "dep:deadpool-postgres",
+  "dep:enum-display",
+  "dep:json-patch",
+  "dep:postgis",
+  "dep:postgres",
+  "dep:postgres-protocol",
+  "dep:regex",
+  "dep:rustls-native-certs",
+  "dep:rustls-pemfile",
+  "dep:semver",
+  "dep:tokio-postgres-rustls",
+]
 sprites = ["dep:spreet", "tokio/fs"]
 styles = ["dep:walkdir", "tokio/fs"]
 webui = ["dep:actix-web-static-files", "dep:static-files", "dep:walkdir"]
@@ -116,6 +163,9 @@ tiff = { workspace = true, optional = true }
 tilejson.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
 tokio-postgres-rustls = { workspace = true, optional = true }
+tracing.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 walkdir = { workspace = true, optional = true }
 xxhash-rust.workspace = true

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -23,36 +23,12 @@ maintainer = "Yuri Astrakhan <YuriAstrakhan@gmail.com>, Stepan Kuzmin <to.stepan
 maintainer-scripts = "../debian"
 depends = "$auto"
 assets = [
-  [
-    "target/release/martin",
-    "/usr/bin/martin",
-    "755",
-  ],
-  [
-    "target/release/martin-cp",
-    "/usr/bin/martin-cp",
-    "755",
-  ],
-  [
-    "target/release/mbtiles",
-    "/usr/bin/mbtiles",
-    "755",
-  ],
-  [
-    "../README.md",
-    "/usr/share/doc/martin/README.md",
-    "644",
-  ],
-  [
-    "../debian/config.yaml",
-    "/usr/share/doc/martin/config.yaml",
-    "644",
-  ],
-  [
-    "../debian/config.yaml",
-    "/usr/local/etc/martin/config.yaml",
-    "644",
-  ],
+  ["target/release/martin","/usr/bin/martin","755"],
+  ["target/release/martin-cp","/usr/bin/martin-cp","755"],
+  ["target/release/mbtiles","/usr/bin/mbtiles","755"],
+  ["../README.md","/usr/share/doc/martin/README.md","644"],
+  ["../debian/config.yaml","/usr/share/doc/martin/config.yaml","644"],
+  ["../debian/config.yaml","/usr/local/etc/martin/config.yaml","644"],
 ]
 
 # see https://github.com/kornelski/cargo-deb/blob/main/systemd.md#packagemetadatadebsystemd-units-options
@@ -80,37 +56,14 @@ name = "bench"
 harness = false
 
 [features]
-default = [
-  "cog",
-  "fonts",
-  "lambda",
-  "mbtiles",
-  "metrics",
-  "pmtiles",
-  "postgres",
-  "sprites",
-  "styles",
-  "webui",
-]
+default = ["cog","fonts","lambda","mbtiles","metrics","pmtiles","postgres","sprites","styles","webui"]
 cog = ["dep:png", "dep:tiff"]
 fonts = ["dep:bit-set", "dep:pbf_font_tools", "dep:regex"]
 lambda = ["dep:lambda-web"]
 mbtiles = ["dep:mbtiles"]
 metrics = ["dep:actix-web-prom"]
 pmtiles = ["dep:aws-config", "dep:pmtiles"]
-postgres = [
-  "dep:deadpool-postgres",
-  "dep:enum-display",
-  "dep:json-patch",
-  "dep:postgis",
-  "dep:postgres",
-  "dep:postgres-protocol",
-  "dep:regex",
-  "dep:rustls-native-certs",
-  "dep:rustls-pemfile",
-  "dep:semver",
-  "dep:tokio-postgres-rustls",
-]
+postgres = ["dep:deadpool-postgres","dep:enum-display","dep:json-patch","dep:postgis","dep:postgres","dep:postgres-protocol","dep:regex","dep:rustls-native-certs","dep:rustls-pemfile","dep:semver","dep:tokio-postgres-rustls"]
 sprites = ["dep:spreet", "tokio/fs"]
 styles = ["dep:walkdir", "tokio/fs"]
 webui = ["dep:actix-web-static-files", "dep:static-files", "dep:walkdir"]

--- a/martin/src/args/root.rs
+++ b/martin/src/args/root.rs
@@ -6,7 +6,6 @@ use clap::builder::styling::AnsiColor;
 use log::warn;
 
 use crate::MartinError::ConfigAndConnectionsError;
-use crate::MartinResult;
 #[cfg(feature = "fonts")]
 use crate::OptOneMany;
 use crate::args::connections::Arguments;
@@ -21,6 +20,7 @@ use crate::config::Config;
     feature = "styles",
 ))]
 use crate::file_config::FileConfigEnum;
+use crate::{LogFormatOptions, MartinResult};
 
 /// Defines the styles used for the CLI help output.
 const HELP_STYLES: Styles = Styles::styled()
@@ -69,6 +69,9 @@ pub struct MetaArgs {
     pub watch: bool,
     /// Connection strings, e.g. `postgres://...` or `/path/to/files`
     pub connection: Vec<String>,
+    /// Logging format
+    #[arg(long)]
+    pub log_format: Option<LogFormatOptions>,
 }
 
 #[derive(Parser, Debug, Clone, PartialEq, Default)]

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -135,7 +135,8 @@ fn parse_key_value(s: &str) -> Result<(String, String), String> {
 async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     let trace = ReloadableTracingConfiguration::init_global_registry("martin_cp=info");
     if let Ok(fmt) = std::env::var("MARTIN_CP_LOG_FORMAT") {
-        if let Some(fmt) = LogFormatOptions::from_str_opt(&fmt) {
+        use clap::ValueEnum;
+        if let Ok(fmt) = LogFormatOptions::from_str(&fmt, true) {
             trace.reload_fmt(fmt);
         } else {
             warn!("ignoring invalid log format for MARTIN_CP_LOG_FORMAT");

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -17,7 +17,7 @@ use martin::args::{Args, ExtraArgs, MetaArgs, OsEnv, SrvArgs};
 use martin::mbtiles::MbtilesError;
 use martin::srv::{DynTileSource, merge_tilejson};
 use martin::{
-    Config, Env, LogFormatOptions, MartinError, MartinResult, ReloadableTracingConfiguration,
+    Config, LogFormatOptions, MartinError, MartinResult, ReloadableTracingConfiguration,
     ServerState, TileData, TileInfoSource, read_config,
 };
 use martin_tile_utils::{TileCoord, TileInfo, TileRect, append_rect, bbox_to_xyz};
@@ -30,7 +30,6 @@ use mbtiles::{
 use tilejson::Bounds;
 use tokio::sync::mpsc::channel;
 use tokio::time::Instant;
-use tokio::time::error::Elapsed;
 use tokio::try_join;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -9,7 +9,8 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 async fn start(args: Args) -> MartinResult<()> {
     let trace = ReloadableTracingConfiguration::init_global_registry("martin=info");
     if let Ok(fmt) = std::env::var("MARTIN_LOG_FORMAT") {
-        if let Some(fmt) = LogFormatOptions::from_str_opt(&fmt) {
+        use clap::ValueEnum;
+        if let Ok(fmt) = LogFormatOptions::from_str(&fmt, true) {
             trace.reload_fmt(fmt);
         } else {
             warn!("ignoring invalid log format for MARTIN_LOG_FORMAT");

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -10,7 +10,10 @@ pub use source::{
 };
 
 mod utils;
-pub use utils::{IdResolver, MartinError, MartinResult, NO_MAIN_CACHE, OptBoolObj, OptOneMany};
+pub use utils::{
+    IdResolver, LogFormatOptions, MartinError, MartinResult, NO_MAIN_CACHE, OptBoolObj, OptOneMany,
+    ReloadableTracingConfiguration,
+};
 
 pub mod args;
 #[cfg(feature = "cog")]

--- a/martin/src/pg/query_tables.rs
+++ b/martin/src/pg/query_tables.rs
@@ -1,8 +1,8 @@
-use martin_tile_utils::EARTH_CIRCUMFERENCE_DEGREES;
 use std::collections::HashMap;
 
 use futures::pin_mut;
 use log::{debug, warn};
+use martin_tile_utils::EARTH_CIRCUMFERENCE_DEGREES;
 use postgis::ewkb;
 use postgres_protocol::escape::{escape_identifier, escape_literal};
 use serde_json::Value;

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -32,6 +32,7 @@ pub struct ObservabilityConfig {
     /// Configure the logging format
     pub log_format: Option<LogFormatOptions>,
     /// Configure metrics reported under `/_/metrics`
+    #[cfg(feature = "metrics")]
     pub metrics: Option<MetricsConfig>,
 }
 

--- a/martin/src/srv/config.rs
+++ b/martin/src/srv/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::cors::CorsConfig;
+use crate::LogFormatOptions;
 use crate::args::PreferredEncoding;
 
 pub const KEEP_ALIVE_DEFAULT: u64 = 75;
@@ -21,15 +22,15 @@ pub struct SrvConfig {
     pub web_ui: Option<crate::args::WebUiMode>,
     pub cors: Option<CorsConfig>,
     /// Advanced monitoring options
-    #[cfg(feature = "metrics")]
     pub observability: Option<ObservabilityConfig>,
 }
 
 /// More advanced monitoring montoring options
-#[cfg(feature = "metrics")]
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct ObservabilityConfig {
+    /// Configure the logging format
+    pub log_format: Option<LogFormatOptions>,
     /// Configure metrics reported under `/_/metrics`
     pub metrics: Option<MetricsConfig>,
 }

--- a/martin/src/utils/mod.rs
+++ b/martin/src/utils/mod.rs
@@ -6,6 +6,8 @@ pub use cfg_containers::{OptBoolObj, OptOneMany};
 
 mod error;
 pub use error::*;
+mod tracing;
+pub use tracing::*;
 
 mod id_resolver;
 pub use id_resolver::IdResolver;

--- a/martin/src/utils/tracing.rs
+++ b/martin/src/utils/tracing.rs
@@ -37,20 +37,7 @@ pub enum LogFormatOptions {
     #[value(alias("jsonl"))]
     Json,
 }
-impl LogFormatOptions {
-    /// parse [`LogFormatOptions`] from a String
-    #[must_use]
-    pub fn from_str_opt(var: &str) -> Option<Self> {
-        match var {
-            "full" => Some(LogFormatOptions::Full),
-            "pretty" | "verbose" => Some(LogFormatOptions::Pretty),
-            "json" | "jsonl" => Some(LogFormatOptions::Json),
-            "compact" => Some(LogFormatOptions::Compact),
-            "bare" => Some(LogFormatOptions::Bare),
-            _ => None,
-        }
-    }
-}
+
 type FormattingLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 type FilterLayer = Layered<EnvFilter, FormattingLayer, Registry>;
 

--- a/martin/src/utils/tracing.rs
+++ b/martin/src/utils/tracing.rs
@@ -1,0 +1,119 @@
+use std::str::FromStr;
+
+use tracing_subscriber::fmt::Layer as FormatLayer;
+use tracing_subscriber::reload::{Handle, Layer as ReloadLayer};
+use tracing_subscriber::{EnvFilter, Layer, Registry};
+
+#[derive(
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Default,
+    Debug,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum LogFormatOptions {
+    /// Emit human-readable, single-line logs.
+    /// See [here for a sample](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html#example-output)
+    Full,
+    /// A variant of the full-format, optimized for short line lengths.
+    /// See [here for a sample](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Compact.html#example-output)
+    #[default]
+    Compact,
+    /// The bare log without timestamps or modules. Just the level and the log
+    Bare,
+    /// Excessively pretty, multi-line logs for local development/debugging, prioritizing readability over compact storage.
+    /// See [here for a sample](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Pretty.html#example-output)
+    #[serde(alias = "verbose")]
+    #[value(alias("verbose"))]
+    Pretty,
+    /// Output newline-delimited (structured) JSON logs, ***not*** optimized for human readability.
+    /// See [here for a sample](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html#example-output)
+    #[serde(alias = "jsonl")]
+    #[value(alias("jsonl"))]
+    Json,
+}
+impl LogFormatOptions {
+    pub fn from_str_opt(var: &str) -> Option<Self> {
+        match var {
+            "full" => Some(LogFormatOptions::Full),
+            "pretty" | "verbose" => Some(LogFormatOptions::Pretty),
+            "json" | "jsonl" => Some(LogFormatOptions::Json),
+            "compact" => Some(LogFormatOptions::Compact),
+            "bare" => Some(LogFormatOptions::Bare),
+            _ => None,
+        }
+    }
+}
+
+pub struct ReloadableTracingConfiguration {
+    reload_handle: Handle<
+        tracing_subscriber::layer::Layered<
+            EnvFilter,
+            Box<dyn Layer<Registry> + Send + Sync + 'static>,
+            Registry,
+        >,
+        Registry,
+    >,
+    default_level: &'static str,
+}
+
+impl ReloadableTracingConfiguration {
+    /// Transform [`log`](https://docs.rs/log) records into [`tracing`](https://docs.rs/tracing) [`Event`](tracing::Event)s.
+    ///
+    /// # Panics
+    /// This function will panic if the global `log`-logger cannot be set.
+    /// This only happens if the global `log`-logger has already been set.
+    fn initialise_log_tracing() {
+        tracing_log::LogTracer::builder()
+            .with_interest_cache(tracing_log::InterestCacheConfig::default())
+            .init()
+            .expect("the global logger to only be set once");
+    }
+
+    /// Initialise the global tracing registry.
+    ///
+    /// # Panics
+    /// This function will panic if the global `log`-logger cannot be set or if the global `tracing`-registry cannot be set.
+    #[must_use]
+    pub fn init_global_registry(default_level: &'static str) -> Self {
+        Self::initialise_log_tracing();
+        use tracing_subscriber::prelude::*;
+        let default_fmt = FormatLayer::default().boxed();
+        let default_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            EnvFilter::from_str(default_level).expect("the default level should not be invalid")
+        });
+        // counterintuitive: this is env first, then format. Not a bug!
+        let default_layer = default_fmt.and_then(default_filter);
+        let (reload_layer, reload_handle) = ReloadLayer::new(default_layer);
+        let registry = Registry::default().with(reload_layer);
+        tracing::subscriber::set_global_default(registry)
+            .expect("since martin has not set the global_default, no global default is set");
+        Self {
+            reload_handle,
+            default_level,
+        }
+    }
+    /// Reload the configured format and level.
+    pub fn reload_fmt(&self, format: LogFormatOptions) {
+        let log_format_layer = match format {
+            LogFormatOptions::Full => FormatLayer::default().boxed(),
+            LogFormatOptions::Pretty => FormatLayer::default().pretty().boxed(),
+            LogFormatOptions::Json => FormatLayer::default().json().boxed(),
+            LogFormatOptions::Compact => FormatLayer::default().compact().boxed(),
+            LogFormatOptions::Bare => FormatLayer::default().compact().without_time().boxed(),
+        };
+        let default_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            EnvFilter::from_str(self.default_level)
+                .expect("the default level should not be invalid")
+        });
+
+        // counterintuitive: this is env first, then format. Not a bug!
+        self.reload_handle
+            .reload(log_format_layer.and_then(default_filter))
+            .expect("the subscriber should still exist")
+    }
+}

--- a/martin/src/utils/tracing.rs
+++ b/martin/src/utils/tracing.rs
@@ -90,7 +90,11 @@ impl ReloadableTracingConfiguration {
             LogFormatOptions::Pretty => FormatLayer::default().pretty().boxed(),
             LogFormatOptions::Json => FormatLayer::default().json().boxed(),
             LogFormatOptions::Compact => FormatLayer::default().compact().boxed(),
-            LogFormatOptions::Bare => FormatLayer::default().compact().without_time().boxed(),
+            LogFormatOptions::Bare => FormatLayer::default()
+                .compact()
+                .without_time()
+                .with_target(false)
+                .boxed(),
         };
         let default_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             EnvFilter::from_str(self.default_level)


### PR DESCRIPTION
This is like the previous PR a version of `tracing`
- https://github.com/maplibre/martin/pull/1747

So by now we have had
- the one where I configured everything 3x => did not work due to too much duplication
- then was with the new crate and parsing/ intialising staticly
- and now runtime-reconfiguration

Honestly, I still like the extra crate more.
Much more readad and extendable in the future.

The runtime reconfiguration of formatting options is tricky as I need to get around some compiler limtations.
Changing the log level the same way is sadly not as simple, this is where I am hitting the `'static`-requring brick wall.
There are also some heavy tricks to allow for runtime recajigling of the log format (see the `boxing` and the reload layer).

I suspect that there is at least a bit of performance impact of all this work. Likely not enoguh to make a difference anyhow.

Before I do this work, shoud we go back to https://github.com/maplibre/martin/pull/1747 as a more reasonable approach?

