### PR TITLE
chore(ci): add two obscure windows specific filename checks to pre-commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,9 +18,9 @@ demo/
 **/dist/
 **/node_modules/
 *.profraw
-.DS_Store
 .aider*
 .aws-sam/
+.DS_Store
 .env.local
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@
 **/dist/
 **/node_modules/
 *.profraw
-.DS_Store
 .aider*
 .aws-sam/
+.DS_Store
 .env.local
 .idea/
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+      - id: check-case-conflict
       - id: check-executables-have-shebangs
+      - id: check-illegal-windows-names
       - id: check-json
         exclude: ".+/tsconfig.json"
       - id: check-shebang-scripts-are-executable

--- a/demo/frontend/biome.json
+++ b/demo/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
   "extends": "//",
   "files": {
     "experimentalScannerIgnores": ["node_modules", "dist"],

--- a/demo/frontend/tsconfig.json
+++ b/demo/frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowJs": true,
-
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
In response to https://github.com/maplibre/martin/pull/1868 I explored if we check for some of these things and found that we don't for filename specific things, but otherwise we are OK.

I also sorted a few things alphabetically