### PR TITLE
chore: move publishing testcase to stable rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          # TODO: Change to stable once rust 1.90 hits in mid sebtember 2025
-          toolchain: nightly-2025-08-10
       - name: Test packaging
-        run: cargo publish --workspace -Z package-workspace --dry-run
+        run: cargo publish --workspace --dry-run


### PR DESCRIPTION
As noted, this was a workaround until `v1.90.0`.
Since it is released now, we can remove the workaround