### PR TITLE
feat(martin-cp): infer default bounds from configured sources for better performance

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -363,7 +363,7 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
                 source
                     .get_tilejson()
                     .bounds
-                    .unwrap_or_else(|| Bounds::MAX_TILED)
+                    .unwrap_or(Bounds::MAX_TILED)
             })
             .collect::<Vec<Bounds>>();
 

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -691,10 +691,10 @@ mod tests {
     #[rstest]
     #[case::one_source(one_source(), "test_source", vec![Bounds::from_str("-120.0,30.0,-110.0,40.0").unwrap()])]
     #[case::many_sources(many_sources(), "test_source,test_source2", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap()])]
-    #[case::many_sources_rev(many_sources(), "test_source2,test_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap()])]
+    #[case::many_sources_rev(many_sources(), "test_source2,test_source", vec![Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap(), Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap()])]
     #[case::many_sources_only_unbounded(many_sources(), "unbounded_source", vec![Bounds::MAX_TILED])]
     #[case::many_sources_bounded_and_unbounded(many_sources(), "test_source,unbounded_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::MAX_TILED])]
-    #[case::many_sources_bounded_and_unbounded_rev(many_sources(), "unbounded_source,test_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::MAX_TILED])]
+    #[case::many_sources_bounded_and_unbounded_rev(many_sources(), "unbounded_source,test_source", vec![Bounds::MAX_TILED, Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap()])]
     #[case::source_wo_bounds(source_wo_bounds(), "test_source", vec![Bounds::MAX_TILED])]
     fn test_default_bounds(
         #[case] src: TileSources,

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -667,6 +667,11 @@ mod tests {
                 tj: tilejson! { tiles: vec![], bounds: Bounds::from_str("-150.0,40.0,-120.0,10.0").unwrap() },
                 data: Vec::default(),
             }),
+            Box::new(MockSource {
+                id: "unbounded_source",
+                tj: tilejson! { tiles: vec![] },
+                data: Vec::default(),
+            }),
         ]])
     }
 
@@ -691,6 +696,10 @@ mod tests {
     #[rstest]
     #[case::one_source(one_source(), "test_source", vec![Bounds::from_str("-120.0,30.0,-110.0,40.0").unwrap()])]
     #[case::many_sources(many_sources(), "test_source,test_source2", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap()])]
+    #[case::many_sources_rev(many_sources(), "test_source2,test_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap()])]
+    #[case::many_sources_only_unbounded(many_sources(), "unbounded_source", vec![Bounds::MAX_TILED])]
+    #[case::many_sources_bounded_and_unbounded(many_sources(), "test_source,unbounded_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::MAX_TILED])]
+    #[case::many_sources_bounded_and_unbounded_rev(many_sources(), "unbounded_source,test_source", vec![Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap(), Bounds::MAX_TILED])]
     #[case::source_wo_bounds(source_wo_bounds(), "test_source", vec![Bounds::MAX_TILED])]
     fn test_default_bounds(
         #[case] src: TileSources,

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -359,12 +359,7 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
         let mut source_bounds = src
             .sources
             .iter()
-            .map(|source| {
-                source
-                    .get_tilejson()
-                    .bounds
-                    .unwrap_or(Bounds::MAX_TILED)
-            })
+            .map(|source| source.get_tilejson().bounds.unwrap_or(Bounds::MAX_TILED))
             .collect::<Vec<Bounds>>();
 
         source_bounds.dedup_by_key(|bounds| bounds.to_string());

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -356,19 +356,28 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
     if src.sources.is_empty() {
         vec![Bounds::MAX_TILED]
     } else {
-        let mut source_bounds = src.sources.iter().filter_map(|source|
-            source.get_tilejson().bounds
-        ).collect::<Vec<Bounds>>();
-        
+        let mut source_bounds = src
+            .sources
+            .iter()
+            .filter_map(|source| source.get_tilejson().bounds)
+            .collect::<Vec<Bounds>>();
+
         source_bounds.dedup_by_key(|bounds| bounds.to_string());
-        
+
         if source_bounds.is_empty() {
-            info!("No configured bounds for source, using: {}", Bounds::MAX_TILED);
+            info!(
+                "No configured bounds for source, using: {}",
+                Bounds::MAX_TILED
+            );
             vec![Bounds::MAX_TILED]
         } else {
             info!(
                 "No bbox specified, using source bounds: {}",
-                source_bounds.iter().map(|s| format!("[{s}]")).collect::<Vec<String>>().join(", ")
+                source_bounds
+                    .iter()
+                    .map(|s| format!("[{s}]"))
+                    .collect::<Vec<String>>()
+                    .join(", ")
             );
             source_bounds
         }
@@ -651,8 +660,8 @@ mod tests {
             Box::new(MockSource {
                 id: "unrequested_source",
                 tj: tilejson! { tiles: vec![], bounds: Bounds::from_str("-150.0,40.0,-120.0,10.0").unwrap() },
-                data: Vec::default()
-            })
+                data: Vec::default(),
+            }),
         ]])
     }
 

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -359,7 +359,12 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
         let mut source_bounds = src
             .sources
             .iter()
