### PR TITLE
chore(deps): enable npm based dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,33 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+  - package-ecosystem: npm
+    directory: "/martin/martin-ui/"
+    schedule:
+      interval: daily
+      time: "02:00"
+    open-pull-requests-limit: 10
+    groups:
+      all-cargo-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      all-cargo-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: "/demo/frontend/"
+    schedule:
+      interval: daily
+      time: "02:00"
+    open-pull-requests-limit: 10
+    groups:
+      all-cargo-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      all-cargo-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
I noticed that we currently don't have dependabot updates active via npm.

We likely should..