### PR TITLE
chore: Add build for `aarch64-unknown-linux-gnu`

### DIFF
--- a/.github/files/homebrew.martin.rb.j2
+++ b/.github/files/homebrew.martin.rb.j2
@@ -23,11 +23,11 @@ class Martin < Formula
   on_linux do
     on_arm do
       sha256 "{{ linux_arm_sha256 }}"
-      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-aarch64-unknown-linux-musl.tar.gz"
+      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-aarch64-unknown-linux-gnu.tar.gz"
     end
     on_intel do
       sha256 "{{ linux_intel_sha256 }}"
-      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-x86_64-unknown-linux-musl.tar.gz"
+      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
 

--- a/.github/files/homebrew.martin.rb.j2
+++ b/.github/files/homebrew.martin.rb.j2
@@ -23,11 +23,11 @@ class Martin < Formula
   on_linux do
     on_arm do
       sha256 "{{ linux_arm_sha256 }}"
-      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-aarch64-unknown-linux-musl.tar.gz"
     end
     on_intel do
       sha256 "{{ linux_intel_sha256 }}"
-      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/maplibre/martin/releases/download/v#{current_version}/martin-x86_64-unknown-linux-musl.tar.gz"
     end
   end
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
       PGHOST: localhost
       PGUSER: postgres
       PGPASSWORD: postgres
-      # TODO:  aarch64-unknown-linux-gnu
     services:
       postgres:
         image: postgis/postgis:16-3.5
@@ -366,6 +365,8 @@ jobs:
             ext: '.exe'
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
     steps:
       - run: rustup update stable && rustup default stable
       - name: Checkout sources
@@ -737,6 +738,9 @@ jobs:
       - name: Download build artifact build-x86_64-apple-darwin
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with: { name: 'build-x86_64-apple-darwin', path: 'target/x86_64-apple-darwin' }
+      - name: Download build artifact build-aarch64-unknown-linux-gnu
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with: { name: 'build-aarch64-unknown-linux-gnu', path: 'target/aarch64-unknown-linux-gnu' }
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target/x86_64-unknown-linux-gnu' }
@@ -760,7 +764,7 @@ jobs:
           cd target
           mkdir files
 
-          for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-musl x86_64-unknown-linux-musl;
+          for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu aarch64-unknown-linux-musl x86_64-unknown-linux-musl;
           do
             cd "$target"
             chmod +x martin martin-cp mbtiles
@@ -797,8 +801,8 @@ jobs:
           version: "$MARTIN_VERSION"
           macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
           macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
-          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)"
+          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)"
           EOF
 
       - name: Save Homebrew Config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,8 +801,8 @@ jobs:
           version: "$MARTIN_VERSION"
           macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
           macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)"
-          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)"
+          linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
+          linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF
 
       - name: Save Homebrew Config

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -313,8 +313,9 @@ styles:
 # This is useful to give clients a better way to cache-bust a CDN:
 # 1. maplibre requests tilejson, tilejson contains the tiles URL. This is always up-to-date.
 # 2. maplibre requests each tile it requires, with the tiles URL in the tilejson.
-# 3. `Control: public, max-age=..., immutable` on tiles to optimize browser/CDN cache hit rates
-#    It also ensures that old tiles aren’t served when a new tileset is deployed.
+# 3. Add `Control: public, max-age=..., immutable` on the tile responses 
+#    optimize browser/CDN cache hit rates, while also making sure that
+#    old tiles aren't served when a new tileset is deployed.
 #
 # The CDN must handle query parameters for caching to work correctly.
 # Many CDNs ignore them by default.

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -313,7 +313,7 @@ styles:
 # This is useful to give clients a better way to cache-bust a CDN:
 # 1. maplibre requests tilejson, tilejson contains the tiles URL. This is always up-to-date.
 # 2. maplibre requests each tile it requires, with the tiles URL in the tilejson.
-# 3. Add `Control: public, max-age=..., immutable` on the tile responses 
+# 3. Add `Control: public, max-age=..., immutable` on the tile responses
 #    optimize browser/CDN cache hit rates, while also making sure that
 #    old tiles aren't served when a new tileset is deployed.
 #

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -313,10 +313,11 @@ styles:
 # This is useful to give clients a better way to cache-bust a CDN:
 # 1. maplibre requests tilejson, tilejson contains the tiles URL. This is always up-to-date.
 # 2. maplibre requests each tile it requires, with the tiles URL in the tilejson.
-# 3. `Control: public, max-age=..., immutable` on the tile responses can bow be set to optimize browser and CDN cache hit rates, while also making sure that old tiles aren't served when a new tileset is deployed
+# 3. Set `Control: public, max-age=..., immutable` on tile responses can now optimize browser and CDN cache hit rates.
+#    It also ensures that old tiles aren’t served when a new tileset is deployed.
 #
-# To work correctly, this needs the CDN to be configured to allow query parameters and take them into acount for cacheing purposes.
-# Some common CDN configurations ignore query parameters by default.
+# The CDN must handle query parameters for caching to work correctly.
+# Many CDNs ignore them by default.
 #
 # For example, if
 # - the setting here is `version`, and

--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -313,7 +313,7 @@ styles:
 # This is useful to give clients a better way to cache-bust a CDN:
 # 1. maplibre requests tilejson, tilejson contains the tiles URL. This is always up-to-date.
 # 2. maplibre requests each tile it requires, with the tiles URL in the tilejson.
-# 3. Set `Control: public, max-age=..., immutable` on tile responses can now optimize browser and CDN cache hit rates.
+# 3. `Control: public, max-age=..., immutable` on tiles to optimize browser/CDN cache hit rates
 #    It also ensures that old tiles aren’t served when a new tileset is deployed.
 #
 # The CDN must handle query parameters for caching to work correctly.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -24,7 +24,7 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 
 | Platform | x64                                                                                              | ARM-64                              |
 |----------|--------------------------------------------------------------------------------------------------|-------------------------------------|
-| Linux    | [.tar.gz][rl-linux-x64] (gnu)<br>[.tar.gz][rl-linux-x64-musl] (musl)<br>[.deb][rl-linux-x64-deb] | [.tar.gz][rl-linux-a64-musl] (musl) |
+| Linux    | [.tar.gz][rl-linux-x64] (gnu)<br>[.tar.gz][rl-linux-x64-musl] (musl)<br>[.deb][rl-linux-x64-deb] | [.tar.gz][rl-linux-a64-gnu] (gnu)<br>[.tar.gz][rl-linux-a64-musl] (musl) |
 | macOS    | [.tar.gz][rl-macos-x64]                                                                          | [.tar.gz][rl-macos-a64]             |
 | Windows  | [.zip][rl-win64-zip]                                                                             |                                     |
 
@@ -33,6 +33,8 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 [rl-linux-x64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-musl.tar.gz
 
 [rl-linux-x64-deb]: https://github.com/maplibre/martin/releases/latest/download/martin-Debian-x86_64.deb
+
+[rl-linux-a64-gnu]: https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-unknown-linux-gnu.tar.gz
 
 [rl-linux-a64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-unknown-linux-musl.tar.gz
 


### PR DESCRIPTION
Closes #2269.

I'm no expert in this stuff but I think something like this should work.

I also switched the Homebrew package on Linux to use the `gnu` binaries instead of `musl` since I'm _pretty_ sure they're [expected](https://docs.brew.sh/Support-Tiers) to use `glibc` by default. Not 100% sure though.