### PR TITLE
docs(dev-guide): Add some note about alternative Docker hosts/runtimes

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -4,7 +4,7 @@
 
 Install [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/)
 
-Note that alternative container hosts/runtimes should also work, but you might need some tweak such as setting `DOCKER_HOST` envvar in order to let [the testcontainers module](https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution) detect your container. For example, [Colima uses a different socket location](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running).
+Note that alternative container hosts/runtimes should also work, but you might need some tweaks such as setting `DOCKER_HOST` envvar in order to let [the testcontainers module](https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution) detect your container. For example, [Colima uses a different socket location](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running).
 
 ## just
 

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -4,6 +4,8 @@
 
 Install [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/)
 
+Note that alternative container hosts/runtimes should also work, but you might need some tweak such as setting `DOCKER_HOST` envvar in order to let [the testcontainers module](https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution) detect your container. For example, [Colima uses a different socket location](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running).
+
 ## just
 
 Install [Just](https://github.com/casey/just#readme):

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -4,7 +4,9 @@
 
 Install [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/)
 
-Note that alternative container hosts/runtimes should also work, but you might need some tweaks such as setting `DOCKER_HOST` envvar in order to let [the testcontainers module](https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution) detect your container. For example, [Colima uses a different socket location](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running).
+> [!TIP]
+> Alternative container hosts/runtimes work, but you need to set the `DOCKER_HOST` environment variable to let [the testcontainers module](https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution) detect your container.
+> For example, [Colima uses a different socket location](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running).
 
 ## just
 


### PR DESCRIPTION
I get this error when I tried to run `cargo test`, and found this is because I use an alternative Docker host (Colima), which locates its docker socket on a different location (`${HOME}/.colima/default/docker.sock`).

```
failures:

---- tiles::postgres::pool::tests::parse_version stdout ----

thread 'tiles::postgres::pool::tests::parse_version' (107274) panicked at martin-core/src/tiles/postgres/pool.rs:239:14:
container launched: Client(Init(SocketNotFoundError("/var/run/docker.sock")))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This can be solved by several ways according to the testcontainers crate's documentation.

https://docs.rs/testcontainers/latest/testcontainers/index.html#docker-host-resolution

This pull request adds a few notes about this. I'm not sure if this is a common issue or not, so please feel free to remove or modify any part that you feel is a bit too specific!