### PR TITLE
chore(release): bump `martin-tile-utils` to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "approx",
  "brotli 8.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.1"
 martin-core = { path = "./martin-core", version = "0.2.3", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.6" }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.7" }
 mbtiles = { path = "./mbtiles", version = "0.14.2" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.6.6"
+version = "0.6.7"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]


### PR DESCRIPTION
Apparently, I should have bumped `martin-tile-utils` as well.