### PR TITLE
chore(core): remove `sorted_opt_set` testing utility in favor of `insta::sorted_redaction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3260,6 +3260,8 @@ checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "once_cell",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
  "toml",
@@ -4319,6 +4321,50 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.16",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -6942,6 +6988,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ulid"

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -175,7 +175,7 @@ approx.workspace = true
 criterion.workspace = true
 ctor.workspace = true
 indoc.workspace = true
-insta = { workspace = true, features = ["json", "yaml"] }
+insta = { workspace = true, features = ["json", "yaml", "redactions"] }
 pprof.workspace = true
 rstest.workspace = true
 tempfile.workspace = true

--- a/martin/src/pg/builder.rs
+++ b/martin/src/pg/builder.rs
@@ -63,7 +63,6 @@ pub struct PgBuilderFuncs {
 #[derive(Debug, Default, PartialEq)]
 #[cfg_attr(test, serde_with::skip_serializing_none, derive(serde::Serialize))]
 pub struct PgBuilderTables {
-    #[cfg_attr(test, serde(serialize_with = "crate::pg::utils::sorted_opt_set"))]
     schemas: Option<HashSet<String>>,
     source_id_format: String,
     id_columns: Option<Vec<String>>,
@@ -614,7 +613,11 @@ mod tests {
                 tables:
                     from_schemas: osm
                     id_format: 'foo_{schema}.{table}_bar'"});
-        assert_yaml_snapshot!(cfg, @r#"
+        assert_yaml_snapshot!(cfg,
+        {
+            ".auto_table.schemas" => insta::sorted_redaction()
+        },
+        @r#"
         auto_table:
           schemas:
             - osm
@@ -629,7 +632,11 @@ mod tests {
                 tables:
                     from_schemas: osm
                     source_id_format: '{schema}.{table}'"});
-        assert_yaml_snapshot!(cfg, @r#"
+        assert_yaml_snapshot!(cfg,
+          {
+              ".auto_table.schemas" => insta::sorted_redaction()
+          },
+          @r#"
         auto_table:
           schemas:
             - osm
@@ -644,7 +651,11 @@ mod tests {
                     from_schemas:
                       - osm
                       - public"});
-        assert_yaml_snapshot!(cfg, @r#"
+        assert_yaml_snapshot!(cfg,
+          {
+              ".auto_table.schemas" => insta::sorted_redaction()
+          },
+          @r#"
         auto_table:
           schemas:
             - osm

--- a/martin/src/pg/utils.rs
+++ b/martin/src/pg/utils.rs
@@ -7,24 +7,6 @@ use martin_core::tiles::UrlQuery;
 use postgis::{LineString, Point, Polygon, ewkb};
 use tilejson::{Bounds, TileJSON};
 
-#[cfg(test)]
-#[expect(clippy::ref_option)]
-pub fn sorted_opt_set<S: serde::Serializer>(
-    value: &Option<std::collections::HashSet<String>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    use serde::Serialize as _;
-
-    value
-        .as_ref()
-        .map(|v| {
-            let mut v: Vec<_> = v.iter().collect();
-            v.sort();
-            v
-        })
-        .serialize(serializer)
-}
-
 #[must_use]
 pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
     let mut result = BTreeMap::new();


### PR DESCRIPTION
This utility was primarily used to have stable snapshots in tests.
For this usecase, `insta` has `insta::sorted_redaction`, which IMO is a bit simpler and tangles less.