### PR TITLE
chore(release): manually bump martin-core to `0.1.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ itertools = "0.14"
 json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
-martin-core = { path = "./martin-core", version = "0.1.0", default-features = false }
+martin-core = { path = "./martin-core", version = "0.1.1", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.4" }
 mbtiles = { path = "./mbtiles", version = "0.13.0" }
 md5 = "0.8.0"

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/maplibre/martin/compare/martin-core-v0.1.0...martin-core-v0.1.1) - 2025-09-27
+
+- fix release not working for some packages due to outdated dependedncy definitions
+- update documentation to reflect the features better
+
 ## [0.1.0](https://github.com/maplibre/martin/releases/tag/martin-core-v0.1.0) - 2025-09-26
 
 This marks the v0.1 relese, where we moved over the largest part of the previous `martin` crate.

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]


### PR DESCRIPTION
this is required for the automation to work properly