### PR TITLE
fix: broken url to github release in web-ui

### DIFF
--- a/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
+++ b/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
@@ -1256,9 +1256,10 @@ exports[`Header Component > renders correctly 1`] = `
             class="items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90 hover:bg-purple-700 hidden md:block p-1"
             data-slot="badge"
             href="https://github.com/maplibre/martin/releases/tag/martin-v0.0.0-test"
-            target="_blank" rel="noopener noreferrer"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            v0.0.0-test
+            0.0.0-test
           </a>
         </div>
         <div

--- a/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
+++ b/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
@@ -1255,7 +1255,8 @@ exports[`Header Component > renders correctly 1`] = `
           <a
             class="items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90 hover:bg-purple-700 hidden md:block p-1"
             data-slot="badge"
-            href="https://github.com/maplibre/martin/releases/tag/v0.0.0-test"
+            href="https://github.com/maplibre/martin/releases/tag/martin-v0.0.0-test"
+            target="_blank" rel="noopener noreferrer"
           >
             v0.0.0-test
           </a>

--- a/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
+++ b/martin/martin-ui/__tests__/components/__snapshots__/header.test.tsx.snap
@@ -1255,11 +1255,11 @@ exports[`Header Component > renders correctly 1`] = `
           <a
             class="items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90 hover:bg-purple-700 hidden md:block p-1"
             data-slot="badge"
-            href="https://github.com/maplibre/martin/releases/tag/martin-v0.0.0-test"
+            href="https://github.com/maplibre/martin/releases/tag/martin-v1.0.0"
             rel="noopener noreferrer"
             target="_blank"
           >
-            0.0.0-test
+            1.0.0
           </a>
         </div>
         <div

--- a/martin/martin-ui/__tests__/components/header.test.tsx
+++ b/martin/martin-ui/__tests__/components/header.test.tsx
@@ -6,7 +6,7 @@ import { render } from '../test-utils';
 // Mock import.meta.env for tests
 const mockImportMeta = {
   env: {
-    VITE_MARTIN_VERSION: '0.0.0-test',
+    VITE_MARTIN_VERSION: '1.0.0',
   },
 };
 
@@ -25,7 +25,7 @@ describe('Header Component', () => {
 
   it('displays the Martin version', () => {
     const { getByText } = render(<Header />);
-    expect(getByText('0.0.0-test')).toBeTruthy();
+    expect(getByText('1.0.0')).toBeTruthy();
   });
 
   it('contains navigation links', () => {

--- a/martin/martin-ui/__tests__/components/header.test.tsx
+++ b/martin/martin-ui/__tests__/components/header.test.tsx
@@ -6,7 +6,7 @@ import { render } from '../test-utils';
 // Mock import.meta.env for tests
 const mockImportMeta = {
   env: {
-    VITE_MARTIN_VERSION: 'v0.0.0-test',
+    VITE_MARTIN_VERSION: '0.0.0-test',
   },
 };
 
@@ -25,7 +25,7 @@ describe('Header Component', () => {
 
   it('displays the Martin version', () => {
     const { getByText } = render(<Header />);
-    expect(getByText('v0.0.0-test')).toBeTruthy();
+    expect(getByText('0.0.0-test')).toBeTruthy();
   });
 
   it('contains navigation links', () => {

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -21,8 +21,9 @@ export function Header() {
             <Badge asChild className="hover:bg-purple-700 hidden md:block" variant="default">
               {import.meta.env.VITE_MARTIN_VERSION ? (
                 <a
-                  className="p-1" target="_blank"
+                  className="p-1"
                   href={`https://github.com/maplibre/martin/releases/tag/martin-v${import.meta.env.VITE_MARTIN_VERSION}`}
+                  target="_blank"
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
                 </a>

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -23,7 +23,8 @@ export function Header() {
                 <a
                   className="p-1"
                   href={`https://github.com/maplibre/martin/releases/tag/martin-v${import.meta.env.VITE_MARTIN_VERSION}`}
-                  target="_blank" rel="noopener noreferrer"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
                 </a>

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -21,8 +21,8 @@ export function Header() {
             <Badge asChild className="hover:bg-purple-700 hidden md:block" variant="default">
               {import.meta.env.VITE_MARTIN_VERSION ? (
                 <a
-                  className="p-1"
-                  href={`https://github.com/maplibre/martin/releases/tag/${import.meta.env.VITE_MARTIN_VERSION}`}
+                  className="p-1" target="_blank"
+                  href={`https://github.com/maplibre/martin/releases/tag/martin-v${import.meta.env.VITE_MARTIN_VERSION}`}
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
                 </a>

--- a/martin/martin-ui/src/components/header.tsx
+++ b/martin/martin-ui/src/components/header.tsx
@@ -23,7 +23,7 @@ export function Header() {
                 <a
                   className="p-1"
                   href={`https://github.com/maplibre/martin/releases/tag/martin-v${import.meta.env.VITE_MARTIN_VERSION}`}
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                 >
                   {import.meta.env.VITE_MARTIN_VERSION}
                 </a>

--- a/martin/martin-ui/vitest.setup.ts
+++ b/martin/martin-ui/vitest.setup.ts
@@ -21,7 +21,7 @@ vi.mock('react', async () => {
 });
 
 // Mock import.meta.env globally - Vitest handles this natively, but we set defaults
-vi.stubEnv('VITE_MARTIN_VERSION', 'v0.0.0-test');
+vi.stubEnv('VITE_MARTIN_VERSION', '0.0.0-test');
 vi.stubEnv('VITE_MARTIN_BASE', 'http://localhost:3000');
 
 // Suppress console errors during tests

--- a/martin/martin-ui/vitest.setup.ts
+++ b/martin/martin-ui/vitest.setup.ts
@@ -21,7 +21,7 @@ vi.mock('react', async () => {
 });
 
 // Mock import.meta.env globally - Vitest handles this natively, but we set defaults
-vi.stubEnv('VITE_MARTIN_VERSION', '0.0.0-test');
+vi.stubEnv('VITE_MARTIN_VERSION', '1.0.0');
 vi.stubEnv('VITE_MARTIN_BASE', 'http://localhost:3000');
 
 // Suppress console errors during tests


### PR DESCRIPTION
## Rationale

I noticed that the github release link has an outdated format.

<img width="956" height="354" alt="image" src="https://github.com/user-attachments/assets/e4f43e7c-ad0f-4d6b-a74a-146d1ba7c80e" />

- broken link: https://github.com/maplibre/martin/releases/tag/0.20.1
- actual url: https://github.com/maplibre/martin/releases/tag/martin-v0.20.1

## Changes in this PR
- Fixes the github release link
- Open the release page in a new tab to match the behavior of the other header links.
- The tests used `v0.0.0-test` as mock value, updated it to `0.0.0-test` to match the actual format 