### PR TITLE
fix(ui): basepath handling needing to change in the maputnik iframe

### DIFF
--- a/martin/martin-ui/__tests__/lib/api.test.ts
+++ b/martin/martin-ui/__tests__/lib/api.test.ts
@@ -15,12 +15,12 @@ describe('getMartinBaseUrl', () => {
     expect(getMartinBaseUrl()).toBe('https://api.example.com');
   });
 
-  it('returns window.location.pathname when VITE_MARTIN_BASE is not set', () => {
+  it('returns origin + pathname when VITE_MARTIN_BASE is not set', () => {
     delete process.env.VITE_MARTIN_BASE;
 
     // window.location.pathname is "/"
     const result = getMartinBaseUrl();
-    expect(result).toBe('/');
+    expect(result).toBe('http://localhost/');
   });
 });
 
@@ -43,8 +43,8 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    // Should use window.location.pathname as fallback
-    expect(result).toBe('/catalog');
+    // pathname
+    expect(result).toBe('http://localhost/catalog');
   });
 
   it('handles paths without leading slash', () => {
@@ -84,6 +84,6 @@ describe('buildMartinUrl', () => {
 
     const result = buildMartinUrl('/catalog');
 
-    expect(result).toBe('/catalog');
+    expect(result).toBe('http://localhost/catalog');
   });
 });

--- a/martin/martin-ui/src/lib/api.ts
+++ b/martin/martin-ui/src/lib/api.ts
@@ -4,7 +4,7 @@
  */
 export function getMartinBaseUrl(): string {
   // we want to construct via origin+pathname as otherwise query/hash params result in wrong api urls
-  return import.meta.env.VITE_MARTIN_BASE || (window.location.origin + window.location.pathname);
+  return import.meta.env.VITE_MARTIN_BASE || window.location.origin + window.location.pathname;
 }
 
 /**

--- a/martin/martin-ui/src/lib/api.ts
+++ b/martin/martin-ui/src/lib/api.ts
@@ -3,7 +3,8 @@
  * Uses VITE_MARTIN_BASE environment variable if set, otherwise defaults to current origin
  */
 export function getMartinBaseUrl(): string {
-  return import.meta.env.VITE_MARTIN_BASE || window.location.pathname;
+  // we want to construct via origin+pathname as otherwise query/hash params result in wrong api urls
+  return import.meta.env.VITE_MARTIN_BASE || (window.location.origin + window.location.pathname);
 }
 
 /**


### PR DESCRIPTION
So the previous approach worked... Mostly

Except in the `iframe` when the origin switches to be `maplibre.org`.

Yes this is the fifth PR fixing the same underlying issue but I hope that this time I have though of all the edgecases.
