### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,7 +3611,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "martin"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "async-trait",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,9 @@ itertools = "0.14"
 json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
-martin-core = { path = "./martin-core", version = "0.1.1", default-features = false }
+martin-core = { path = "./martin-core", version = "0.1.2", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.4" }
-mbtiles = { path = "./mbtiles", version = "0.13.0" }
+mbtiles = { path = "./mbtiles", version = "0.13.1" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/maplibre/martin/compare/martin-core-v0.1.1...martin-core-v0.1.2) - 2025-09-28
+
+### Other
+
+- updated the following local packages: mbtiles
+
 ## [0.1.1](https://github.com/maplibre/martin/compare/martin-core-v0.1.0...martin-core-v0.1.1) - 2025-09-27
 
 - fix release not working for some packages due to outdated dependedncy definitions

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/maplibre/martin/compare/martin-v0.19.1...martin-v0.19.2) - 2025-09-28
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.19.1](https://github.com/maplibre/martin/compare/martin-v0.19.0...martin-v0.19.1) - 2025-09-28
 
 ### Fixed

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "0.19.1"
+version = "0.19.2"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/maplibre/martin/compare/mbtiles-v0.13.0...mbtiles-v0.13.1) - 2025-09-28
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.13.0](https://github.com/maplibre/martin/compare/mbtiles-v0.12.2...mbtiles-v0.13.0) - 2025-09-26
 
 ### Breaking Changes

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.13.0 -> 0.13.1 (✓ API compatible changes)
* `martin`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `martin-core`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.13.1](https://github.com/maplibre/martin/compare/mbtiles-v0.13.0...mbtiles-v0.13.1) - 2025-09-28

### Other

- update Cargo.lock dependencies
</blockquote>

## `martin`

<blockquote>

## [0.19.2](https://github.com/maplibre/martin/compare/martin-v0.19.1...martin-v0.19.2) - 2025-09-28

### Other

- update Cargo.lock dependencies
</blockquote>

## `martin-core`

<blockquote>

## [0.1.2](https://github.com/maplibre/martin/compare/martin-core-v0.1.1...martin-core-v0.1.2) - 2025-09-28

### Other

- updated the following local packages: mbtiles
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).