### PR TITLE
Fix typo in SAM template docs

### DIFF
--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -72,7 +72,7 @@ cat <<EOF >template.yaml
 AWSTemplateFormatVersion: 2010-09-09
 Transform: 'AWS::Serverless-2016-10-31'
 Resources:
-  martin:
+  MartinLayer:
     Type: 'AWS::Serverless::LayerVersion'
     DeletionPolicy: Delete
     Properties:


### PR DESCRIPTION
The `!Ref` in the outputs didn't match the key in the Resources block, causing an error:

```
Reason: Unresolved resource dependencies [MartinLayer] in the Outputs block of the template
```

This fixes the problem by renaming the resource to MartinLayer