### PR TITLE
chore(release): migrate to new pmtiles directory cache api and add avif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4880,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "pmtiles"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01c60faf873f6bbffc603c84934402fdf51d1b32624a405041524fce89da23"
+checksum = "6ccb5d2a71c30442e35985a680614e0666d24daab8682aa01d4b1c4eae10de40"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -4893,6 +4893,7 @@ dependencies = [
  "flate2",
  "fmmap",
  "futures-util",
+ "moka",
  "object_store",
  "reqwest",
  "rust-s3",
@@ -6755,9 +6756,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.16.3"
+version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
+checksum = "b3d8046c5674ab857104bc4559d505f4809b8060d57806e45d49737c97afeb60"
 dependencies = [
  "debugid",
  "memmap2",
@@ -6767,9 +6768,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.16.3"
+version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
+checksum = "1accb6e5c4b0f682de907623912e616b44be1c9e725775155546669dbff720ec"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 object_store = { version = "0.12.4", features = ["gcp", "aws", "azure", "fs", "http"] }
 pbf_font_tools = { version = "3.0.0", features = ["freetype"] }
-pmtiles = { version = "0.18", features = ["http-async", "mmap-async-tokio", "tilejson", "reqwest-rustls-tls-native-roots", "aws-s3-async"] }
+pmtiles = { version = "0.18.2", features = ["tilejson", "object-store"] }
 png = "0.18.0"
 postgis = "0.9"
 postgres = { version = "0.19", features = ["with-time-0_3", "with-uuid-1", "with-serde_json-1"] }

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -79,6 +79,7 @@ impl PmtilesSource {
             TileType::Png => Format::Png.into(),
             TileType::Jpeg => Format::Jpeg.into(),
             TileType::Webp => Format::Webp.into(),
+            TileType::Avif => Format::Avif.into(),
             TileType::Unknown => {
                 return Err(PmtilesError::UnknownTileType(
                     id.clone(),

--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -79,6 +79,7 @@ pub enum Format {
     Mvt,
     Png,
     Webp,
+    Avif,
 }
 
 impl Format {
@@ -91,6 +92,7 @@ impl Format {
             "pbf" | "mvt" => Self::Mvt,
             "png" => Self::Png,
             "webp" => Self::Webp,
+            "avif" => Self::Avif,
             _ => None?,
         })
     }
@@ -106,6 +108,7 @@ impl Format {
             Self::Mvt => "pbf",
             Self::Png => "png",
             Self::Webp => "webp",
+            Self::Avif => "avif",
         }
     }
 
@@ -118,13 +121,14 @@ impl Format {
             Self::Mvt => "application/x-protobuf",
             Self::Png => "image/png",
             Self::Webp => "image/webp",
+            Self::Avif => "image/avif",
         }
     }
 
     #[must_use]
     pub fn is_detectable(self) -> bool {
         match self {
-            Self::Png | Self::Jpeg | Self::Gif | Self::Webp => true,
+            Self::Png | Self::Jpeg | Self::Gif | Self::Webp | Self::Avif => true,
             // TODO: Json can be detected, but currently we only detect it
             //       when it's not compressed, so to avoid a warning, keeping it as false for now.
             //       Once we can detect it inside a compressed data, change it to true.
@@ -142,6 +146,7 @@ impl Display for Format {
             Self::Mvt => "mvt",
             Self::Png => "png",
             Self::Webp => "webp",
+            Self::Avif => "avif",
         })
     }
 }
@@ -241,7 +246,9 @@ impl From<Format> for TileInfo {
         Self::new(
             format,
             match format {
-                Format::Png | Format::Jpeg | Format::Webp | Format::Gif => Encoding::Internal,
+                Format::Png | Format::Jpeg | Format::Webp | Format::Gif | Format::Avif => {
+                    Encoding::Internal
+                }
                 Format::Mvt | Format::Json => Encoding::Uncompressed,
             },
         )

--- a/martin/src/srv/tiles/metadata.rs
+++ b/martin/src/srv/tiles/metadata.rs
@@ -191,9 +191,8 @@ pub mod tests {
 
     use tilejson::{Bounds, VectorLayer};
 
-    use crate::srv::tiles::tests::TestSource;
-
     use super::*;
+    use crate::srv::tiles::tests::TestSource;
 
     #[test]
     fn test_merge_tilejson() {


### PR DESCRIPTION
This PR bumps pmtiles and fixes its version to minor as the last two patch releases were breaking and should have bumped minor instead. 