### PR TITLE
chore(config): unify the `unrecognized`-handling

### DIFF
--- a/martin/src/config/args/pg.rs
+++ b/martin/src/config/args/pg.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::connections::Arguments;
 use super::connections::State::{Ignore, Take};
+use crate::config::file::UnrecognizedValues;
 use crate::config::file::pg::{PgConfig, PgSslCerts};
 use crate::pg::POOL_SIZE_DEFAULT;
 
@@ -77,6 +78,7 @@ impl PgArgs {
                 auto_publish: OptBoolObj::NoValue,
                 tables: None,
                 functions: None,
+                unrecognized: UnrecognizedValues::default(),
             })
             .collect();
 
@@ -200,6 +202,7 @@ impl PgArgs {
             ssl_cert: Self::parse_env_var(env, "PGSSLCERT", "ssl certificate"),
             ssl_key: Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate"),
             ssl_root_cert: self.ca_root_file.clone(),
+            unrecognized: UnrecognizedValues::default(),
         };
         if result.ssl_root_cert.is_none() {
             result.ssl_root_cert = Self::parse_env_var(env, "PGSSLROOTCERT", "root certificate(s)");
@@ -338,6 +341,7 @@ mod tests {
                     ssl_cert: Some(PathBuf::from("cert")),
                     ssl_key: Some(PathBuf::from("key")),
                     ssl_root_cert: Some(PathBuf::from("root")),
+                    unrecognized: UnrecognizedValues::default()
                 },
                 ..Default::default()
             })

--- a/martin/src/config/file/cog.rs
+++ b/martin/src/config/file/cog.rs
@@ -10,7 +10,7 @@ use crate::{MartinResult, TileInfoSource};
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CogConfig {
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
 

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -23,7 +23,7 @@ pub struct CorsProperties {
     #[serde(default)]
     pub origin: Vec<String>,
     pub max_age: Option<usize>,
-    
+
     #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -23,6 +23,9 @@ pub struct CorsProperties {
     #[serde(default)]
     pub origin: Vec<String>,
     pub max_age: Option<usize>,
+    
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: UnrecognizedValues,
 }
 
 impl Default for CorsProperties {
@@ -30,6 +33,7 @@ impl Default for CorsProperties {
         Self {
             origin: vec!["*".to_string()],
             max_age: None,
+            unrecognized: UnrecognizedValues::default(),
         }
     }
 }
@@ -211,6 +215,7 @@ mod tests {
         let properties = CorsProperties {
             origin: vec![],
             max_age: Some(3600),
+            unrecognized: UnrecognizedValues::default(),
         };
 
         assert!(matches!(
@@ -224,6 +229,7 @@ mod tests {
         let properties = CorsProperties {
             origin: vec!["https://example.org".to_string()],
             max_age: Some(3600),
+            unrecognized: UnrecognizedValues::default(),
         };
         assert!(properties.validate().is_ok());
 

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -2,7 +2,7 @@ use actix_http::Method;
 use log::info;
 use serde::{Deserialize, Serialize};
 
-use crate::config::file::{ConfigFileError, ConfigFileResult};
+use crate::config::file::{ConfigFileError, ConfigFileResult, UnrecognizedValues};
 use crate::{MartinError, MartinResult};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -47,6 +47,7 @@ pub trait ConfigExtras: Clone + Debug + Default + PartialEq + Send {
         Ok(())
     }
 
+    /// Iterates over all unrecognized (present, but not expected) keys in the configuration
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys;
 }
 

--- a/martin/src/config/file/mbtiles.rs
+++ b/martin/src/config/file/mbtiles.rs
@@ -11,7 +11,7 @@ use crate::source::TileInfoSource;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct MbtConfig {
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
 

--- a/martin/src/config/file/pg/config.rs
+++ b/martin/src/config/file/pg/config.rs
@@ -12,7 +12,9 @@ use tokio::time::timeout;
 use super::{FuncInfoSources, TableInfoSources};
 use crate::MartinResult;
 use crate::config::args::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT};
-use crate::config::file::{UnrecognizedKeys, copy_unrecognized_keys_from_config};
+use crate::config::file::{
+    ConfigExtras, UnrecognizedKeys, UnrecognizedValues, copy_unrecognized_keys_from_config,
+};
 use crate::pg::builder::PgBuilder;
 use crate::pg::{PgError, PgResult};
 use crate::source::TileInfoSources;
@@ -35,6 +37,9 @@ pub struct PgSslCerts {
     /// Same as PGSSLROOTCERT
     /// ([docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT))
     pub ssl_root_cert: Option<std::path::PathBuf>,
+
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: UnrecognizedValues,
 }
 
 #[serde_with::skip_serializing_none]
@@ -67,6 +72,9 @@ pub struct PgConfig {
     pub tables: Option<TableInfoSources>,
     /// Associative arrays of function sources
     pub functions: Option<FuncInfoSources>,
+
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: UnrecognizedValues,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -97,6 +105,14 @@ pub struct PgCfgPublishTables {
     pub clip_geom: Option<bool>,
     pub buffer: Option<u32>,
     pub extent: Option<u32>,
+
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: UnrecognizedValues,
+}
+impl ConfigExtras for PgCfgPublishTables {
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        self.unrecognized.keys().cloned().collect()
+    }
 }
 
 #[serde_with::skip_serializing_none]
@@ -107,6 +123,14 @@ pub struct PgCfgPublishFuncs {
     pub from_schemas: OptOneMany<String>,
     #[serde(alias = "id_format")]
     pub source_id_format: Option<String>,
+
+    #[serde(flatten, skip_serializing)]
+    pub unrecognized: UnrecognizedValues,
+}
+impl ConfigExtras for PgCfgPublishFuncs {
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        self.unrecognized.keys().cloned().collect()
+    }
 }
 
 impl PgConfig {

--- a/martin/src/config/file/pg/config.rs
+++ b/martin/src/config/file/pg/config.rs
@@ -109,6 +109,7 @@ pub struct PgCfgPublishTables {
     #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
+
 impl ConfigExtras for PgCfgPublishTables {
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
         self.unrecognized.keys().cloned().collect()
@@ -127,6 +128,7 @@ pub struct PgCfgPublishFuncs {
     #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
+
 impl ConfigExtras for PgCfgPublishFuncs {
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
         self.unrecognized.keys().cloned().collect()

--- a/martin/src/config/file/pmtiles.rs
+++ b/martin/src/config/file/pmtiles.rs
@@ -29,7 +29,7 @@ pub struct PmtConfig {
     /// If `None` (the default), this will look at `AWS_SKIP_CREDENTIALS` and `AWS_NO_CREDENTIALS` or default to `false`.
     #[serde(default, alias = "aws_skip_credentials")]
     pub skip_credentials: Option<bool>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 
     //

--- a/martin/src/config/file/sprites.rs
+++ b/martin/src/config/file/sprites.rs
@@ -46,7 +46,7 @@ impl SpriteConfig {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct InnerSpriteConfig {
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
 

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -67,6 +67,7 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
+    use crate::config::file::UnrecognizedValues;
     use crate::config::file::cors::CorsProperties;
 
     #[test]

--- a/martin/src/config/file/styles.rs
+++ b/martin/src/config/file/styles.rs
@@ -12,7 +12,7 @@ use crate::config::file::{
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct InnerStyleConfig {
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing)]
     pub unrecognized: UnrecognizedValues,
 }
 


### PR DESCRIPTION
This PR pulls the handling of `unrecognized` from https://github.com/maplibre/martin/pull/2151 as this is kind of unrelated and litters in that PR a bit.