-            .map(|source| source.get_tilejson().bounds.unwrap_or_else(|| Bounds::MAX_TILED))
+            .map(|source| {
+                source
+                    .get_tilejson()
+                    .bounds
+                    .unwrap_or_else(|| Bounds::MAX_TILED)
+            })
             .collect::<Vec<Bounds>>();
 
         source_bounds.dedup_by_key(|bounds| bounds.to_string());

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -359,7 +359,7 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
         let mut source_bounds = src
             .sources
             .iter()
-            .filter_map(|source| source.get_tilejson().bounds)
+            .map(|source| source.get_tilejson().bounds.unwrap_or_else(|| Bounds::MAX_TILED))
             .collect::<Vec<Bounds>>();
 
         source_bounds.dedup_by_key(|bounds| bounds.to_string());

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -358,11 +358,14 @@ fn default_bounds(src: &DynTileSource) -> Vec<Bounds> {
             Some(bounds) => {
                 info!("No bbox specified, using source bounds: {}", bounds);
                 vec![bounds]
-            },
+            }
             None => {
-                info!("No configured bounds for source, using: {}", Bounds::MAX_TILED);
+                info!(
+                    "No configured bounds for source, using: {}",
+                    Bounds::MAX_TILED
+                );
                 vec![Bounds::MAX_TILED]
-            },
+            }
         }
     } else {
         vec![Bounds::MAX_TILED]
@@ -585,15 +588,15 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use super::*;
     use async_trait::async_trait;
     use insta::assert_yaml_snapshot;
-    use rstest::{fixture, rstest};
-    use tilejson::{tilejson, TileJSON};
     use martin::TileSources;
     use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format};
-    use super::*;
+    use rstest::{fixture, rstest};
+    use std::str::FromStr;
+    use tilejson::{TileJSON, tilejson};
 
     #[derive(Debug, Clone)]
     pub struct MockSource {
@@ -635,13 +638,13 @@ mod tests {
             Box::new(MockSource {
                 id: "test_source",
                 tj: tilejson! { tiles: vec![], bounds: Bounds::from_str("-110.0,20.0,-120.0,80.0").unwrap() },
-                data: Vec::default()
+                data: Vec::default(),
             }),
             Box::new(MockSource {
                 id: "test_source2",
                 tj: tilejson! { tiles: vec![], bounds: Bounds::from_str("-130.0,40.0,-170.0,10.0").unwrap() },
-                data: Vec::default()
-            })
+                data: Vec::default(),
+            }),
         ]])
     }
 
@@ -650,16 +653,16 @@ mod tests {
         TileSources::new(vec![vec![Box::new(MockSource {
             id: "test_source",
             tj: tilejson! { tiles: vec![], bounds: Bounds::from_str("-120.0,30.0,-110.0,40.0").unwrap() },
-            data: Vec::default()
+            data: Vec::default(),
         })]])
     }
