### PR TITLE
docs(mbtiles): Improve/Extend a large part of the doc comments

### DIFF
--- a/mbtiles/src/mbtiles.rs
+++ b/mbtiles/src/mbtiles.rs
@@ -85,7 +85,7 @@ pub struct PatchFileInfo {
 /// > **The default in mapbox and maplibre is xyz.***
 /// > **The default in mbtiles generation like plantitler is tms.***
 /// >
-/// > You can use [`mbtiles::invert_y_value`] to convert them.
+/// > You can use [`invert_y_value`] to convert them.
 ///
 /// ```
 /// use mbtiles::Mbtiles;

--- a/mbtiles/src/mbtiles.rs
+++ b/mbtiles/src/mbtiles.rs
@@ -84,7 +84,7 @@ pub struct PatchFileInfo {
 /// > They differ only in if the y coordinate direction.
 /// > **The default in mapbox and maplibre is xyz.***
 /// > **The default in mbtiles generation like plantitler is tms.***
-/// > 
+/// >
 /// > You can use [`mbtiles::invert_y_value`] to convert them.
 ///
 /// ```

--- a/mbtiles/src/mbtiles.rs
+++ b/mbtiles/src/mbtiles.rs
@@ -57,9 +57,9 @@ pub struct PatchFileInfo {
 
 /// A reference to an `MBTiles` file providing low-level database operations.
 ///
-/// `Mbtiles` represents a reference to an [MBTiles](https://github.com/mapbox/mbtiles-spec)
-/// file without holding an open connection. It provides methods for opening connections
-/// and performing tile operations directly.
+/// `Mbtiles` represents a reference to an [MBTiles](https://maplibre.org/martin/mbtiles-schema.html)
+/// file without holding an open connection.
+/// It provides methods for opening connections and performing tile operations directly.
 ///
 /// # `MBTiles` Schema Types
 ///
@@ -78,6 +78,14 @@ pub struct PatchFileInfo {
 /// # Examples
 ///
 /// ## Reading tiles from an existing file
+///
+/// > [!NOTE]
+/// > Note that there are both [osgeos' Tile Map Service](https://wiki.openstreetmap.org/wiki/TMS) and [xyz Slippy map tilenames](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) tiling shemes.
+/// > They differ only in if the y coordinate direction.
+/// > **The default in mapbox and maplibre is xyz.***
+/// > **The default in mbtiles generation like plantitler is tms.***
+/// > 
+/// > You can use [`mbtiles::invert_y_value`] to convert them.
 ///
 /// ```
 /// use mbtiles::Mbtiles;
@@ -410,13 +418,25 @@ impl Mbtiles {
     /// - `x` is the column (0 to 2^z - 1)
     /// - `y` is the row in XYZ format (0 at top, increases southward)
     ///
-    /// Note: `MBTiles` files internally use TMS coordinates (0 at bottom), but this
-    /// method handles the conversion automatically.
+    /// > [!NOTE]
+    /// > MBTiles files internally use [osgeos' Tile Map Service](https://wiki.openstreetmap.org/wiki/TMS) coordinates (0 at bottom).
+    /// > This method handles the conversion automatically as maplibre/mapbox expect this.
     ///
     /// # Performance
     ///
     /// If you also need the tile hash, use [`get_tile_and_hash`](Self::get_tile_and_hash)
     /// to fetch both in a single query.
+    ///
+    /// # Coordinate System
+    ///
+    /// Coordinates use the [xyz Slippy map tilenames](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) tile scheme where:
+    /// - `z` is the zoom level (0-30)
+    /// - `x` is the column (0 to 2^z - 1)
+    /// - `y` is the row in XYZ format (0 at top, increases southward)
+    ///
+    /// > [!NOTE]
+    /// > MBTiles files internally use [osgeos' Tile Map Service](https://wiki.openstreetmap.org/wiki/TMS) coordinates (0 at bottom).
+    /// > This method handles the conversion automatically as maplibre/mapbox expect this.
     ///
     /// # Examples
     ///
@@ -475,6 +495,17 @@ impl Mbtiles {
     ///
     /// If you don't need the hash, use [`get_tile`](Self::get_tile) instead to avoid
     /// the overhead of hash retrieval.
+    ///
+    /// # Coordinate System
+    ///
+    /// Coordinates use the [xyz Slippy map tilenames](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) tile scheme where:
+    /// - `z` is the zoom level (0-30)
+    /// - `x` is the column (0 to 2^z - 1)
+    /// - `y` is the row in XYZ format (0 at top, increases southward)
+    ///
+    /// > [!NOTE]
+    /// > MBTiles files internally use [osgeos' Tile Map Service](https://wiki.openstreetmap.org/wiki/TMS) coordinates (0 at bottom).
+    /// > This method handles the conversion automatically as maplibre/mapbox expect this.
     ///
     /// # Examples
     ///

--- a/mbtiles/src/metadata.rs
+++ b/mbtiles/src/metadata.rs
@@ -48,6 +48,7 @@ pub struct Metadata {
     pub tile_info: TileInfo,
 
     /// Layer type: `"overlay"` or `"baselayer"` (MBTiles-specific field).
+    // todo: change this to an enum
     pub layer_type: Option<String>,
 
     /// Core [TileJSON](https://github.com/mapbox/tilejson-spec) metadata.
@@ -271,11 +272,10 @@ impl Mbtiles {
     /// - Vector tile fields: `vector_layers` (stored in `json` metadata key)
     /// - Custom fields: any values in `TileJSON.other`
     ///
-    /// # Notes
-    ///
-    /// - Existing metadata values are replaced (INSERT OR REPLACE)
-    /// - `None` values are skipped (not inserted)
-    /// - Vector layers are serialized to JSON and stored in the `json` metadata key
+    /// > [!NOTE]
+    /// > - Existing metadata values are replaced (INSERT OR REPLACE)
+    /// > - `None` values are skipped (not inserted)
+    /// > - Vector layers are serialized to JSON and stored in the `json` metadata key
     ///
     /// # Examples
     ///

--- a/mbtiles/src/metadata.rs
+++ b/mbtiles/src/metadata.rs
@@ -15,15 +15,52 @@ use crate::MbtError::InvalidZoomValue;
 use crate::Mbtiles;
 use crate::errors::MbtResult;
 
+/// Tileset metadata combining [MBTiles](https://github.com/mapbox/mbtiles-spec)
+/// and [TileJSON](https://github.com/mapbox/tilejson-spec) specifications.
+///
+/// Returned by [`Mbtiles::get_metadata`] and [`crate::MbtilesPool::get_metadata`].
+///
+/// # Example
+///
+/// ```no_run
+/// use mbtiles::MbtilesPool;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = MbtilesPool::open_readonly("world.mbtiles").await?;
+/// let metadata = pool.get_metadata().await?;
+///
+/// println!("Name: {}", metadata.tilejson.name.unwrap_or_default());
+/// println!("Format: {}", metadata.tile_info.format);
+/// println!("Zoom: {:?}-{:?}", metadata.tilejson.minzoom, metadata.tilejson.maxzoom);
+/// # Ok(())
+/// # }
+/// ```
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Metadata {
+    /// Tileset identifier, typically the filename without extension.
     pub id: String,
+
+    /// Tile format (PNG, JPEG, MVT, etc.) and encoding (gzip, etc.).
+    ///
+    /// Auto-detected from tile data. See [`martin_tile_utils::TileInfo`].
     #[serde(serialize_with = "serialize_ti")]
     pub tile_info: TileInfo,
+
+    /// Layer type: `"overlay"` or `"baselayer"` (MBTiles-specific field).
     pub layer_type: Option<String>,
+
+    /// Core [TileJSON](https://github.com/mapbox/tilejson-spec) metadata.
+    ///
+    /// Includes name, bounds, zoom levels, attribution, vector layers, etc.
     pub tilejson: TileJSON,
+
+    /// Custom JSON metadata for application-specific data.
     pub json: Option<JSONValue>,
+
+    /// Aggregate hash of all tiles for validation and change detection.
+    ///
+    /// See [`Mbtiles::validate`] and [`Mbtiles::update_agg_tiles_hash`].
     pub agg_tiles_hash: Option<String>,
 }
 
@@ -108,6 +145,44 @@ impl Mbtiles {
         Ok(())
     }
 
+    /// Retrieves all metadata from the `MBTiles` file.
+    ///
+    /// Reads the entire metadata table and constructs a [`Metadata`] struct
+    /// containing all tileset information. This includes:
+    /// - All `TileJSON` fields (bounds, zoom levels, attribution, etc.)
+    /// - Tile format and encoding (auto-detected from sample tiles)
+    /// - Vector layer definitions (for MVT tiles)
+    /// - Custom JSON metadata
+    /// - Aggregate tiles hash (if present)
+    ///
+    /// # Format Detection
+    ///
+    /// This method automatically detects the tile format (PNG, JPEG, MVT, etc.)
+    /// and encoding (gzip, etc.) by examining actual tile data in the database.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use mbtiles::Mbtiles;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mbt = Mbtiles::new("world.mbtiles")?;
+    /// let mut conn = mbt.open_readonly().await?;
+    ///
+    /// let metadata = mbt.get_metadata(&mut conn).await?;
+    ///
+    /// // Access various metadata fields
+    /// println!("Name: {}", metadata.tilejson.name.unwrap_or_default());
+    /// println!("Format: {}", metadata.tile_info.format);
+    /// println!("Bounds: {:?}", metadata.tilejson.bounds);
+    /// println!("Zoom: {:?}-{:?}", metadata.tilejson.minzoom, metadata.tilejson.maxzoom);
+    ///
+    /// if let Some(layers) = &metadata.tilejson.vector_layers {
+    ///     println!("Vector layers: {}", layers.len());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_metadata<T>(&self, conn: &mut T) -> MbtResult<Metadata>
     where
         for<'e> &'e mut T: SqliteExecutor<'e>,
@@ -186,6 +261,40 @@ impl Mbtiles {
         })
     }
 
+    /// Inserts `TileJSON` metadata into the `MBTiles` metadata table.
+    ///
+    /// Writes all fields from a [`TileJSON`] struct to the metadata table,
+    /// converting them to the `MBTiles` key-value format. This includes:
+    /// - Standard fields: name, description, version, attribution, legend, template
+    /// - Geographic fields: bounds, center
+    /// - Zoom fields: minzoom, maxzoom
+    /// - Vector tile fields: `vector_layers` (stored in `json` metadata key)
+    /// - Custom fields: any values in `TileJSON.other`
+    ///
+    /// # Notes
+    ///
+    /// - Existing metadata values are replaced (INSERT OR REPLACE)
+    /// - `None` values are skipped (not inserted)
+    /// - Vector layers are serialized to JSON and stored in the `json` metadata key
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use mbtiles::Mbtiles;
+    /// use tilejson::tilejson;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mbt = Mbtiles::new("output.mbtiles")?;
+    /// let mut conn = mbt.open().await?;
+    ///
+    /// // Create TileJSON metadata
+    /// let tj = tilejson! { tiles: vec![] };
+    ///
+    /// // Insert all metadata
+    /// mbt.insert_metadata(&mut conn, &tj).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn insert_metadata<T>(&self, conn: &mut T, tile_json: &TileJSON) -> MbtResult<()>
     where
         for<'e> &'e mut T: SqliteExecutor<'e>,

--- a/mbtiles/src/pool.rs
+++ b/mbtiles/src/pool.rs
@@ -45,15 +45,15 @@ use crate::{MbtType, Mbtiles, Metadata};
 ///
 /// ```
 /// use mbtiles::MbtilesPool;
-/// use std::sync::Arc;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let pool = Arc::new(MbtilesPool::open_readonly("world.mbtiles").await?);
+/// let pool = MbtilesPool::open_readonly("world.mbtiles").await?;
 ///
 /// // Spawn multiple concurrent tile requests
 /// let mut handles = vec![];
 /// for z in 0..5 {
-///     let pool = Arc::clone(&pool);
+///     // cheap and thead-save
+///     let pool = pool.clone();
 ///     handles.push(tokio::spawn(async move {
 ///         pool.get_tile(z, 0, 0).await
 ///     }));
@@ -160,10 +160,9 @@ impl MbtilesPool {
     /// You typically need the schema type for operations like [`get_tile_and_hash`](Self::get_tile_and_hash)
     /// or [`contains`](Self::contains) that behave differently based on the schema.
     ///
-    /// # Performance
-    ///
-    /// This method queries the database schema. Consider caching the result if you
-    /// need it repeatedly.
+    /// > [!TIP]
+    /// > This method queries the database schema.
+    /// > Consider caching the result if you need it repeatedly.
     ///
     /// # Examples
     ///
@@ -195,13 +194,14 @@ impl MbtilesPool {
     ///
     /// # Coordinate System
     ///
-    /// Coordinates use the XYZ tile scheme where:
+    /// Coordinates use the [xyz Slippy map tilenames](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) tile scheme where:
     /// - `z` is the zoom level (0-30)
     /// - `x` is the column (0 to 2^z - 1)
     /// - `y` is the row in XYZ format (0 at top, increases southward)
     ///
-    /// Note: `MBTiles` files internally use TMS coordinates (0 at bottom), but this
-    /// method handles the conversion automatically.
+    /// > [!NOTE]
+    /// > MBTiles files internally use [osgeos' Tile Map Service](https://wiki.openstreetmap.org/wiki/TMS) coordinates (0 at bottom).
+    /// > This method handles the conversion automatically as maplibre/mapbox expect this.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
This PR improves the documentation of the `Mbtiles`, `MbtilesPool` and `Metadata` structs. Most of the docs were admittedly generated by Claude Code, but I've reviewed them to the best of my ability and fixed the few issues I had found in the example snippets :)