### PR TITLE
chore(ci): Update link checker and improve retry configuration

### DIFF
--- a/.github/files/markdown.links.config.json
+++ b/.github/files/markdown.links.config.json
@@ -1,4 +1,5 @@
 {
+  "fallbackRetryDelay": "2000ms",
   "httpHeaders": [
     {
       "headers": {
@@ -31,6 +32,7 @@
       "replacement": ""
     }
   ],
+  "retryCount": 10,
   "retryOn429": true,
   "timeout": "3s"
 }

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -21,10 +21,10 @@ jobs:
           config: '.github/files/config.markdownlint-cli2.jsonc'
 
       - name: 'Check Markdown URLs (same as "just clippy-md")'
-        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1.1.0
         with:
-          use-quiet-mode: 'no'
-          use-verbose-mode: 'yes'
+          use-quiet-mode: 'yes' # only of the checks that failed
+          use-verbose-mode: 'yes' # show status codes
           folder-path: 'docs/src'
           file-path: './README.md'
           config-file: '.github/files/markdown.links.config.json'


### PR DESCRIPTION
The previous version did not match what we have in the justfile.
I am also horribly annoyed by the thing flaking, so the retry settings have been increased

Resolves #1937 