### PR TITLE
chore(deps): change the dependendabot `ignore` configuration to `exclude-patterns`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,7 @@ updates:
       all-npm-ui-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
-        ignore:
-          - '@biomejs/biome'
-          - 'tailwindcss'
+        exclude-patterns: '@biomejs/biome|tailwindcss'
       all-npm-ui-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]
@@ -50,8 +48,7 @@ updates:
       all-npm-fe-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
-        ignore:
-          - '@biomejs/biome'
+        exclude-patterns: '@biomejs/biome'
       all-npm-fe-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,9 @@ updates:
       all-npm-ui-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
-        exclude-patterns: '@biomejs/biome|tailwindcss'
+        exclude-patterns:
+          - '@biomejs/biome'
+          - 'tailwindcss'
       all-npm-ui-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]
@@ -48,7 +50,8 @@ updates:
       all-npm-fe-version-updates:
         applies-to: version-updates
         patterns: [ '*' ]
-        exclude-patterns: '@biomejs/biome'
+        exclude-patterns:
+          - '@biomejs/biome'
       all-npm-fe-security-updates:
         applies-to: security-updates
         patterns: [ '*' ]


### PR DESCRIPTION
It seems that I have misinterpreted how `ignore` works with `groups` and `exclude-patterns` should be the option that does what we want.

Sorry for this churn, there is no real way to check if this works as I think from the docs except on master 😓