### PR TITLE
chore(core): move error types to more appropriate places

### DIFF
--- a/martin-core/src/tiles/postgres/errors.rs
+++ b/martin-core/src/tiles/postgres/errors.rs
@@ -92,8 +92,4 @@ pub enum PgError {
     /// Tile retrieval error with query parameters.
     #[error(r"Unable to get tile {2:#} with {json_query:?} params from {1}: {0}", json_query=query_to_json(.3.as_ref()))]
     GetTileWithQueryError(#[source] TokioPgError, String, TileCoord, Option<UrlQuery>),
-
-    /// Configuration error.
-    #[error("Configuration error: {0}")]
-    ConfigError(&'static str),
 }

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -181,7 +181,9 @@ async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     let sources = config.resolve().await?;
 
     if let Some(file_name) = save_config {
-        config.save_to_file(file_name).map_err(MartinError::from)?;
+        config
+            .save_to_file(file_name.as_path())
+            .map_err(MartinError::from)?;
     } else {
         info!("Use --save-config to save or print configuration.");
     }

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -161,7 +161,7 @@ async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     let save_config = copy_args.meta.save_config.clone();
     let mut config = if let Some(ref cfg_filename) = copy_args.meta.config {
         info!("Using {}", cfg_filename.display());
-        read_config(cfg_filename, &env)?
+        read_config(cfg_filename, &env).map_err(MartinError::from)?
     } else {
         info!("Config file is not specified, auto-detecting sources");
         Config::default()
@@ -181,7 +181,7 @@ async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     let sources = config.resolve().await?;
 
     if let Some(file_name) = save_config {
-        config.save_to_file(file_name)?;
+        config.save_to_file(file_name).map_err(MartinError::from)?;
     } else {
         info!("Use --save-config to save or print configuration.");
     }

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -28,7 +28,7 @@ async fn start(args: Args) -> MartinResult<()> {
     let sources = config.resolve().await?;
 
     if let Some(file_name) = save_config {
-        config.save_to_file(file_name)?;
+        config.save_to_file(file_name.as_path())?;
     } else {
         info!("Use --save-config to save or print Martin configuration.");
     }

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -23,6 +23,19 @@ pub enum ConfigFileError {
     #[error("IO error {0}: {1}")]
     IoError(std::io::Error, PathBuf),
 
+    #[error("Unable to load config file {1}: {0}")]
+    ConfigLoadError(std::io::Error, PathBuf),
+
+    #[error("Unable to parse config file {1}: {0}")]
+    ConfigParseError(subst::yaml::Error, PathBuf),
+
+    #[error("Unable to write config file {1}: {0}")]
+    ConfigWriteError(std::io::Error, PathBuf),
+
+    #[error(
+        "No tile sources found. Set sources by giving a database connection string on command line, env variable, or a config file."
+    )]
+    NoSources,
     #[error("Source path is not a file: {0}")]
     InvalidFilePath(PathBuf),
 
@@ -38,6 +51,22 @@ pub enum ConfigFileError {
     #[cfg(feature = "styles")]
     #[error("Walk directory error {0}: {1}")]
     DirectoryWalking(walkdir::Error, PathBuf),
+
+    #[cfg(feature = "postgres")]
+    #[error("The postgres pool_size must be greater than or equal to 1")]
+    PostgresPoolSizeInvalid,
+
+    #[cfg(feature = "postgres")]
+    #[error("A postgres connection string must be provided")]
+    PostgresConnectionStringMissing,
+
+    #[cfg(feature = "postgres")]
+    #[error("Failed to create postgres pool: {0}")]
+    PostgresPoolCreationFailed(#[source] martin_core::tiles::postgres::PgError),
+
+    #[cfg(feature = "fonts")]
+    #[error("Failed to load fonts from {1}: {0}")]
+    FontResolutionFailed(#[source] martin_core::fonts::FontError, PathBuf),
 }
 
 pub trait ConfigExtras: Clone + Debug + Default + PartialEq + Send {

--- a/martin/src/config/file/fonts.rs
+++ b/martin/src/config/file/fonts.rs
@@ -2,19 +2,23 @@ use std::ops::Deref;
 use std::path::PathBuf;
 
 use martin_core::config::OptOneMany;
-use martin_core::fonts::{FontError, FontSources};
+use martin_core::fonts::FontSources;
 use serde::{Deserialize, Serialize};
+
+use crate::config::file::{ConfigFileError, ConfigFileResult};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct FontConfig(OptOneMany<PathBuf>);
 
 impl FontConfig {
     /// Discovers and loads fonts from the specified directories by recursively scanning for `.ttf`, `.otf`, and `.ttc` files.
-    pub fn resolve(&mut self) -> Result<FontSources, FontError> {
+    pub fn resolve(&mut self) -> ConfigFileResult<FontSources> {
         let mut results = FontSources::default();
 
         for path in self.iter() {
-            results.recursively_add_directory(path.clone())?;
+            results
+                .recursively_add_directory(path.clone())
+                .map_err(|e| ConfigFileError::FontResolutionFailed(e, path.clone()))?;
         }
 
         Ok(results)

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -12,7 +12,6 @@ use martin_core::tiles::BoxedSource;
 use serde::{Deserialize, Serialize};
 use subst::VariableMap;
 
-use crate::MartinError::{ConfigLoadError, ConfigParseError, ConfigWriteError, NoSources};
 #[cfg(any(
     feature = "cog",
     feature = "mbtiles",
@@ -22,7 +21,8 @@ use crate::MartinError::{ConfigLoadError, ConfigParseError, ConfigWriteError, No
 ))]
 use crate::config::file::FileConfigEnum;
 use crate::config::file::{
-    ConfigExtras, UnrecognizedKeys, UnrecognizedValues, copy_unrecognized_keys_from_config,
+    ConfigExtras, ConfigFileError, ConfigFileResult, UnrecognizedKeys, UnrecognizedValues,
+    copy_unrecognized_keys_from_config,
 };
 use crate::source::TileSources;
 use crate::srv::RESERVED_KEYWORDS;
@@ -147,7 +147,11 @@ impl Config {
         #[cfg(feature = "fonts")]
         let is_empty = is_empty && self.fonts.is_empty();
 
-        if is_empty { Err(NoSources) } else { Ok(res) }
+        if is_empty {
+            Err(ConfigFileError::NoSources.into())
+        } else {
+            Ok(res)
+        }
     }
 
     pub async fn resolve(&mut self) -> MartinResult<ServerState> {
@@ -224,7 +228,7 @@ impl Config {
         Ok(TileSources::new(try_join_all(sources).await?))
     }
 
-    pub fn save_to_file(&self, file_name: PathBuf) -> MartinResult<()> {
+    pub fn save_to_file(&self, file_name: PathBuf) -> ConfigFileResult<()> {
         let yaml = serde_yaml::to_string(&self).expect("Unable to serialize config");
         if file_name.as_os_str() == OsStr::new("-") {
             info!("Current system configuration:");
@@ -235,33 +239,34 @@ impl Config {
                 "Saving config to {}, use --config to load it",
                 file_name.display()
             );
-            match File::create(&file_name) {
-                Ok(mut file) => file
-                    .write_all(yaml.as_bytes())
-                    .map_err(|e| ConfigWriteError(e, file_name)),
-                Err(e) => Err(ConfigWriteError(e, file_name)),
-            }
+            File::create(&file_name)
+                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.clone()))?
+                .write_all(yaml.as_bytes())
+                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.clone()))?;
+            Ok(())
         }
     }
 }
 
 /// Read config from a file
-pub fn read_config<'a, M>(file_name: &Path, env: &'a M) -> MartinResult<Config>
+pub fn read_config<'a, M>(file_name: &Path, env: &'a M) -> ConfigFileResult<Config>
 where
     M: VariableMap<'a>,
     M::Value: AsRef<str>,
 {
-    let mut file = File::open(file_name).map_err(|e| ConfigLoadError(e, file_name.into()))?;
+    let mut file =
+        File::open(file_name).map_err(|e| ConfigFileError::ConfigLoadError(e, file_name.into()))?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)
-        .map_err(|e| ConfigLoadError(e, file_name.into()))?;
+        .map_err(|e| ConfigFileError::ConfigLoadError(e, file_name.into()))?;
     parse_config(&contents, env, file_name)
 }
 
-pub fn parse_config<'a, M>(contents: &str, env: &'a M, file_name: &Path) -> MartinResult<Config>
+pub fn parse_config<'a, M>(contents: &str, env: &'a M, file_name: &Path) -> ConfigFileResult<Config>
 where
     M: VariableMap<'a>,
     M::Value: AsRef<str>,
 {
-    subst::yaml::from_str(contents, env).map_err(|e| ConfigParseError(e, file_name.into()))
+    subst::yaml::from_str(contents, env)
+        .map_err(|e| ConfigFileError::ConfigParseError(e, file_name.into()))
 }

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use futures::future::{BoxFuture, try_join_all};
 use log::{info, warn};
