### PR TITLE
chore: Specify platform of PostGIS Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
   db-is-ready:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:18-3.6-alpine
+    platform: linux/x86_64
     network_mode: host
     command:
       - 'sh'
@@ -26,6 +27,7 @@ services:
   db:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:18-3.6-alpine
+    platform: linux/x86_64
     restart: unless-stopped
     ports:
       - '${PGPORT:-5411}:5432'
@@ -48,6 +50,7 @@ services:
   db-ssl:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:18-3.6
+    platform: linux/x86_64
     command:
       - 'postgres'
       - '-c'
@@ -76,6 +79,7 @@ services:
   db-ssl-cert:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:18-3.6
+    platform: linux/x86_64
     command:
       - 'postgres'
       - '-c'
@@ -104,6 +108,7 @@ services:
   db-legacy:
     # This should match the version of postgres used in the CI workflow
     image: postgis/postgis:11-3.0-alpine
+    platform: linux/x86_64
     restart: unless-stopped
     ports:
       - '${PGPORT:-5411}:5432'


### PR DESCRIPTION
On macOS, we get this error because PostGIS doesn't provide Docker image for macOS.

```
❯ just start
docker-compose up -d fileserver
[+] Running 1/1
 ✔ Container martin-fileserver-1  Running                                                                                                    0.0s
docker-compose up -d db
[+] Running 0/1
 ⠴ db Pulling                                                                                                                                4.5s
no matching manifest for linux/arm64/v8 in the manifest list entries
error: Recipe `docker-up` failed on line 496 with exit code 1
```

This happens because Docker chooses the same platform as the host by default. This pull request fixes it by specifying`linux/x86_64` platform for these images explicitly.