### PR TITLE
chore(ci): add content write permissions to automerge dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
I am not quite sure if this is the correct permissions set, the docs don't quite specify this