### PR TITLE
chore(release): fix misconception that tags come from the push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,7 +787,8 @@ jobs:
           set -x
 
           # Extract Github release version only without the "martin-v" prefix from release tag names (martin-vX.Y.Z)
-          MARTIN_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed -e 's/martin-v//')
+          # On non-release events, this still generates a config with not-a-release as the version to test the release process
+          MARTIN_VERSION=$(echo "${{ github.event.release.tag_name || 'not-a-release' }}" | sed -e 's/martin-v//')
 
           mkdir -p target/homebrew
           cd target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
           retention-days: 5
 
       - name: Login to GitHub Docker registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'release'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         # https://github.com/docker/login-action
         with:
@@ -323,7 +323,7 @@ jobs:
 
       - name: Push the Docker image
         id: docker_push
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'release'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           provenance: mode=max
@@ -337,7 +337,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
       - name: Attest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'release'
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v2
         id: attest
         with:
@@ -786,8 +786,8 @@ jobs:
         run: |
           set -x
 
-          # Extract Github release version only without the "v" prefix
-          MARTIN_VERSION=$(echo "${{ github.ref }}" | sed -e 's/refs\/tags\/v//')
+          # Extract Github release version only without the "martin-v" prefix from release tag names (martin-vX.Y.Z)
+          MARTIN_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed -e 's/martin-v//')
 
           mkdir -p target/homebrew
           cd target
@@ -805,17 +805,17 @@ jobs:
         with: { name: 'homebrew-config', path: 'target/homebrew_config.yaml' }
 
       - name: Generate SLSA build provenance attestation
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with: { subject-path: 'target/files/*' }
       - name: Publish
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
         with:
           files: 'target/files/*'
           generate_release_notes: false
           draft: false
-          make_latest: ${{ startsWith(github.ref, 'refs/tags/martin-') }}
+          make_latest: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'martin-') }}
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -832,7 +832,7 @@ jobs:
         #   Access Metadata: Read-only
         #   Access Pull requests: Read and write
       - name: Checkout maplibre/homebrew-martin
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: maplibre/homebrew-martin
@@ -848,14 +848,14 @@ jobs:
           data_file: target/homebrew_config.yaml
 
       - name: Create a PR for maplibre/homebrew-martin
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'martin-v')
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GH_HOMEBREW_MARTIN_TOKEN }} # See instructions above
-          commit-message: 'Update to ${{ github.ref }}'
-          title: 'Update to ${{ github.ref }}'
-          body: 'Update to ${{ github.ref }}'
-          branch: 'update-to-${{ github.ref }}'
+          commit-message: 'Update to ${{ github.event.release.tag_name }}'
+          title: 'Update to ${{ github.event.release.tag_name }}'
+          body: 'Update to ${{ github.event.release.tag_name }}'
+          branch: 'update-to-${{ github.event.release.tag_name }}'
           branch-suffix: timestamp
           base: 'main'
           labels: 'auto-update'


### PR DESCRIPTION
we now release via the release event instead. Weird that we did use the push event before, but if it works..