### PR TITLE
chore(core): simplify the pmtiles implementation

### DIFF
--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -32,9 +32,6 @@ pub enum ConfigFileError {
     #[error("Source {0} uses bad file {1}")]
     InvalidSourceFilePath(String, PathBuf),
 
-    #[error(r"Unable to parse metadata in file {1}: {0}")]
-    InvalidMetadata(String, PathBuf),
-
     #[error("At least one 'origin' must be specified in the 'cors' configuration")]
     CorsNoOriginsConfigured,
 

--- a/martin/src/pmtiles/error.rs
+++ b/martin/src/pmtiles/error.rs
@@ -24,7 +24,7 @@ pub enum PmtilesError {
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidUrlMetadata(String, Url),
 
-    /// Invalid or unparseable metadata in `PMTiles` file.
+    /// Invalid or unparseable metadata in the `PMTiles` source.
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidMetadata(String, PathBuf),
 

--- a/martin/src/pmtiles/error.rs
+++ b/martin/src/pmtiles/error.rs
@@ -9,8 +9,8 @@ use url::Url;
 #[derive(thiserror::Error, Debug)]
 pub enum PmtilesError {
     /// Error processing S3 source URI.
-    #[error(r"Failed to parse bucket name while processing S3 source uri {0}")]
-    S3SourceError(Url),
+    #[error(r"Failed to parse bucket name of S3 source uri {0}")]
+    S3BucketNameNotString(Url),
 
     /// Wrapper for underlying `PMTiles` library errors.
     #[error(transparent)]

--- a/martin/src/pmtiles/error.rs
+++ b/martin/src/pmtiles/error.rs
@@ -1,5 +1,7 @@
 //! Error types for `PMTiles` operations.
 
+use std::path::PathBuf;
+
 use pmtiles::PmtError;
 use url::Url;
 
@@ -7,8 +9,8 @@ use url::Url;
 #[derive(thiserror::Error, Debug)]
 pub enum PmtilesError {
     /// Error processing S3 source URI.
-    #[error(r"Error occurred in processing S3 source uri: {0}")]
-    S3SourceError(String),
+    #[error(r"Failed to parse bucket name while processing S3 source uri {0}")]
+    S3SourceError(Url),
 
     /// Wrapper for underlying `PMTiles` library errors.
     #[error(transparent)]
@@ -21,4 +23,12 @@ pub enum PmtilesError {
     /// Invalid or unparseable metadata in `PMTiles` file.
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidUrlMetadata(String, Url),
+
+    /// Invalid or unparseable metadata in `PMTiles` file.
+    #[error(r"Unable to parse metadata in file {1}: {0}")]
+    InvalidMetadata(String, PathBuf),
+
+    /// IO error occurred while processing `PMTiles` file.
+    #[error("IO error {0}: {1}")]
+    IoError(std::io::Error, PathBuf),
 }

--- a/martin/src/pmtiles/mod.rs
+++ b/martin/src/pmtiles/mod.rs
@@ -2,4 +2,4 @@ mod error;
 pub use error::PmtilesError;
 
 mod source;
-pub use source::*;
+pub use source::{PmtCache, PmtFileSource, PmtHttpSource, PmtS3Source};

--- a/martin/src/pmtiles/source.rs
+++ b/martin/src/pmtiles/source.rs
@@ -26,11 +26,16 @@ use url::Url;
 
 use super::PmtilesError::{self, InvalidMetadata, InvalidUrlMetadata};
 
-/// Directory cache for `PMTiles` files.
+/// [`pmtiles::Directory`] cache for `PMTiles` files.
 #[derive(Clone, Debug)]
 pub struct PmtCache {
+    /// Unique identifier for this cache instance
+    ///
+    /// Uniqueness invariant is guaranteed by how the struct is constructed
     id: usize,
-    /// Storing (id, offset) -> Directory, or None to disable caching
+    /// Cache storing (id, offset) -> [`pmtiles::Directory`]
+    ///
+    /// Set to [`None`] to disable caching
     cache: OptMainCache,
 }
 

--- a/martin/src/pmtiles/source.rs
+++ b/martin/src/pmtiles/source.rs
@@ -4,7 +4,9 @@ use std::convert::identity;
 use std::fmt::{Debug, Formatter};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
 use log::{trace, warn};
@@ -22,9 +24,7 @@ use pmtiles::{
 use tilejson::TileJSON;
 use url::Url;
 
-use super::PmtilesError::{self, InvalidUrlMetadata};
-use crate::config::file::ConfigFileError::{InvalidMetadata, IoError};
-use crate::{MartinError, MartinResult};
+use super::PmtilesError::{self, InvalidMetadata, InvalidUrlMetadata};
 
 /// Directory cache for `PMTiles` files.
 #[derive(Clone, Debug)]
@@ -34,11 +34,14 @@ pub struct PmtCache {
     cache: OptMainCache,
 }
 
-impl PmtCache {
-    /// Creates a new `PMTiles` cache with the given ID and cache store.
-    #[must_use]
-    pub fn new(id: usize, cache: OptMainCache) -> Self {
-        Self { id, cache }
+impl From<OptMainCache> for PmtCache {
+    fn from(cache: OptMainCache) -> Self {
+        static NEXT_CACHE_ID: LazyLock<AtomicUsize> = LazyLock::new(|| AtomicUsize::new(0));
+
+        Self {
+            id: NEXT_CACHE_ID.fetch_add(1, SeqCst),
+            cache,
+        }
     }
 }
 
@@ -93,11 +96,11 @@ macro_rules! impl_pmtiles_source {
                 id: String,
                 path: $path,
                 reader: AsyncPmTilesReader<$backend, PmtCache>,
-            ) -> MartinResult<Self> {
+            ) -> Result<Self, PmtilesError> {
                 let hdr = &reader.get_header();
 
                 if hdr.tile_type != TileType::Mvt && hdr.tile_compression != Compression::None {
-                    return Err(MartinError::from($err(
+                    return Err(PmtilesError::from($err(
                         format!(
                             "Format {:?} and compression {:?} are not yet supported",
                             hdr.tile_type, hdr.tile_compression
@@ -128,10 +131,7 @@ macro_rules! impl_pmtiles_source {
                     TileType::Jpeg => Format::Jpeg.into(),
                     TileType::Webp => Format::Webp.into(),
                     TileType::Unknown => {
-                        return Err(MartinError::from($err(
-                            "Unknown tile type".to_string(),
-                            path,
-                        )));
+                        return Err($err("Unknown tile type".to_string(), path));
                     }
                 };
 
@@ -217,8 +217,11 @@ impl_pmtiles_source!(
 
 impl PmtHttpSource {
     /// Creates a new HTTP-based `PMTiles` source.
-    pub async fn new(client: Client, cache: PmtCache, id: String, url: Url) -> MartinResult<Self> {
-        let reader = AsyncPmTilesReader::new_with_cached_url(cache, client, url.clone()).await;
+    pub async fn new(cache: PmtCache, id: String, url: Url) -> Result<Self, PmtilesError> {
+        static CLIENT: LazyLock<Client> = LazyLock::new(Client::new);
+
+        let reader =
+            AsyncPmTilesReader::new_with_cached_url(cache, CLIENT.clone(), url.clone()).await;
         let reader = reader.map_err(|e| PmtilesError::PmtErrorWithCtx(e, url.to_string()))?;
 
         Self::new_int(id, url, reader).await
@@ -243,7 +246,7 @@ impl PmtS3Source {
         url: Url,
         skip_credentials: bool,
         force_path_style: bool,
-    ) -> MartinResult<Self> {
+    ) -> Result<Self, PmtilesError> {
         let mut aws_config_builder = aws_config::from_env();
         if skip_credentials {
             aws_config_builder = aws_config_builder.no_credentials();
@@ -257,9 +260,7 @@ impl PmtS3Source {
 
         let bucket = url
             .host_str()
-            .ok_or_else(|| {
-                PmtilesError::S3SourceError(format!("failed to parse bucket name from {url}"))
-            })?
+            .ok_or_else(|| PmtilesError::S3SourceError(url.clone()))?
             .to_string();
 
         // Strip leading '/' from the key
@@ -286,16 +287,16 @@ impl_pmtiles_source!(
 
 impl PmtFileSource {
     /// Creates a new file-based `PMTiles` source.
-    pub async fn new(cache: PmtCache, id: String, path: PathBuf) -> MartinResult<Self> {
+    pub async fn new(cache: PmtCache, id: String, path: PathBuf) -> Result<Self, PmtilesError> {
         let backend = MmapBackend::try_from(path.as_path())
             .await
             .map_err(|e| io::Error::other(format!("{e:?}: Cannot open file {}", path.display())))
-            .map_err(|e| IoError(e, path.clone()))?;
+            .map_err(|e| PmtilesError::IoError(e, path.clone()))?;
 
         let reader = AsyncPmTilesReader::try_from_cached_source(backend, cache).await;
         let reader = reader
             .map_err(|e| io::Error::other(format!("{e:?}: Cannot open file {}", path.display())))
-            .map_err(|e| IoError(e, path.clone()))?;
+            .map_err(|e| PmtilesError::IoError(e, path.clone()))?;
 
         Self::new_int(id, path, reader).await
     }

--- a/martin/src/pmtiles/source.rs
+++ b/martin/src/pmtiles/source.rs
@@ -260,7 +260,7 @@ impl PmtS3Source {
 
         let bucket = url
             .host_str()
-            .ok_or_else(|| PmtilesError::S3SourceError(url.clone()))?
+            .ok_or_else(|| PmtilesError::S3BucketNameNotString(url.clone()))?
             .to_string();
 
         // Strip leading '/' from the key


### PR DESCRIPTION
This PR refactors the pmtiles module to be closer to what I think it should be in terms of reusability and final API.

Concrete changes:
- instead of having the internal state in the `PmtConfig`, lets move the `Client` and `directory_id` down to where they are used
- switched `source.rs` to the errors that I will be using in the final version