### PR TITLE
chore(release): add a lint for the correct pr title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pr-title:
-    name: Validate PR title
+    name: Validate PR title follows https://conventionalcommits.org
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: "Lint PR"
+# if someone opens a PR, edits it, or reopens it we want to validate the title
+# This is separate form the rest of the CI as the title may change without code changes
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Given that we now use release-plz and that it works much better with semantic commits, we should add a lint for this.

A bit more annoyance overall, but for releasing much simpler.