### PR TITLE
fix(pg): create temp table `spatially_indexed_columns` to improve query performance

### DIFF
--- a/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
+++ b/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS pg_temp.spatially_indexed_columns;
-
 CREATE TEMP TABLE spatially_indexed_columns AS (
     -- list of columns with spatial indexes
     SELECT
@@ -151,3 +149,5 @@ LEFT JOIN descriptions AS dc
         AND gc.name = dc.table_name
 GROUP BY -- noqa: AM06
     gc.schema, gc.name, gc.geom, gc.srid, gc.type, gc.is_view, gc.geom_idx, dc.description;
+
+DROP TABLE IF EXISTS pg_temp.spatially_indexed_columns; -- clean up in case the pg session is not immediately closed

--- a/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
+++ b/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
@@ -25,7 +25,7 @@ CREATE TEMP TABLE spatially_indexed_columns AS (
     GROUP BY 1, 2, 3
 );
 
-CREATE INDEX IF NOT EXISTS idx_sic_lookup ON spatially_indexed_columns (table_schema, table_name, column_name);
+CREATE INDEX idx_sic_lookup ON spatially_indexed_columns (table_schema, table_name, column_name);
 
 ANALYZE spatially_indexed_columns;
 

--- a/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
+++ b/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS pg_temp.spatially_indexed_columns;
 
-CREATE TEMP TABLE IF NOT EXISTS spatially_indexed_columns AS (
+CREATE TEMP TABLE spatially_indexed_columns AS (
     -- list of columns with spatial indexes
     SELECT
         ns.nspname AS table_schema,

--- a/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
+++ b/martin/src/config/file/postgres/resolver/scripts/query_available_tables.sql
@@ -150,4 +150,4 @@ LEFT JOIN descriptions AS dc
 GROUP BY -- noqa: AM06
     gc.schema, gc.name, gc.geom, gc.srid, gc.type, gc.is_view, gc.geom_idx, dc.description;
 
-DROP TABLE IF EXISTS pg_temp.spatially_indexed_columns; -- clean up in case the pg session is not immediately closed
+DROP TABLE pg_temp.spatially_indexed_columns; -- clean up in case the pg session is not immediately closed


### PR DESCRIPTION
I have analyzed the performance issue that I reported about in 
- https://github.com/maplibre/martin/pull/2112

The main issue in our Martin server deployment is that we still use v0.13.0, not the recent version v0.19.0, which includes a slightly different version of the file `query_available_functions.sql`: the older one does not mention the CTE `annotated_geometry_columns`, whereas the newer one does.
For the older query version, the Postgres query optimizer cannot find a fast way to execute the query for some reason, probably because generally it has only limited ability to look into CTEs. When I execute `query_available_functions.sql` manually, the v0.13.0 version takes ~20-25 minutes, while the v0.19.0 version takes ~15-20 seconds.
That's already a very nice improvement.
But if the CTE `spatially_indexed_columns` is materialized as a temporary table as in the pull request above, then the runtime is improved even further, down to ~5 seconds.

I do not know how the performance changes for other DB configurations though:
- different number of tables,
- different table sizes,
- ...

@CommanderStorm I would greatly appreciate if you would again write the tests for this pull request.