### PR TITLE
fix: restrict zooming and panning on the data inspector (#2325)

### DIFF
--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -79,8 +79,8 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
           [east, north],
         ],
         {
-          padding: 50,
           maxZoom: tileJSON.maxzoom,
+          padding: 50,
         },
       );
     } else if (tileJSON.center) {
@@ -176,25 +176,15 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
           <section className="border rounded-lg overflow-hidden">
             {isImageSource ? (
               <MapLibreMap
-                ref={mapRef}
-                reuseMaps={false}
-                onLoad={() => {
-                  // Configure bounds for raster sources after map loads
-                  if (tileJSON) {
-                    configureMapBounds();
-                  }
-                }}
                 initialViewState={
                   tileJSON?.center
                     ? {
-                        longitude: tileJSON.center[0],
                         latitude: tileJSON.center[1],
+                        longitude: tileJSON.center[0],
                         zoom: tileJSON.center[2] ?? 0,
                       }
                     : undefined
                 }
-                minZoom={tileJSON?.minzoom}
-                maxZoom={tileJSON?.maxzoom}
                 maxBounds={
                   tileJSON?.bounds
                     ? [
@@ -203,6 +193,16 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
                       ]
                     : undefined
                 }
+                maxZoom={tileJSON?.maxzoom}
+                minZoom={tileJSON?.minzoom}
+                onLoad={() => {
+                  // Configure bounds for raster sources after map loads
+                  if (tileJSON) {
+                    configureMapBounds();
+                  }
+                }}
+                ref={mapRef}
+                reuseMaps={false}
                 style={{
                   height: '500px',
                   width: '100%',
@@ -213,20 +213,15 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
               </MapLibreMap>
             ) : (
               <MapLibreMap
-                onLoad={addInspectorToMap}
-                ref={mapRef}
-                reuseMaps={false}
                 initialViewState={
                   tileJSON?.center
                     ? {
-                        longitude: tileJSON.center[0],
                         latitude: tileJSON.center[1],
+                        longitude: tileJSON.center[0],
                         zoom: tileJSON.center[2] ?? 0,
                       }
                     : undefined
                 }
-                minZoom={tileJSON?.minzoom}
-                maxZoom={tileJSON?.maxzoom}
                 maxBounds={
                   tileJSON?.bounds
                     ? [
@@ -235,6 +230,11 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
                       ]
                     : undefined
                 }
+                maxZoom={tileJSON?.maxzoom}
+                minZoom={tileJSON?.minzoom}
+                onLoad={addInspectorToMap}
+                ref={mapRef}
+                reuseMaps={false}
                 style={{
                   height: '500px',
                   width: '100%',


### PR DESCRIPTION
## Description

Fixes issue #2325 by restricting zooming and panning in the data inspector to the dataset's extent.

Currently, the inspector shows 0/0/0 (zoom level 0/0/0) which works for global datasets but not for local/smaller datasets. This PR implements zoom and pan restrictions based on TileJSON metadata.

## Changes

- **Fetch TileJSON** when the inspector dialog opens from the API endpoint `/{source_ids}`
- **Extract metadata** from TileJSON: `bounds`, `minzoom`, `maxzoom`, and `center`
- **Configure map** with:
  - `initialViewState` using center coordinates if available
  - `minZoom` and `maxZoom` restrictions
  - `maxBounds` to prevent panning outside the dataset extent
  - `fitBounds()` to automatically fit the map to the dataset bounds when available
- **Handle both raster and vector sources** with appropriate configuration
- **Update tests** to mock TileJSON fetch calls

## Technical Details

The implementation:
1. Fetches TileJSON asynchronously when the dialog opens
2. Applies restrictions through both React props (`initialViewState`, `minZoom`, `maxZoom`, `maxBounds`) and direct map API calls (`setMinZoom`, `setMaxZoom`, `setMaxBounds`, `fitBounds`)
3. Handles cases where TileJSON loads after the map has already initialized
4. Gracefully continues without restrictions if TileJSON fetch fails

## Testing

- Updated existing tests to mock TileJSON fetch
- Added test to verify TileJSON is fetched when dialog opens
- All existing tests continue to pass

## Screenshots

Before: Inspector showed blank map with no restrictions (0/0/0)
After: Inspector restricts zoom/pan to dataset bounds and fits to extent

## Related Issues

Closes #2325