### PR TITLE
chore(bench): reduce pg discovery bench sizes

### DIFF
--- a/martin/benches/postgres_discovery.rs
+++ b/martin/benches/postgres_discovery.rs
@@ -10,7 +10,7 @@ use testcontainers_modules::testcontainers::ImageExt;
 use testcontainers_modules::testcontainers::runners::SyncRunner;
 
 // Benchmark sizes
-const SIZES: &[usize] = &[10, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600];
+const SIZES: &[usize] = &[10, 100, 200];
 
 /// Setup [`PostGIS`](https://hub.docker.com/r/postgis/postgis/) container
 fn setup_postgres_container() -> (


### PR DESCRIPTION
In a few places we are exiecuting the benchmarks in CI (`--all-targets`).

Becuase these benchmarks were not designed for this, they are rather slow.
Reducing how extensive this is benchmarked is in our interest