### PR TITLE
chore: reworded `InternalError`, `FontError`

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -419,7 +419,7 @@ async fn run_tile_copy(args: CopyArgs, state: ServerState) -> MartinCpResult<()>
                         let data = tile.data;
                         tx.send(TileXyz { xyz, data })
                             .await
-                            .map_err(|e| MartinError::InternalError(e.into()))?;
+                            .expect("The receive half of the channel is not closed");
                         Ok(())
                     }
                 })

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -155,7 +155,7 @@ impl Config {
     }
 
     pub async fn resolve(&mut self) -> MartinResult<ServerState> {
-        init_aws_lc_tls()?;
+        init_aws_lc_tls();
         let resolver = IdResolver::new(RESERVED_KEYWORDS);
         let cache_size = self.cache_size_mb.unwrap_or(512) * 1024 * 1024;
         let cache = if cache_size > 0 {

--- a/martin/src/utils/error.rs
+++ b/martin/src/utils/error.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::fmt::Write as _;
 use std::io;
 
@@ -62,16 +61,17 @@ pub enum MartinError {
     #[error(transparent)]
     SpriteError(#[from] martin_core::sprites::SpriteError),
 
-    #[cfg(feature = "fonts")]
-    #[error(transparent)]
-    FontError(#[from] martin_core::fonts::FontError),
-
     #[error(transparent)]
     WebError(#[from] actix_web::Error),
 
     #[error(transparent)]
     IoError(#[from] io::Error),
 
-    #[error("Internal error: {0}")]
-    InternalError(#[from] Box<dyn Error + Send + Sync>),
+    #[cfg(feature = "lambda")]
+    #[error(transparent)]
+    LambdaError(#[from] lambda_web::LambdaError),
+
+    #[cfg(feature = "metrics")]
+    #[error("could not initialize metrics: {0}")]
+    MetricsIntialisationError(#[source] Box<dyn std::error::Error>),
 }

--- a/martin/src/utils/utilities.rs
+++ b/martin/src/utils/utilities.rs
@@ -3,18 +3,16 @@ use std::sync::LazyLock;
 use actix_web::http::Uri;
 
 use crate::MartinError::BasePathError;
-use crate::{MartinError, MartinResult};
+use crate::MartinResult;
 
-pub fn init_aws_lc_tls() -> MartinResult<()> {
+pub fn init_aws_lc_tls() {
     // https://github.com/rustls/rustls/issues/1877
-    static INIT_TLS: LazyLock<Result<(), String>> = LazyLock::new(|| {
+    static INIT_TLS: LazyLock<()> = LazyLock::new(|| {
         rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
-            .map_err(|e| format!("Unable to init rustls: {e:?}"))
+            .expect("Unable to init rustls: {e:?}");
     });
-    (*INIT_TLS)
-        .clone()
-        .map_err(|e| MartinError::InternalError(e.into()))
+    *INIT_TLS;
 }
 
 pub fn parse_base_path(path: &str) -> MartinResult<String> {


### PR DESCRIPTION
This continues reworking the error types.

These two error types don't super make sense to have here and breaking them apart makes more sense