### PR TITLE
test(pg): Update PostGIS image to version 18-3.6 in CI and docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,7 @@ just lint
 
 ### Database Management
 ```bash
-# Start test database (PostgreSQL 16 with PostGIS)
+# Start test database (PostgreSQL 18 with PostGIS)
 just start
 
 # Stop database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       PGPASSWORD: postgres
     services:
       postgres:
-        image: postgis/postgis:16-3.5
+        image: postgis/postgis:18-3.6
         ports:
           # will assign a random free host port
           - 5432/tcp
@@ -59,7 +59,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
           --entrypoint sh
-          postgis/postgis:16-3.5
+          postgis/postgis:18-3.6
           -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
       - run: rustup update stable && rustup default stable
@@ -155,7 +155,7 @@ jobs:
       # TODO:  aarch64-unknown-linux-gnu
     services:
       postgres:
-        image: postgis/postgis:16-3.5
+        image: postgis/postgis:18-3.6
         ports:
           - 5432/tcp
         options: >-
@@ -170,7 +170,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
           --entrypoint sh
-          postgis/postgis:16-3.5
+          postgis/postgis:18-3.6
           -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
 
     steps:
@@ -465,7 +465,7 @@ jobs:
           --health-interval=10s \
           --health-timeout=5s \
           --health-retries=5 \
-          postgis/postgis:16-3.5 \
+          postgis/postgis:18-3.6 \
           postgres \
           -c ssl=on \
           -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem  \
@@ -555,11 +555,11 @@ jobs:
           - img_ver: 11-3.0-alpine
             args: postgres
             sslmode: disable
-          - img_ver: 16-3.5-alpine
+          - img_ver: 18-3.6-alpine
             args: postgres
             sslmode: disable
           # alpine images don't support SSL, so for this we use the debian images
-          - img_ver: 16-3.5
+          - img_ver: 18-3.6
             args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
             sslmode: require
           #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   db-is-ready:
     # This should match the version of postgres used in the CI workflow
-    image: postgis/postgis:16-3.5-alpine
+    image: postgis/postgis:18-3.6-alpine
     network_mode: host
     command:
       - 'sh'
@@ -25,7 +25,7 @@ services:
 
   db:
     # This should match the version of postgres used in the CI workflow
-    image: postgis/postgis:16-3.5-alpine
+    image: postgis/postgis:18-3.6-alpine
     restart: unless-stopped
     ports:
       - '${PGPORT:-5411}:5432'
@@ -47,7 +47,7 @@ services:
 
   db-ssl:
     # This should match the version of postgres used in the CI workflow
-    image: postgis/postgis:16-3.5
+    image: postgis/postgis:18-3.6
     command:
       - 'postgres'
       - '-c'
@@ -75,7 +75,7 @@ services:
 
   db-ssl-cert:
     # This should match the version of postgres used in the CI workflow
-    image: postgis/postgis:16-3.5
+    image: postgis/postgis:18-3.6
     command:
       - 'postgres'
       - '-c'


### PR DESCRIPTION
This update ensures that we also work with pg 18 / 3.6