@@ -228,7 +228,7 @@ impl Config {
         Ok(TileSources::new(try_join_all(sources).await?))
     }
 
-    pub fn save_to_file(&self, file_name: PathBuf) -> ConfigFileResult<()> {
+    pub fn save_to_file(&self, file_name: &Path) -> ConfigFileResult<()> {
         let yaml = serde_yaml::to_string(&self).expect("Unable to serialize config");
         if file_name.as_os_str() == OsStr::new("-") {
             info!("Current system configuration:");
@@ -239,10 +239,10 @@ impl Config {
                 "Saving config to {}, use --config to load it",
                 file_name.display()
             );
-            File::create(&file_name)
-                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.clone()))?
+            File::create(file_name)
+                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.to_path_buf()))?
                 .write_all(yaml.as_bytes())
-                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.clone()))?;
+                .map_err(|e| ConfigFileError::ConfigWriteError(e, file_name.to_path_buf()))?;
             Ok(())
         }
     }

--- a/martin/src/config/file/postgres/builder.rs
+++ b/martin/src/config/file/postgres/builder.rs
@@ -98,7 +98,7 @@ impl PgBuilder {
             config.pool_size.unwrap_or(POOL_SIZE_DEFAULT),
         )
         .await
-        .map_err(|e| ConfigFileError::PostgresPoolCreationFailed(e))?;
+        .map_err(ConfigFileError::PostgresPoolCreationFailed)?;
 
         let (auto_tables, auto_functions) = calc_auto(config);
 