-    
+
     #[fixture]
     fn source_wo_bounds() -> TileSources {
         TileSources::new(vec![vec![Box::new(MockSource {
             id: "test_source",
             tj: tilejson! { tiles: vec![] },
-            data: Vec::default()
+            data: Vec::default(),
         })]])
     }
 
@@ -667,7 +670,11 @@ mod tests {
     #[case::one_source(one_source(), "test_source", vec![Bounds::from_str("-120.0,30.0,-110.0,40.0").unwrap()])]
     #[case::many_sources(many_sources(), "test_source,test_source2", vec![Bounds::MAX_TILED])]
     #[case::source_wo_bounds(source_wo_bounds(), "test_source", vec![Bounds::MAX_TILED])]
-    fn test_default_bounds(#[case] src: TileSources, #[case] ids: &str, #[case] expected: Vec<Bounds>) {
+    fn test_default_bounds(
+        #[case] src: TileSources,
+        #[case] ids: &str,
+        #[case] expected: Vec<Bounds>,
+    ) {
         let dts = DynTileSource::new(&src, ids, None, "", None, None, None, None).unwrap();
 
         assert_eq!(default_bounds(&dts), expected);

--- a/tests/expected/martin-cp/no-bbox_metadata.txt
+++ b/tests/expected/martin-cp/no-bbox_metadata.txt
@@ -1,0 +1,25 @@
+[INFO ] cp_no-bbox has an unrecognized metadata value foo={"bar":"foo"}
+id: cp_no-bbox
+tile_info:
+  format: mvt
+  encoding: gzip
+tilejson:
+  tilejson: 3.0.0
+  tiles: []
+  vector_layers:
+  - id: table_source
+    fields:
+      gid: int4
+  bounds:
+  - -2.0
+  - -1.0
+  - 142.84131509869133
+  - 45.0
+  maxzoom: 6
+  minzoom: 0
+  name: table_source
+  foo: '{"bar":"foo"}'
+  format: pbf
+  generator: martin-cp v0.0.0
+agg_tiles_hash: 7323D1D8A07A7176998822DB65E08567
+

--- a/tests/expected/martin-cp/no-bbox_save_config.yaml
+++ b/tests/expected/martin-cp/no-bbox_save_config.yaml
@@ -1,0 +1,275 @@
+postgres:
+  auto_publish: true
+  tables:
+    .-Points-----------quote:
+      schema: '"Quotes'' \ \'' \" and Space.Dot.'
+      table: . Points" \ \' \" 'quote
+      srid: 4326
+      geometry_column: . ' \ \' \" "Geom"
+      bounds:
+      - -170.94984639 # truncated to 10 digits
+      - -84.2002558073 # truncated to 10 digits
+      - 167.7089285828 # truncated to 10 digits
+      - 74.2357328475 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        ''' id ''': int4
+        '.namE ': text
+    MixPoints:
+      schema: MixedCase
+      table: MixPoints
+      srid: 4326
+      geometry_column: Geom
+      bounds:
+      - -170.94984639 # truncated to 10 digits
+      - -84.2002558073 # truncated to 10 digits
+      - 167.7089285828 # truncated to 10 digits
+      - 74.2357328475 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        Gid: int4
+        TABLE: text
+    antimeridian:
+      schema: public
+      table: antimeridian
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -182.0
+      - 51.0
+      - -160.0
+      - 62.0
+      geometry_type: GEOMETRY
+      properties:
+        gid: int4
+    auto_table:
+      schema: autodetect
+      table: auto_table
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -166.8710712623 # truncated to 10 digits
+      - -53.4474724911 # truncated to 10 digits
+      - 168.1406122036 # truncated to 10 digits
+      - 84.2241186147 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        feat_id: int4
+        gid: int4
+    bigint_table:
+      schema: autodetect
+      table: bigint_table
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -174.8947556456 # truncated to 10 digits
+      - -77.2579745396 # truncated to 10 digits
+      - 174.7275322451 # truncated to 10 digits
+      - 73.8078595059 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        big_feat_id: int8
+        id: int4
+    points1:
+      schema: public
+      table: points1
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -179.2731397013 # truncated to 10 digits
+      - -67.5251856326 # truncated to 10 digits
+      - 162.6011719373 # truncated to 10 digits
+      - 84.9309209512 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    points1_vw:
+      schema: public
+      table: points1_vw
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -179.2731397013 # truncated to 10 digits
+      - -67.5251856326 # truncated to 10 digits
+      - 162.6011719373 # truncated to 10 digits
+      - 84.9309209512 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    points2:
+      schema: public
+      table: points2
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -174.0507507353 # truncated to 10 digits
+      - -80.4617715784 # truncated to 10 digits
+      - 179.1118718108 # truncated to 10 digits
+      - 81.1306876416 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    points3857:
+      schema: public
+      table: points3857
+      srid: 3857
+      geometry_column: geom
+      bounds:
+      - -161.4059077755 # truncated to 10 digits
+      - -81.507270216 # truncated to 10 digits
+      - 172.5154912676 # truncated to 10 digits
+      - 84.2440187164 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    table_name_existing_two_schemas:
+      schema: schema_a
+      table: table_name_existing_two_schemas
+      srid: 4326
+      geometry_column: a_geom
+      bounds:
+      - 142.8409440943 # truncated to 10 digits
+      - 11.926741846 # truncated to 10 digits
+      - 142.8414336 # truncated to 10 digits
+      - 11.9273703485 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        a_id: int4
+        a_name: text
+    table_name_existing_two_schemas.1:
+      schema: schema_b
+      table: table_name_existing_two_schemas
+      srid: 4326
+      geometry_column: b_geom
+      bounds:
+      - 10.0
+      - 10.0
+      - 40.0
+      - 40.0
+      geometry_type: POLYGON
+      properties:
+        b_id: int4
+        b_info: text
+    table_source:
+      schema: public
+      table: table_source
+      srid: 4326
+      geometry_column: geom
+      bounds:
+      - -2.0
+      - -1.0
+      - 142.8413150986 # truncated to 10 digits
+      - 45.0
+      geometry_type: GEOMETRY
+      properties:
+        gid: int4
+    table_source_geog:
+      schema: public
+      table: table_source_geog
+      srid: 4326
+      geometry_column: geog
+      bounds:
+      - -2.0
+      - 0.0
+      - 142.8413150986 # truncated to 10 digits
+      - 45.0
+      geometry_type: Geometry
+      properties:
+        gid: int4
+    table_source_multiple_geom:
+      schema: public
+      table: table_source_multiple_geom
+      srid: 4326
+      geometry_column: geom1
+      bounds:
+      - -136.620760497 # truncated to 10 digits
+      - -78.3350299285 # truncated to 10 digits
+      - 176.5629774349 # truncated to 10 digits
+      - 75.7873106595 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    table_source_multiple_geom.1:
+      schema: public
+      table: table_source_multiple_geom
+      srid: 4326
+      geometry_column: geom2
+      bounds:
+      - -136.620760497 # truncated to 10 digits
+      - -78.3350299285 # truncated to 10 digits
+      - 176.5629774349 # truncated to 10 digits
+      - 75.7873106595 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        gid: int4
+    view_name_existing_two_schemas:
+      schema: schema_a
+      table: view_name_existing_two_schemas
+      srid: 4326
+      geometry_column: a_geom
+      bounds:
+      - 142.8409440943 # truncated to 10 digits
+      - 11.926741846 # truncated to 10 digits
+      - 142.8414336 # truncated to 10 digits
+      - 11.9273703485 # truncated to 10 digits
+      geometry_type: POINT
+      properties:
+        a_id: int4
+        a_name: text
+    view_name_existing_two_schemas.1:
+      schema: schema_b
+      table: view_name_existing_two_schemas
+      srid: 4326
+      geometry_column: b_geom
+      bounds:
+      - 10.0
+      - 10.0
+      - 40.0
+      - 40.0
+      geometry_type: POLYGON
+      properties:
+        b_id: int4
+        b_info: text
+  functions:
+    -function.withweired---_-characters:
+      schema: public
+      function: '"function.withweired$*;_ characters'
+    function_Mixed_Name:
+      schema: MixedCase
+      function: function_Mixed_Name
+    function_null:
+      schema: public
+      function: function_null
+    function_null_row:
+      schema: public
+      function: function_null_row
+    function_null_row2:
+      schema: public
+      function: function_null_row2
+    function_zoom_xy:
+      schema: public
+      function: function_zoom_xy
+    function_zxy:
+      schema: public
+      function: function_zxy
+    function_zxy2:
+      schema: public
+      function: function_zxy2
+    function_zxy_query:
+      schema: public
+      function: function_zxy_query
+    function_zxy_query_jsonb:
+      schema: public
+      function: function_zxy_query_jsonb
+    function_zxy_query_test:
+      schema: public
+      function: function_zxy_query_test
+    function_zxy_row:
+      schema: public
+      function: function_zxy_row
+    function_zxy_row_key:
+      schema: public
+      function: function_zxy_row_key
+mbtiles:
+  sources:
+    world_cities: ./tests/fixtures/mbtiles/world_cities.mbtiles

--- a/tests/expected/martin-cp/no-bbox_summary.txt
+++ b/tests/expected/martin-cp/no-bbox_summary.txt
@@ -1,0 +1,14 @@
+MBTiles file summary for tests/mbtiles_temp_files/cp_no-bbox.mbtiles
+Schema: flat
+Page size: 512B
+
+ Zoom |   Count   | Smallest  |  Largest  |  Average  | Bounding Box
+    0 |         1 |      643B |      643B |      643B | -180,-85,180,85
+    1 |         4 |      338B |      705B |      439B | -180,-85,180,85
+    2 |         5 |      123B |      690B |      356B | -90,-67,180,67
+    3 |         8 |       75B |      727B |      245B | -45,-41,180,67
+    4 |        13 |       75B |      684B |      225B | -23,-22,158,56
+    5 |        27 |       75B |      659B |      195B | -11,-11,146,49
+    6 |        69 |       75B |      633B |      155B | -6,-6,146,45
+  all |       127 |       75B |      727B |      197B | -180,-85,180,85
+

--- a/tests/expected/martin-cp/no-bbox_validate.txt
+++ b/tests/expected/martin-cp/no-bbox_validate.txt
@@ -1,0 +1,3 @@
+[INFO ] Quick integrity check passed for tests/mbtiles_temp_files/cp_no-bbox.mbtiles
+[INFO ] All values in the `tiles` table/view are valid for tests/mbtiles_temp_files/cp_no-bbox.mbtiles
+[INFO ] Skipping per-tile hash validation because this is a flat MBTiles file

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -604,6 +604,11 @@ if [[ "$MARTIN_CP_BIN" != "-" ]]; then
       --min-zoom 0 --max-zoom 6 "--bbox=-2,-1,142.84,45" \
       --set-meta "generator=martin-cp v0.0.0" --set-meta "name=composite" --set-meta=center=0,0,0
 
+  test_martin_cp "no-bbox" ./tests/fixtures/mbtiles/world_cities.mbtiles \
+          --source table_source --mbtiles-type flat --concurrency 3 \
+          --min-zoom 0 --max-zoom 6 \
+          --set-meta "generator=martin-cp v0.0.0"
+
   unset DATABASE_URL
 
   test_martin_cp "no-source" ./tests/fixtures/mbtiles/world_cities.mbtiles \


### PR DESCRIPTION
#2212

- Adds more dynamic default bounds (bbox) to `martin-cp`
- If no bounds passed as args, and a single source exists with defined bounds, use them. Fallback to global as previously done.