### PR TITLE
feat(mbtiles): export `martin_tile_utils::{Tile, TileCoord}` publicly

### DIFF
--- a/mbtiles/src/lib.rs
+++ b/mbtiles/src/lib.rs
@@ -34,11 +34,11 @@ mod bindiff;
 
 mod validation;
 
+pub use martin_tile_utils::{Tile, TileCoord};
 pub use validation::{
     AGG_TILES_HASH, AGG_TILES_HASH_AFTER_APPLY, AGG_TILES_HASH_BEFORE_APPLY, AggHashType,
     IntegrityCheckType, MbtType, calc_agg_tiles_hash,
 };
-pub use martin_tile_utils::{Tile, TileCoord};
 
 /// `MBTiles` uses a TMS (Tile Map Service) scheme for its tile coordinates (inverted along the Y axis).
 /// This function converts Y value between TMS tile coordinate to an XYZ tile coordinate.

--- a/mbtiles/src/lib.rs
+++ b/mbtiles/src/lib.rs
@@ -38,6 +38,7 @@ pub use validation::{
     AGG_TILES_HASH, AGG_TILES_HASH_AFTER_APPLY, AGG_TILES_HASH_BEFORE_APPLY, AggHashType,
     IntegrityCheckType, MbtType, calc_agg_tiles_hash,
 };
+pub use martin_tile_utils::{Tile, TileCoord};
 
 /// `MBTiles` uses a TMS (Tile Map Service) scheme for its tile coordinates (inverted along the Y axis).
 /// This function converts Y value between TMS tile coordinate to an XYZ tile coordinate.


### PR DESCRIPTION
We return them from some of our APIs and thus working with them is a bit cumbersome otherwise