### PR TITLE
chore(release): include chages to CI and tests in the changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -23,12 +23,12 @@ git_release_enable = false
 
 [[package]]
 name = "martin"
-changelog_include = ["martin", "martin-core", "martin-tile-utils", "mbtiles"]
+changelog_include = ["martin", "martin-core", "martin-tile-utils", "mbtiles", ".github", "tests", "docs", "debian"]
 semver_check = false # this binary crate doesn't have a public API in the cargo-semver-checks sense
 
 [[package]]
 name = "mbtiles"
-changelog_include = ["martin-tile-utils", "mbtiles"]
+changelog_include = ["martin-tile-utils", "mbtiles", ".github", "tests", "docs"]
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
our changelog generation currently ommits certain things. That is not great as I need to remember this when writing the changelogs

I think below works, but I am not entirely sure.