### PR TITLE
chore(core): fix MartinCoreError being a `Box<dyn Error>`

### DIFF
--- a/martin-core/src/tiles/error.rs
+++ b/martin-core/src/tiles/error.rs
@@ -1,13 +1,25 @@
-/// Temporary error type for integration purposes.
-pub type BoxedMartinCoreError = Box<dyn std::error::Error>;
-
-/// Errors that can occur during mbtiles processing operations.
+/// Errors that can occur during tile processing operations.
 #[derive(thiserror::Error, Debug)]
 pub enum MartinCoreError {
-    /// Errors that can occur during mbtiles processing operations.
+    /// Errors that can occur during [`mbtiles`](crate::tiles::cog) processing operations.
     #[cfg(feature = "mbtiles")]
     #[error(transparent)]
     MbtilesError(#[from] super::mbtiles::MbtilesError),
+
+    /// Errors that can occur during [`postgres`](crate::tiles::cog) processing operations.
+    #[cfg(feature = "postgres")]
+    #[error(transparent)]
+    PostgresError(#[from] super::postgres::PgError),
+
+    /// Errors that can occur during [`pmtiles`](crate::tiles::cog) processing operations.
+    #[cfg(feature = "pmtiles")]
+    #[error(transparent)]
+    PmtilesError(#[from] super::pmtiles::PmtilesError),
+
+    /// Errors that can occur during [`cog`](crate::tiles::cog) processing operations.
+    #[cfg(feature = "cog")]
+    #[error(transparent)]
+    CogError(#[from] super::cog::CogError),
 
     /// Errors occurring from other sources, not implemented by `martin-core`.
     #[error(transparent)]
@@ -15,4 +27,4 @@ pub enum MartinCoreError {
 }
 
 /// A convenience [`Result`] for tiles coming from `martin-core`.
-pub type MartinCoreResult<T> = Result<T, BoxedMartinCoreError>;
+pub type MartinCoreResult<T> = Result<T, MartinCoreError>;

--- a/martin/benches/sources.rs
+++ b/martin/benches/sources.rs
@@ -8,7 +8,7 @@ use pprof::criterion::{Output, PProfProfiler};
 mod sources {
     use async_trait::async_trait;
     use martin_core::tiles::catalog::CatalogSourceEntry;
-    use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
+    use martin_core::tiles::{MartinCoreError, MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format, TileCoord, TileData, TileInfo};
     use tilejson::{TileJSON, tilejson};
 
@@ -100,7 +100,8 @@ mod sources {
             _xyz: TileCoord,
             _url_query: Option<&UrlQuery>,
         ) -> MartinCoreResult<TileData> {
-            Err(Box::new(std::io::Error::other("some error".to_string())))
+            let error = std::io::Error::other("some error".to_string());
+            Err(MartinCoreError::OtherError(Box::new(error)))
         }
 
         fn get_catalog_entry(&self) -> CatalogSourceEntry {


### PR DESCRIPTION
There are still some refactorings in this realm necessary, but splitting this apart proved sensible.