### PR TITLE
chore(ci): add cargo-sort to consistently sort our `Cargo.toml`

### DIFF
--- a/justfile
+++ b/justfile
@@ -303,7 +303,7 @@ test-doc *args:
     cargo test --doc {{args}}
 
 # Test code formatting
-test-fmt: (cargo-install 'cargo-sort')
+test-fmt: (cargo-install 'cargo-sort') && (fmt-toml '--check' '--check-format')
     cargo fmt --all -- --check
     {{just_executable()}} fmt-toml-sort --check --check-format
 

--- a/justfile
+++ b/justfile
@@ -201,7 +201,7 @@ fmt-sql:
     docker run -it --rm -v $PWD:/sql sqlfluff/sqlfluff:latest fix --dialect=postgres --exclude-rules=AL07,LT05,LT12
 
 # Reformat all Cargo.toml files using cargo-sort
-fmt-toml-sort *args: (cargo-install 'cargo-sort')
+fmt-toml *args: (cargo-install 'cargo-sort')
     cargo sort --workspace --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies {{args}}
 
 # Get all testable features of the main crate as space-separated list

--- a/justfile
+++ b/justfile
@@ -201,8 +201,8 @@ fmt-sql:
     docker run -it --rm -v $PWD:/sql sqlfluff/sqlfluff:latest fix --dialect=postgres --exclude-rules=AL07,LT05,LT12
 
 # Reformat all Cargo.toml files using cargo-sort
-fmt-toml-sort: (cargo-install 'cargo-sort')
-    cargo sort --workspace --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies
+fmt-toml-sort *args: (cargo-install 'cargo-sort')
+    cargo sort --workspace --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies {{args}}
 
 # Get all testable features of the main crate as space-separated list
 get-features:
@@ -305,7 +305,7 @@ test-doc *args:
 # Test code formatting
 test-fmt: (cargo-install 'cargo-sort')
     cargo fmt --all -- --check
-    cargo sort --workspace --check --check-format --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies
+    {{just_executable()}} fmt-toml-sort --check --check-format
 
 # Run frontend tests
 [working-directory: 'martin/martin-ui']

--- a/justfile
+++ b/justfile
@@ -200,6 +200,10 @@ fmt-md:
 fmt-sql:
     docker run -it --rm -v $PWD:/sql sqlfluff/sqlfluff:latest fix --dialect=postgres --exclude-rules=AL07,LT05,LT12
 
+# Reformat all Cargo.toml files using cargo-sort
+fmt-toml-sort: (cargo-install 'cargo-sort')
+    cargo sort --workspace --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies
+
 # Get all testable features of the main crate as space-separated list
 get-features:
     cargo metadata --format-version=1 --no-deps --manifest-path Cargo.toml | jq -r '.packages[] | select(.name == "{{main_crate}}") | .features | keys[] | select(. != "default")' | tr '\n' ' '
@@ -299,8 +303,9 @@ test-doc *args:
     cargo test --doc {{args}}
 
 # Test code formatting
-test-fmt:
+test-fmt: (cargo-install 'cargo-sort')
     cargo fmt --all -- --check
+    cargo sort --workspace --check --check-format --order package,lib,bin,bench,features,dependencies,build-dependencies,dev-dependencies
 
 # Run frontend tests
 [working-directory: 'martin/martin-ui']

--- a/justfile
+++ b/justfile
@@ -305,7 +305,6 @@ test-doc *args:
 # Test code formatting
 test-fmt: (cargo-install 'cargo-sort') && (fmt-toml '--check' '--check-format')
     cargo fmt --all -- --check
-    {{just_executable()}} fmt-toml-sort --check --check-format
 
 # Run frontend tests
 [working-directory: 'martin/martin-ui']

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -2,9 +2,9 @@
 name = "martin"
 version = "0.18.0"
 authors = [
-  "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
-  "Yuri Astrakhan <YuriAstrakhan@gmail.com>",
-  "MapLibre contributors",
+    "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
+    "Yuri Astrakhan <YuriAstrakhan@gmail.com>",
+    "MapLibre contributors",
 ]
 description = "Blazing fast and lightweight tile server with PostGIS, MBTiles, and PMTiles support"
 keywords = ["maps", "tiles", "mbtiles", "pmtiles", "postgis"]
@@ -56,14 +56,37 @@ name = "bench"
 harness = false
 
 [features]
