### PR TITLE
chore(release): activate `release_always` to release on every commit to main

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,6 @@
 dependencies_update = true
 git_release_type = "auto"
 changelog_update = true
-release_always = false
 
 [[package]]
 name = "martin-core"


### PR DESCRIPTION
we now have our first release-plz release out of the door, so it makes sense to activate this option