### PR TITLE
chore(core): move non-util utilities to better places

### DIFF
--- a/martin/src/config/file/pg/config_function.rs
+++ b/martin/src/config/file/pg/config_function.rs
@@ -3,7 +3,8 @@ use tilejson::{Bounds, TileJSON};
 
 use super::config::PgInfo;
 use crate::config::file::UnrecognizedValues;
-use crate::pg::utils::{InfoMap, patch_json};
+use crate::config::file::pg::utils::patch_json;
+use crate::pg::utils::InfoMap;
 
 pub type FuncInfoSources = InfoMap<FunctionInfo>;
 

--- a/martin/src/config/file/pg/config_table.rs
+++ b/martin/src/config/file/pg/config_table.rs
@@ -6,7 +6,8 @@ use tilejson::{Bounds, TileJSON, VectorLayer};
 
 use super::PgInfo;
 use crate::config::file::UnrecognizedValues;
-use crate::pg::utils::{InfoMap, normalize_key, patch_json};
+use crate::config::file::pg::utils::patch_json;
+use crate::pg::utils::{InfoMap, normalize_key};
 
 pub type TableInfoSources = InfoMap<TableInfo>;
 

--- a/martin/src/config/file/pg/mod.rs
+++ b/martin/src/config/file/pg/mod.rs
@@ -6,3 +6,5 @@ pub use config_function::*;
 
 mod config_table;
 pub use config_table::*;
+
+mod utils;

--- a/martin/src/config/file/pg/utils.rs
+++ b/martin/src/config/file/pg/utils.rs
@@ -1,0 +1,30 @@
+use log::error;
+use tilejson::TileJSON;
+
+#[must_use]
+pub fn patch_json(target: TileJSON, patch: Option<&serde_json::Value>) -> TileJSON {
+    let Some(tj) = patch else {
+        // Nothing to merge in, keep the original
+        return target;
+    };
+    // Not the most efficient, but this is only executed once per source:
+    // * Convert the TileJSON struct to a serde_json::Value
+    // * Merge the self.tilejson into the value
+    // * Convert the merged value back to a TileJSON struct
+    // * In case of errors, return the original tilejson
+    let mut tilejson2 = match serde_json::to_value(target.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Failed to serialize tilejson, unable to merge function comment: {e}");
+            return target;
+        }
+    };
+    json_patch::merge(&mut tilejson2, tj);
+    match serde_json::from_value(tilejson2.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Failed to deserialize merged function comment tilejson: {e}");
+            target
+        }
+    }
+}

--- a/martin/src/pg/query_tables.rs
+++ b/martin/src/pg/query_tables.rs
@@ -18,7 +18,7 @@ use crate::pg::PgResult;
 use crate::pg::builder::SqlTableInfoMapMapMap;
 use crate::pg::pool::PgPool;
 use crate::pg::source::PgSqlInfo;
-use crate::pg::utils::{json_to_hashmap, polygon_to_bbox};
+use crate::pg::utils::json_to_hashmap;
 
 static DEFAULT_EXTENT: u32 = 4096;
 static DEFAULT_BUFFER: u32 = 64;
@@ -257,4 +257,23 @@ FROM {schema}.{table};
         .map_err(|e| PostgresError(e, "querying table bounds"))?
         .get::<_, Option<ewkb::Polygon>>("bounds")
         .and_then(|p| polygon_to_bbox(&p)))
+}
+
+#[must_use]
+pub fn polygon_to_bbox(polygon: &ewkb::Polygon) -> Option<Bounds> {
+    use postgis::{LineString, Point, Polygon};
+
+    polygon.rings().next().and_then(|linestring| {
+        let mut points = linestring.points();
+        if let (Some(bottom_left), Some(top_right)) = (points.next(), points.nth(1)) {
+            Some(Bounds::new(
+                bottom_left.x(),
+                bottom_left.y(),
+                top_right.x(),
+                top_right.y(),
+            ))
+        } else {
+            None
+        }
+    })
 }

--- a/martin/src/pg/utils.rs
+++ b/martin/src/pg/utils.rs
@@ -4,8 +4,6 @@ use deadpool_postgres::tokio_postgres::types::Json;
 use itertools::Itertools as _;
 use log::{error, info, warn};
 use martin_core::tiles::UrlQuery;
-use postgis::{LineString, Point, Polygon, ewkb};
-use tilejson::{Bounds, TileJSON};
 
 #[cfg(test)]
 #[expect(clippy::ref_option)]
@@ -39,34 +37,6 @@ pub fn json_to_hashmap(value: &serde_json::Value) -> InfoMap<String> {
 }
 
 #[must_use]
-pub fn patch_json(target: TileJSON, patch: Option<&serde_json::Value>) -> TileJSON {
-    let Some(tj) = patch else {
-        // Nothing to merge in, keep the original
-        return target;
-    };
-    // Not the most efficient, but this is only executed once per source:
-    // * Convert the TileJSON struct to a serde_json::Value
-    // * Merge the self.tilejson into the value
-    // * Convert the merged value back to a TileJSON struct
-    // * In case of errors, return the original tilejson
-    let mut tilejson2 = match serde_json::to_value(target.clone()) {
-        Ok(v) => v,
-        Err(e) => {
-            error!("Failed to serialize tilejson, unable to merge function comment: {e}");
-            return target;
-        }
-    };
-    json_patch::merge(&mut tilejson2, tj);
-    match serde_json::from_value(tilejson2.clone()) {
-        Ok(v) => v,
-        Err(e) => {
-            error!("Failed to deserialize merged function comment tilejson: {e}");
-            target
-        }
-    }
-}
-
-#[must_use]
 pub fn query_to_json(query: Option<&UrlQuery>) -> Json<HashMap<String, serde_json::Value>> {
     let mut query_as_json = HashMap::new();
     if let Some(query) = query {
@@ -79,23 +49,6 @@ pub fn query_to_json(query: Option<&UrlQuery>) -> Json<HashMap<String, serde_jso
     }
 
     Json(query_as_json)
-}
-
-#[must_use]
-pub fn polygon_to_bbox(polygon: &ewkb::Polygon) -> Option<Bounds> {
-    polygon.rings().next().and_then(|linestring| {
-        let mut points = linestring.points();
-        if let (Some(bottom_left), Some(top_right)) = (points.next(), points.nth(1)) {
-            Some(Bounds::new(
-                bottom_left.x(),
-                bottom_left.y(),
-                top_right.x(),
-                top_right.y(),
-            ))
-        } else {
-            None
-        }
-    })
 }
 
 pub type InfoMap<T> = BTreeMap<String, T>;
@@ -144,6 +97,7 @@ fn find_info_kv<'a, T>(
 }
 
 /// Find a key in a map, ignoring case.
+///
 /// If there is no exact match, but there is a case-insensitive match, return that as `Ok(Some(value))`.
 /// If there is no exact match and there are multiple case-insensitive matches, return an error with a vector of the possible matches.
 /// If there is no match, return `Ok(None)`.


### PR DESCRIPTION
A few of our utilies are only ever used in one place.
The coming migrations are much simpler if we move them to the appropriate places instead