### PR TITLE
chore(ci): Update ignored vulnerabilities to add the non-exploitable `RUSTSEC-2025-0111`

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -18,8 +18,9 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2025-0111
           # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing sidechannels => not used explitably
+          # RUSTSEC-2025-0111 = tokio-tar parses PAX extended headers incorrectly, allows file smuggling => only used in testcontainer-rs, so not explitably
   codeql:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added RUSTSEC-2025-0111 to the list of ignored vulnerabilities in the audit check.