### PR TITLE
feat(config): warn! on bad source paths instead of hard fail

### DIFF
--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -497,3 +497,71 @@ pub fn copy_unrecognized_keys_from_config(
 ) {
     result.extend(unrecognized.keys().map(|k| format!("{prefix}{k}")));
 }
+
+#[cfg(all(test, feature = "mbtiles"))]
+mod mbtiles_tests {
+    use martin_core::config::IdResolver;
+
+    use super::*;
+    use crate::config::file::tiles::mbtiles::MbtConfig;
+
+    #[tokio::test]
+    async fn test_invalid_path_warns_instead_of_failing() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let invalid_path = PathBuf::from("/nonexistent/path/");
+        let invalid_source = PathBuf::from("/nonexistent/path/to/file.mbtiles");
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "test_source".to_string(),
+            FileConfigSrc::Path(invalid_source.clone()),
+        );
+        let mut config = FileConfigEnum::<MbtConfig>::Config(FileConfig {
+            paths: OptOneMany::One(invalid_path.clone()),
+            sources: Some(sources),
+            custom: MbtConfig::default(),
+        });
+
+        let idr = IdResolver::new(&[]);
+        let result = resolve_files(&mut config, &idr, &["mbtiles"]).await;
+
+        // Should succeed despite invalid paths
+        assert!(result.is_ok());
+        let sources = result.unwrap();
+        assert_eq!(sources.len(), 0);
+    }
+}
+
+#[cfg(all(test, feature = "pmtiles"))]
+mod pmtiles_tests {
+    use martin_core::config::IdResolver;
+
+    use super::*;
+    use crate::config::file::tiles::pmtiles::PmtConfig;
+
+    #[tokio::test]
+    async fn test_invalid_path_warns_instead_of_failing() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let invalid_path = PathBuf::from("/nonexistent/path/");
+        let invalid_source = PathBuf::from("/nonexistent/path/to/file.pmtiles");
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "test_source".to_string(),
+            FileConfigSrc::Path(invalid_source.clone()),
+        );
+        let mut config = FileConfigEnum::<PmtConfig>::Config(FileConfig {
+            paths: OptOneMany::One(invalid_path.clone()),
+            sources: Some(sources),
+            custom: PmtConfig::default(),
+        });
+
+        let idr = IdResolver::new(&[]);
+        let result = resolve_files(&mut config, &idr, &["pmtiles"]).await;
+
+        // Should succeed despite invalid paths
+        assert!(result.is_ok());
+        let sources = result.unwrap();
+        assert_eq!(sources.len(), 0);
+    }
+}

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -409,7 +409,7 @@ async fn resolve_int<T: TileSourceConfiguration>(
             &cfg.custom,
             idr,
             extension,
-            path,
+            path.clone(),
             &mut files,
             &mut directories,
             &mut configs,
@@ -417,7 +417,10 @@ async fn resolve_int<T: TileSourceConfiguration>(
         .await
         {
             Ok(mut sources) => results.append(&mut sources),
-            Err(e) => warn!("Failed to resolve sources from path: {e}"),
+            Err(e) => warn!(
+                "Failed to resolve sources from path {}: {e}",
+                path.display(),
+            ),
         }
     }
 

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -274,6 +274,111 @@ pub async fn resolve_files<T: TileSourceConfiguration>(
 }
 
 #[cfg(feature = "_tiles")]
+async fn resolve_one_source_int<T: TileSourceConfiguration>(
+    custom: &T,
+    idr: &IdResolver,
+    id: &String,
+    source: FileConfigSrc,
+    files: &mut HashSet<PathBuf>,
+    configs: &mut BTreeMap<String, FileConfigSrc>,
+) -> MartinResult<Vec<BoxedSource>> {
+    let mut results = Vec::new();
+
+    if let Some(url) = parse_url(T::parse_urls(), source.get_path())? {
+        let dup = !files.insert(source.get_path().clone());
+        let dup = if dup { "duplicate " } else { "" };
+        let id = idr.resolve(&id, url.to_string());
+        configs.insert(id.clone(), source);
+        results.push(custom.new_sources_url(id.clone(), url.clone()).await?);
+        info!("Configured {dup}source {id} from {}", sanitize_url(&url));
+    } else {
+        let can = source.abs_path()?;
+        if !can.is_file() {
+            log::warn!("The file: {} does not exist", can.display());
+        }
+
+        let dup = !files.insert(can.clone());
+        let dup = if dup { "duplicate " } else { "" };
+        let id = idr.resolve(&id, can.to_string_lossy().to_string());
+        info!("Configured {dup}source {id} from {}", can.display());
+        configs.insert(id.clone(), source.clone());
+        results.push(custom.new_sources(id, source.into_path()).await?);
+    }
+
+    Ok(results)
+}
+
+#[cfg(feature = "_tiles")]
+async fn resolve_one_path_int<T: TileSourceConfiguration>(
+    custom: &T,
+    idr: &IdResolver,
+    extension: &[&str],
+    path: PathBuf,
+    files: &mut HashSet<PathBuf>,
+    directories: &mut Vec<PathBuf>,
+    configs: &mut BTreeMap<String, FileConfigSrc>,
+) -> MartinResult<Vec<BoxedSource>> {
+    let mut results = Vec::new();
+
+    if let Some(url) = parse_url(T::parse_urls(), &path)? {
+        let target_ext = extension.iter().find(|&e| url.to_string().ends_with(e));
+        let id = if let Some(ext) = target_ext {
+            url.path_segments()
+                .and_then(Iterator::last)
+                .and_then(|s| {
+                    // Strip extension and trailing dot, or keep the original string
+                    s.strip_suffix(ext)
+                        .and_then(|s| s.strip_suffix('.'))
+                        .or(Some(s))
+                })
+                .unwrap_or("web_source")
+        } else {
+            "web_source"
+        };
+
+        let id = idr.resolve(id, url.to_string());
+        configs.insert(id.clone(), FileConfigSrc::Path(path));
+        results.push(custom.new_sources_url(id.clone(), url.clone()).await?);
+        info!("Configured source {id} from URL {}", sanitize_url(&url));
+    } else {
+        let is_dir = path.is_dir();
+        let dir_files = if is_dir {
+            // directories will be kept in the config just in case there are new files
+            directories.push(path.clone());
+            collect_files_with_extension(&path, extension)?
+        } else if path.is_file() {
+            vec![path]
+        } else {
+            return Err(MartinError::from(ConfigFileError::InvalidFilePath(
+                path.canonicalize().unwrap_or(path),
+            )));
+        };
+        for path in dir_files {
+            let can = path
+                .canonicalize()
+                .map_err(|e| ConfigFileError::IoError(e, path.clone()))?;
+            if files.contains(&can) {
+                if !is_dir {
+                    warn!("Ignoring duplicate MBTiles path: {}", can.display());
+                }
+                continue;
+            }
+            let id = path.file_stem().map_or_else(
+                || "_unknown".to_string(),
+                |s| s.to_string_lossy().to_string(),
+            );
+            let id = idr.resolve(&id, can.to_string_lossy().to_string());
+            info!("Configured source {id} from {}", can.display());
+            files.insert(can);
+            configs.insert(id.clone(), FileConfigSrc::Path(path.clone()));
+            results.push(custom.new_sources(id, path).await?);
+        }
+    }
+
+    Ok(results)
+}
+
+#[cfg(feature = "_tiles")]
 async fn resolve_int<T: TileSourceConfiguration>(
     config: &mut FileConfigEnum<T>,
     idr: &IdResolver,
@@ -290,83 +395,29 @@ async fn resolve_int<T: TileSourceConfiguration>(
 
     if let Some(sources) = cfg.sources {
         for (id, source) in sources {
-            if let Some(url) = parse_url(T::parse_urls(), source.get_path())? {
-                let dup = !files.insert(source.get_path().clone());
-                let dup = if dup { "duplicate " } else { "" };
-                let id = idr.resolve(&id, url.to_string());
-                configs.insert(id.clone(), source);
-                results.push(cfg.custom.new_sources_url(id.clone(), url.clone()).await?);
-                info!("Configured {dup}source {id} from {}", sanitize_url(&url));
-            } else {
-                let can = source.abs_path()?;
-                if !can.is_file() {
-                    log::warn!("The file: {} does not exist", can.display());
-                }
-
-                let dup = !files.insert(can.clone());
-                let dup = if dup { "duplicate " } else { "" };
-                let id = idr.resolve(&id, can.to_string_lossy().to_string());
-                info!("Configured {dup}source {id} from {}", can.display());
-                configs.insert(id.clone(), source.clone());
-                results.push(cfg.custom.new_sources(id, source.into_path()).await?);
+            match resolve_one_source_int(&cfg.custom, idr, &id, source, &mut files, &mut configs)
+                .await
+            {
+                Ok(mut sources) => results.append(&mut sources),
+                Err(e) => warn!("Failed to resolve source {}: {}", id, e),
             }
         }
     }
 
     for path in cfg.paths {
-        if let Some(url) = parse_url(T::parse_urls(), &path)? {
-            let target_ext = extension.iter().find(|&e| url.to_string().ends_with(e));
-            let id = if let Some(ext) = target_ext {
-                url.path_segments()
-                    .and_then(Iterator::last)
-                    .and_then(|s| {
-                        // Strip extension and trailing dot, or keep the original string
-                        s.strip_suffix(ext)
-                            .and_then(|s| s.strip_suffix('.'))
-                            .or(Some(s))
-                    })
-                    .unwrap_or("web_source")
-            } else {
-                "web_source"
-            };
-
-            let id = idr.resolve(id, url.to_string());
-            configs.insert(id.clone(), FileConfigSrc::Path(path));
-            results.push(cfg.custom.new_sources_url(id.clone(), url.clone()).await?);
-            info!("Configured source {id} from URL {}", sanitize_url(&url));
-        } else {
-            let is_dir = path.is_dir();
-            let dir_files = if is_dir {
-                // directories will be kept in the config just in case there are new files
-                directories.push(path.clone());
-                collect_files_with_extension(&path, extension)?
-            } else if path.is_file() {
-                vec![path]
-            } else {
-                return Err(MartinError::from(ConfigFileError::InvalidFilePath(
-                    path.canonicalize().unwrap_or(path),
-                )));
-            };
-            for path in dir_files {
-                let can = path
-                    .canonicalize()
-                    .map_err(|e| ConfigFileError::IoError(e, path.clone()))?;
-                if files.contains(&can) {
-                    if !is_dir {
-                        warn!("Ignoring duplicate MBTiles path: {}", can.display());
-                    }
-                    continue;
-                }
-                let id = path.file_stem().map_or_else(
-                    || "_unknown".to_string(),
-                    |s| s.to_string_lossy().to_string(),
-                );
-                let id = idr.resolve(&id, can.to_string_lossy().to_string());
-                info!("Configured source {id} from {}", can.display());
-                files.insert(can);
-                configs.insert(id.clone(), FileConfigSrc::Path(path.clone()));
-                results.push(cfg.custom.new_sources(id, path).await?);
-            }
+        match resolve_one_path_int(
+            &cfg.custom,
+            idr,
+            extension,
+            path,
+            &mut files,
+            &mut directories,
+            &mut configs,
+        )
+        .await
+        {
+            Ok(mut sources) => results.append(&mut sources),
+            Err(e) => warn!("Failed to resolve sources from path: {}", e),
         }
     }
 

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -277,7 +277,7 @@ pub async fn resolve_files<T: TileSourceConfiguration>(
 async fn resolve_one_source_int<T: TileSourceConfiguration>(
     custom: &T,
     idr: &IdResolver,
-    id: &String,
+    id: &str,
     source: FileConfigSrc,
     files: &mut HashSet<PathBuf>,
     configs: &mut BTreeMap<String, FileConfigSrc>,
@@ -287,7 +287,7 @@ async fn resolve_one_source_int<T: TileSourceConfiguration>(
     if let Some(url) = parse_url(T::parse_urls(), source.get_path())? {
         let dup = !files.insert(source.get_path().clone());
         let dup = if dup { "duplicate " } else { "" };
-        let id = idr.resolve(&id, url.to_string());
+        let id = idr.resolve(id, url.to_string());
         configs.insert(id.clone(), source);
         results.push(custom.new_sources_url(id.clone(), url.clone()).await?);
         info!("Configured {dup}source {id} from {}", sanitize_url(&url));
@@ -299,7 +299,7 @@ async fn resolve_one_source_int<T: TileSourceConfiguration>(
 
         let dup = !files.insert(can.clone());
         let dup = if dup { "duplicate " } else { "" };
-        let id = idr.resolve(&id, can.to_string_lossy().to_string());
+        let id = idr.resolve(id, can.to_string_lossy().to_string());
         info!("Configured {dup}source {id} from {}", can.display());
         configs.insert(id.clone(), source.clone());
         results.push(custom.new_sources(id, source.into_path()).await?);
@@ -399,7 +399,7 @@ async fn resolve_int<T: TileSourceConfiguration>(
                 .await
             {
                 Ok(mut sources) => results.append(&mut sources),
-                Err(e) => warn!("Failed to resolve source {}: {}", id, e),
+                Err(e) => warn!("Failed to resolve source {id}: {e}"),
             }
         }
     }
@@ -417,7 +417,7 @@ async fn resolve_int<T: TileSourceConfiguration>(
         .await
         {
             Ok(mut sources) => results.append(&mut sources),
-            Err(e) => warn!("Failed to resolve sources from path: {}", e),
+            Err(e) => warn!("Failed to resolve sources from path: {e}"),
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/maplibre/martin/issues/2395

`warn!()`s on an `Error` result from per-file or per-path file resolution during Martin startup, instead of propagating the error up the stack. Allows for unknown file paths to be ignored, instead of failing startup altogether.

Testing:

- Added simple unit tests to catch regression.