### PR TITLE
chore: sync our versions in the docs to the actual version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,13 +48,19 @@ repos:
         language: rust
         pass_filenames: false
 
-      - id: sync-frontend-version
-        name: Sync Frontend Version
+      - id: sync-martin-version
+        name: Sync martin Version
         description: "Update martin-ui package.json version from martin Cargo.toml"
         entry: |
           bash -c '
             VERSION=$(grep "^version = " martin/Cargo.toml | sed "s/version = \"\(.*\)\"/\1/")
             sed -i "s/version\": \".*\"/version\": \"$VERSION\"/" martin/martin-ui/package.json
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/src/run-with-docker-compose.md
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/src/run-with-docker.md
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" demo/docker-compose.yml
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/src/installation.md
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/src/run-with-lambda.md
+            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" justfile
             echo "Synced version to $VERSION"
           '
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,6 @@ repos:
             sed -i "s/version\": \".*\"/version\": \"$VERSION\"/" martin/martin-ui/package.json
             sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/src/run-with-docker-compose.md
             sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/src/run-with-docker.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" demo/docker-compose.yml
             sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/src/installation.md
             sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/src/run-with-lambda.md
             sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" justfile

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:0.20.2
+    image: ghcr.io/maplibre/martin
     # For Arm64 - you have to build your own image from source https://github.com/maplibre/martin/issues/655#issuecomment-1540669505
     restart: unless-stopped
     ports:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin
+    image: ghcr.io/maplibre/martin:0.20.0
     # For Arm64 - you have to build your own image from source https://github.com/maplibre/martin/issues/655#issuecomment-1540669505
     restart: unless-stopped
     ports:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:0.20.0
+    image: ghcr.io/maplibre/martin:0.20.2
     # For Arm64 - you have to build your own image from source https://github.com/maplibre/martin/issues/655#issuecomment-1540669505
     restart: unless-stopped
     ports:

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:0.20.0 \
+           ghcr.io/maplibre/martin:0.20.2 \
            --config /config/config.yaml
 ```
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -15,7 +15,8 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin --config /config/config.yaml
+           ghcr.io/maplibre/martin:0.20.0 \
+           --config /config/config.yaml
 ```
 
 ### From Binary Distributions Manually

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:v0.16.0
+    image: ghcr.io/maplibre/martin:0.20.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:0.20.0
+    image: ghcr.io/maplibre/martin:0.20.2
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/run-with-docker.md
+++ b/docs/src/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:0.20.0
+  ghcr.io/maplibre/martin:0.20.2
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:0.20.0 \
+  ghcr.io/maplibre/martin:0.20.2 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:0.20.0
+  ghcr.io/maplibre/martin:0.20.2
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:0.20.0
+  ghcr.io/maplibre/martin:0.20.2
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:0.20.0
+  ghcr.io/maplibre/martin:0.20.2
 ```

--- a/docs/src/run-with-docker.md
+++ b/docs/src/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin
+  ghcr.io/maplibre/martin:0.20.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,8 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin /files
+  ghcr.io/maplibre/martin:0.20.0 \
+  /files
 ```
 
 ### Accessing Local PostgreSQL on Linux
@@ -34,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin
+  ghcr.io/maplibre/martin:0.20.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -45,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin
+  ghcr.io/maplibre/martin:0.20.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -56,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin
+  ghcr.io/maplibre/martin:0.20.0
 ```

--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:0.20.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:0.20.2 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:0.20.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:0.20.2 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:latest --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:0.20.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:latest 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:0.20.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:0.20.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:0.20.2 {{args}}
 
 # Build and open code documentation
 docs *args='--open':

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:0.2 {{args}}
 
 # Build and open code documentation
 docs *args='--open':

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:0.2 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:0.20.0 {{args}}
 
 # Build and open code documentation
 docs *args='--open':


### PR DESCRIPTION
Some parts of our docs don't actually refer to versions, despite that they likely should

This PR adds them to the version sync logic