### PR TITLE
chore(martin-cp)!: Remove unused `--cache-size` from martin-cp.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,7 +3503,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "martin"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/docs/src/help/martin-cp.txt
+++ b/docs/src/help/martin-cp.txt
@@ -62,9 +62,6 @@ Options:
       --save-config <SAVE_CONFIG>
           Save resulting config to a file or use "-" to print to stdout. By default, only print if sources are auto-detected
 
-  -C, --cache-size <CACHE_SIZE>
-          Main cache size (in MB)
-
   -b, --auto-bounds <AUTO_BOUNDS>
           Specify how bounds should be computed for the spatial PG tables. [DEFAULT: quick]
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "0.18.1"
+version = "0.19.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "martin-ui",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --noEmit"
   },
-  "version": "0.18.1"
+  "version": "0.19.0"
 }

--- a/martin/src/args/root.rs
+++ b/martin/src/args/root.rs
@@ -61,12 +61,6 @@ pub struct MetaArgs {
     /// By default, only print if sources are auto-detected.
     #[arg(long)]
     pub save_config: Option<PathBuf>,
-    /// Main cache size (in MB)
-    #[arg(short = 'C', long)]
-    pub cache_size: Option<u64>,
-    /// **Deprecated** Scan for new sources on sources list requests
-    #[arg(short, long, hide = true)]
-    pub watch: bool,
     /// Connection strings, e.g. `postgres://...` or `/path/to/files`
     pub connection: Vec<String>,
 }
@@ -94,15 +88,15 @@ impl Args {
         config: &mut Config,
         #[allow(unused_variables)] env: &impl Env<'a>,
     ) -> MartinResult<()> {
-        if self.meta.watch {
+        if self.srv.watch {
             warn!("The --watch flag is no longer supported, and will be ignored");
         }
         if self.meta.config.is_some() && !self.meta.connection.is_empty() {
             return Err(ConfigAndConnectionsError(self.meta.connection));
         }
 
-        if self.meta.cache_size.is_some() {
-            config.cache_size_mb = self.meta.cache_size;
+        if self.srv.cache_size.is_some() {
+            config.cache_size_mb = self.srv.cache_size;
         }
 
         self.srv.merge_into_config(&mut config.srv);

--- a/martin/src/args/srv.rs
+++ b/martin/src/args/srv.rs
@@ -34,6 +34,12 @@ pub struct SrvArgs {
     #[arg(short = 'u', long = "webui")]
     #[cfg(feature = "webui")]
     pub web_ui: Option<WebUiMode>,
+    /// Main cache size (in MB)
+    #[arg(short = 'C', long)]
+    pub cache_size: Option<u64>,
+    /// **Deprecated** Scan for new sources on sources list requests
+    #[arg(short, long, hide = true)]
+    pub watch: bool,
 }
 
 #[cfg(feature = "webui")]


### PR DESCRIPTION
This is a breaking change for `martin-cp` and removes the `--cache-size` flag.
Said flag was never supposed to exist and also does not make sense for `martin-cp`.

Resolves #1988