### PR TITLE
feat(core): make sure that `martin_core` logs just as `martin` if not configured

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -543,7 +543,7 @@ async fn main() {
             .split(',')
             .find_map(|s| s.strip_prefix("martin="))
         {
-            log_filter.push_str(&format!(",martin_core={}", level));
+            log_filter.push_str(&format!(",martin_core={level}"));
         }
     }
     env_logger::builder().parse_filters(&log_filter).init();

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -536,8 +536,17 @@ async fn init_schema(
 
 #[actix_web::main]
 async fn main() {
-    let env = env_logger::Env::default().default_filter_or("martin_cp=info");
-    env_logger::Builder::from_env(env).init();
+    let mut log_filter = std::env::var("RUST_LOG").unwrap_or("marin-cp=info".to_string());
+    // if we don't have martin_core set, this can hide parts of our logs unintentionally
+    if log_filter.contains("marin-cp=") && !log_filter.contains("martin_core=") {
+        if let Some(level) = log_filter
+            .split(',')
+            .find_map(|s| s.strip_prefix("martin="))
+        {
+            log_filter.push_str(&format!(",martin_core={}", level));
+        }
+    }
+    env_logger::builder().parse_filters(&log_filter).init();
 
     if let Err(e) = start(CopierArgs::parse()).await {
         // Ensure the message is printed, even if the logging is disabled

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -51,8 +51,17 @@ async fn start(args: Args) -> MartinResult<()> {
 
 #[actix_web::main]
 async fn main() {
-    let env = env_logger::Env::default().default_filter_or("martin=info");
-    env_logger::Builder::from_env(env).init();
+    let mut log_filter = std::env::var("RUST_LOG").unwrap_or("marin=info".to_string());
+    // if we don't have martin_core set, this can hide parts of our logs unintentionally
+    if log_filter.contains("marin=") && !log_filter.contains("martin_core=") {
+        if let Some(level) = log_filter
+            .split(',')
+            .find_map(|s| s.strip_prefix("martin="))
+        {
+            log_filter.push_str(&format!(",martin_core={}", level));
+        }
+    }
+    env_logger::builder().parse_filters(&log_filter).init();
 
     if let Err(e) = start(Args::parse()).await {
         // Ensure the message is printed, even if the logging is disabled

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -58,7 +58,7 @@ async fn main() {
             .split(',')
             .find_map(|s| s.strip_prefix("martin="))
         {
-            log_filter.push_str(&format!(",martin_core={}", level));
+            log_filter.push_str(&format!(",martin_core={level}"));
         }
     }
     env_logger::builder().parse_filters(&log_filter).init();


### PR DESCRIPTION
This PR removes a footgun identified:
if one configures logging as currently for past v1.0.0, this means that only `martin=..` is configured. => `martin_core` is entirely left out and won't log anything.