-default = ["cog", "fonts", "lambda", "mbtiles", "metrics", "pmtiles", "postgres", "sprites", "styles", "webui"]
+default = [
+    "cog",
+    "fonts",
+    "lambda",
+    "mbtiles",
+    "metrics",
+    "pmtiles",
+    "postgres",
+    "sprites",
+    "styles",
+    "webui",
+]
 cog = ["dep:png", "dep:tiff"]
 fonts = ["dep:bit-set", "dep:pbf_font_tools", "dep:regex"]
 lambda = ["dep:lambda-web"]
 mbtiles = ["dep:mbtiles"]
 metrics = ["dep:actix-web-prom"]
 pmtiles = ["dep:aws-config", "dep:pmtiles"]
-postgres = ["dep:deadpool-postgres", "dep:enum-display", "dep:json-patch", "dep:postgis", "dep:postgres", "dep:postgres-protocol", "dep:regex", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:semver", "dep:tokio-postgres-rustls"]
+postgres = [
+    "dep:deadpool-postgres",
+    "dep:enum-display",
+    "dep:json-patch",
+    "dep:postgis",
+    "dep:postgres",
+    "dep:postgres-protocol",
+    "dep:regex",
+    "dep:rustls-native-certs",
+    "dep:rustls-pemfile",
+    "dep:semver",
+    "dep:tokio-postgres-rustls",
+]
 sprites = ["dep:spreet", "tokio/fs"]
 styles = ["dep:walkdir", "tokio/fs"]
 webui = ["dep:actix-web-static-files", "dep:static-files", "dep:walkdir"]
@@ -73,9 +96,9 @@ actix-cors.workspace = true
 actix-http.workspace = true
 actix-middleware-etag.workspace = true
 actix-rt.workspace = true
+actix-web.workspace = true
 actix-web-prom = { workspace = true, optional = true }
 actix-web-static-files = { workspace = true, optional = true }
-actix-web.workspace = true
 async-trait.workspace = true
 aws-config = { workspace = true, optional = true }
 bit-set = { workspace = true, optional = true }
@@ -100,9 +123,9 @@ postgis = { workspace = true, optional = true }
 postgres = { workspace = true, optional = true }
 postgres-protocol = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
+rustls.workspace = true
 rustls-native-certs = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
-rustls.workspace = true
 semver = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -210,7 +210,7 @@ fn compute_tile_ranges(boxes: &[Bounds], zooms: &[u8]) -> Vec<TileRect> {
     ranges
 }
 
-fn get_zooms(args: &CopyArgs) -> Cow<[u8]> {
+fn get_zooms(args: &CopyArgs) -> Cow<'_, [u8]> {
     if let Some(max_zoom) = args.max_zoom {
         let mut zooms_vec = Vec::new();
         let min_zoom = args.min_zoom.unwrap_or(0);

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -11,12 +11,23 @@ repository.workspace = true
 rust-version.workspace = true
 homepage = "https://maplibre.org/martin/tools.html#mbtiles"
 
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "mbtiles"
+path = "src/bin/mbtiles.rs"
+required-features = ["cli"]
+
 [features]
 default = ["cli"]
 cli = ["dep:anyhow", "dep:clap", "dep:env_logger", "dep:serde_yaml"]
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
 enum-display.workspace = true
+env_logger = { workspace = true, optional = true }
 flume.workspace = true
 futures.workspace = true
 itertools.workspace = true
@@ -27,6 +38,7 @@ num_cpus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+serde_yaml = { workspace = true, optional = true }
 size_format.workspace = true
 sqlite-compressions.workspace = true
 sqlite-hashes.workspace = true
@@ -36,12 +48,6 @@ tilejson.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 xxhash-rust.workspace = true
 
-# Bin dependencies
-anyhow = { workspace = true, optional = true }
-clap = { workspace = true, optional = true }
-env_logger = { workspace = true, optional = true }
-serde_yaml = { workspace = true, optional = true }
-
 [dev-dependencies]
 # For testing, might as well use the same async framework as the Martin itself
 actix-rt.workspace = true
@@ -50,14 +56,6 @@ env_logger.workspace = true
 insta = { workspace = true, features = ["toml", "yaml"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
-
-[lib]
-path = "src/lib.rs"
-
-[[bin]]
-name = "mbtiles"
-path = "src/bin/mbtiles.rs"
-required-features = ["cli"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
I find this kind of labor intensive to check every time and would like to automate this the same way we do other formatting tasks.