--- a/martin/src/config/file/styles.rs
+++ b/martin/src/config/file/styles.rs
@@ -5,9 +5,9 @@ use log::warn;
 use martin_core::styles::StyleSources;
 use serde::{Deserialize, Serialize};
 
-use crate::MartinResult;
 use crate::config::file::{
-    ConfigExtras, ConfigFileError, FileConfigEnum, UnrecognizedKeys, UnrecognizedValues,
+    ConfigExtras, ConfigFileError, ConfigFileResult, FileConfigEnum, UnrecognizedKeys,
+    UnrecognizedValues,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -25,7 +25,7 @@ impl ConfigExtras for InnerStyleConfig {
 pub type StyleConfig = FileConfigEnum<InnerStyleConfig>;
 
 impl StyleConfig {
-    pub fn resolve(&mut self) -> MartinResult<StyleSources> {
+    pub fn resolve(&mut self) -> ConfigFileResult<StyleSources> {
         let Some(cfg) = self.extract_file_config(None)? else {
             return Ok(StyleSources::default());
         };

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::fmt::Write as _;
 use std::io;
-use std::path::PathBuf;
 
 /// A convenience [`Result`] for Martin crate.
 pub type MartinResult<T> = Result<T, MartinError>;
@@ -36,20 +35,6 @@ pub enum MartinError {
 
     #[error("Base path must be a valid URL path, and must begin with a '/' symbol, but is '{0}'")]
     BasePathError(String),
-
-    #[error("Unable to load config file {1}: {0}")]
-    ConfigLoadError(io::Error, PathBuf),
-
-    #[error("Unable to parse config file {1}: {0}")]
-    ConfigParseError(subst::yaml::Error, PathBuf),
-
-    #[error("Unable to write config file {1}: {0}")]
-    ConfigWriteError(io::Error, PathBuf),
-
-    #[error(
-        "No tile sources found. Set sources by giving a database connection string on command line, env variable, or a config file."
-    )]
-    NoSources,
 
     #[error("Unrecognizable connection strings: {0:?}")]
     UnrecognizableConnections(Vec<String>),


### PR DESCRIPTION
This PR starts the cleanup work on the error handling we do.
Mainly, this moves all purely config related code to the ConfigFileError enum.