### PR TITLE
chore(deps): make sure that biomejs and tailwind don't stay in the main dependabot update rotation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
       all-npm-ui-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
+        ignore:
+          - '@biomejs/biome'
+          - 'tailwindcss'
       all-npm-ui-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]
@@ -47,6 +50,8 @@ updates:
       all-npm-fe-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
+        ignore:
+          - '@biomejs/biome'
       all-npm-fe-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]


### PR DESCRIPTION
these two dependencys are kind of annoying.

- tailwindcss, as migrating to v4 is a larger issue and lumping this in with the other changes is kind of messy.
- biomejs as this would require updating the pre-commit action, which is currently not done by dependabot