### PR TITLE
fix(ui): search params messing with api-url generation (4/1)

### DIFF
--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -20,7 +20,7 @@ describe('getMartinBaseUrl', () => {
 
     // window.location.pathname is "/"
     const result = getMartinBaseUrl();
-    expect(result).toBe('http://localhost/');
+    expect(result).toBe('/');
   });
 });
 
@@ -44,7 +44,7 @@ describe('buildMartinUrl', () => {
     const result = buildMartinUrl('/catalog');
 
     // Should use window.location.pathname as fallback
-    expect(result).toBe('http://localhost/catalog');
+    expect(result).toBe('/catalog');
   });
 
   it('handles paths without leading slash', () => {
@@ -84,6 +84,6 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    expect(result).toBe('http://localhost/catalog');
+    expect(result).toBe('/catalog');
   });
 });

--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -15,10 +15,10 @@ describe('getMartinBaseUrl', () => {
     expect(getMartinBaseUrl()).toBe('https://api.example.com');
   });
 
-  it('returns window.location.href when VITE_MARTIN_BASE is not set', () => {
+  it('returns window.location.pathname when VITE_MARTIN_BASE is not set', () => {
     delete process.env.VITE_MARTIN_BASE;
 
-    // window.location.href is "http://localhost"
+    // window.location.pathname is "http://localhost"
     const result = getMartinBaseUrl();
     expect(result).toBe('http://localhost/');
   });
@@ -43,7 +43,7 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    // Should use window.location.href as fallback
+    // Should use window.location.pathname as fallback
     expect(result).toBe('http://localhost/catalog');
   });
 

--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -18,7 +18,7 @@ describe('getMartinBaseUrl', () => {
   it('returns window.location.pathname when VITE_MARTIN_BASE is not set', () => {
     delete process.env.VITE_MARTIN_BASE;
 
-    // window.location.pathname is "http://localhost"
+    // window.location.pathname is "/"
     const result = getMartinBaseUrl();
     expect(result).toBe('http://localhost/');
   });

--- a/martin/martin-ui/src/lib/api.ts
+++ b/martin/martin-ui/src/lib/api.ts
@@ -3,7 +3,7 @@
  * Uses VITE_MARTIN_BASE environment variable if set, otherwise defaults to current origin
  */
 export function getMartinBaseUrl(): string {
-  return import.meta.env.VITE_MARTIN_BASE || window.location.href;
+  return import.meta.env.VITE_MARTIN_BASE || window.location.pathname;
 }
 
 /**


### PR DESCRIPTION
grrr.

So apparently, the current approach does not work so nicely because we now have query parameters.
We don't want to include those into the request so we need to use the `pathname`

I did not test this aspect in https://github.com/maplibre/martin/pull/1997 as that problem was only introduced in combination with https://github.com/maplibre/martin/pull/1999

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbmxxYTZmcHlxajE0ZDk5MWswcHowaTFhdHFzY3NyeWZwMGJsanM1dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/vwI4mYEHP8k0w/giphy.gif"/>