### PR TITLE
chore(config)!: remove deprecated `--watch` from the CLI options and `MbtilesPool::new`

### DIFF
--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
-use log::warn;
 use martin_core::config::env::Env;
 
 use super::connections::Arguments;

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -90,10 +90,6 @@ impl Args {
         config: &mut Config,
         #[allow(unused_variables)] env: &impl Env<'a>,
     ) -> MartinResult<()> {
-        if self.srv.watch {
-            warn!("The --watch flag is no longer supported, and will be ignored");
-        }
-
         if self.meta.config.is_some() && !self.meta.connection.is_empty() {
             return Err(ConfigAndConnectionsError(self.meta.connection));
         }

--- a/martin/src/config/args/srv.rs
+++ b/martin/src/config/args/srv.rs
@@ -43,9 +43,6 @@ pub struct SrvArgs {
     /// Main cache size (in MB)
     #[arg(short = 'C', long)]
     pub cache_size: Option<u64>,
-    /// **Deprecated** Scan for new sources on sources list requests
-    #[arg(short, long, hide = true)]
-    pub watch: bool,
 }
 
 #[cfg(all(feature = "webui", not(docsrs)))]

--- a/mbtiles/src/pool.rs
+++ b/mbtiles/src/pool.rs
@@ -13,12 +13,6 @@ pub struct MbtilesPool {
 }
 
 impl MbtilesPool {
-    #[deprecated(note = "Use `MbtilesPool::open_readonly` instead")]
-    #[doc(hidden)]
-    pub async fn new<P: AsRef<Path>>(filepath: P) -> MbtResult<Self> {
-        Self::open_readonly(filepath).await
-    }
-
     /// Open a `MBTiles` file in read-only mode.
     pub async fn open_readonly<P: AsRef<Path>>(filepath: P) -> MbtResult<Self> {
         let mbtiles = Mbtiles::new(filepath)?;


### PR DESCRIPTION
This is parts of the items for the v1.0 release