### PR TITLE
fix: filter available tables result when auto publish false

### DIFF
--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -134,13 +134,13 @@ impl PostgresAutoDiscoveryBuilder {
     pub async fn instantiate_tables(&self) -> PostgresResult<(Vec<BoxedSource>, TableInfoSources)> {
         // FIXME: this function has gotten too long due to the new formatting rules, need to be refactored
 
-        let filter_config_tables: Option<Vec<(&str, &str)>> = if self.auto_tables.is_none() {
+        let restrict_to_tables = if self.auto_tables.is_none() {
             Some(self.configured_tables())
         } else {
             None
         };
 
-        let mut db_tables_info = query_available_tables(&self.pool, filter_config_tables).await?;
+        let mut db_tables_info = query_available_tables(&self.pool, restrict_to_tables).await?;
 
         // Match configured sources with the discovered ones and add them to the pending list.
         let mut used = HashSet::<(&str, &str, &str)>::new();
@@ -343,11 +343,11 @@ impl PostgresAutoDiscoveryBuilder {
         sources.push(Box::new(source));
     }
 
-    fn configured_tables(&self) -> Vec<(&str, &str)> {
+    fn configured_tables(&self) -> HashSet<(&str, &str)> {
         self.tables
             .values()
             .map(|t| (t.schema.as_str(), t.table.as_str()))
-            .collect::<Vec<(&str, &str)>>()
+            .collect()
     }
 }
 

--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -343,10 +343,10 @@ impl PostgresAutoDiscoveryBuilder {
         sources.push(Box::new(source));
     }
 
-    fn configured_tables(&self) -> HashSet<(&str, &str)> {
+    fn configured_tables(&self) -> HashSet<(String, String)> {
         self.tables
             .values()
-            .map(|t| (t.schema.as_str(), t.table.as_str()))
+            .map(|t| (t.schema.to_lowercase(), t.table.to_lowercase()))
             .collect()
     }
 }

--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -134,7 +134,7 @@ impl PostgresAutoDiscoveryBuilder {
     pub async fn instantiate_tables(&self) -> PostgresResult<(Vec<BoxedSource>, TableInfoSources)> {
         // FIXME: this function has gotten too long due to the new formatting rules, need to be refactored
 
-        let filter_config_tables: Option<Vec<&str>> = if self.auto_tables.is_none() {
+        let filter_config_tables: Option<Vec<(&str, &str)>> = if self.auto_tables.is_none() {
             Some(self.configured_tables())
         } else {
             None
@@ -343,8 +343,11 @@ impl PostgresAutoDiscoveryBuilder {
         sources.push(Box::new(source));
     }
 
-    fn configured_tables(&self) -> Vec<&str> {
-        self.tables.values().map(|t| t.table.as_str()).collect::<Vec<&str>>()
+    fn configured_tables(&self) -> Vec<(&str, &str)> {
+        self.tables
+            .values()
+            .map(|t| (t.schema.as_str(), t.table.as_str()))
+            .collect::<Vec<(&str, &str)>>()
     }
 }
 

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -42,8 +42,9 @@ pub async fn query_available_tables(
         let schema: String = row.get("schema");
         let table: String = row.get("name");
 
-        // If a list of configured tables was provided to the function, because auto_publish set
-        // to false, skip processing the tables that are not in the list.
+        // Within the config, if auto_publish is false or omitted, the list of schema and table
+        // names set explicitly under the tables key is provided to the function. As the query above
+        // may return more tables than explicitly defined, these are filtered out below.
         if let Some(ref table_names) = restrict_to_tables
             && !table_names.contains(&(schema.to_lowercase(), table.to_lowercase()))
         {

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -28,7 +28,7 @@ const DEFAULT_CLIP_GEOM: bool = true;
 /// The reported tables are filtered by the `restrict_to_tables` parameter.
 pub async fn query_available_tables(
     pool: &PostgresPool,
-    restrict_to_tables: Option<HashSet<(&str, &str)>>,
+    restrict_to_tables: Option<HashSet<(String, String)>>,
 ) -> PostgresResult<SqlTableInfoMapMapMap> {
     let rows = pool
         .get()
@@ -45,7 +45,7 @@ pub async fn query_available_tables(
         // If a list of configured tables was provided to the function, because auto_publish set
         // to false, skip processing the tables that are not in the list.
         if let Some(ref table_names) = restrict_to_tables
-            && !table_names.contains(&(schema.as_str(), table.as_str())) {
+            && !table_names.contains(&(schema.to_lowercase(), table.to_lowercase())) {
                 continue;
             }
 

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -24,7 +24,10 @@ const DEFAULT_BUFFER: u32 = 64;
 const DEFAULT_CLIP_GEOM: bool = true;
 
 /// Queries the database for available tables with geometry columns.
-pub async fn query_available_tables(pool: &PostgresPool, filtered_tables: Option<Vec<(&str, &str)>>) -> PostgresResult<SqlTableInfoMapMapMap> {
+pub async fn query_available_tables(
+    pool: &PostgresPool,
+    filtered_tables: Option<Vec<(&str, &str)>>,
+) -> PostgresResult<SqlTableInfoMapMapMap> {
     let rows = pool
         .get()
         .await?

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -45,9 +45,10 @@ pub async fn query_available_tables(
         // If a list of configured tables was provided to the function, because auto_publish set
         // to false, skip processing the tables that are not in the list.
         if let Some(ref table_names) = restrict_to_tables
-            && !table_names.contains(&(schema.to_lowercase(), table.to_lowercase())) {
-                continue;
-            }
+            && !table_names.contains(&(schema.to_lowercase(), table.to_lowercase()))
+        {
+            continue;
+        }
 
         let tilejson = if let Some(text) = row.get("description") {
             match serde_json::from_str::<Value>(text) {

--- a/martin/src/config/file/tiles/postgres/resolver/scripts/query_available_tables.sql
+++ b/martin/src/config/file/tiles/postgres/resolver/scripts/query_available_tables.sql
@@ -114,35 +114,30 @@ descriptions AS (
     INNER JOIN pg_namespace ON cls.relnamespace = pg_namespace.oid
     LEFT JOIN pg_description ON cls.oid = pg_description.objoid AND pg_description.objsubid = 0
     WHERE cls.relkind = 'r' OR cls.relkind = 'v'
-)
+),
 
-SELECT
-    gc.schema,
-    gc.name,
-    gc.geom,
-    gc.srid,
-    gc.type,
-    gc.is_view,
-    gc.geom_idx,
-    dc.description,
-    coalesce(
+--
+available_tables AS (
+    SELECT
+        gc.schema, gc.name, gc.geom, gc.srid, gc.type, gc.is_view, gc.geom_idx, dc.description, coalesce (
         jsonb_object_agg(columns.column_name, columns.type_name)
         FILTER (
-            WHERE columns.column_name IS NOT null
-            AND columns.type_name != 'geometry'
-            AND columns.type_name != 'geography'
-        ),
-        '{}'::jsonb
-    ) AS properties
-FROM annotated_geo_columns AS gc
-LEFT JOIN columns
+        WHERE columns.column_name IS NOT null
+        AND columns.type_name != 'geometry'
+        AND columns.type_name != 'geography'
+        ), '{}'::jsonb
+        ) AS properties
+    FROM annotated_geo_columns AS gc
+        LEFT JOIN columns
     ON
         gc.schema = columns.table_schema
         AND gc.name = columns.table_name
         AND gc.geom != columns.column_name
-LEFT JOIN descriptions AS dc
-    ON
+        LEFT JOIN descriptions AS dc
+        ON
         gc.schema = dc.schema_name
         AND gc.name = dc.table_name
-GROUP BY -- noqa: AM06
-    gc.schema, gc.name, gc.geom, gc.srid, gc.type, gc.is_view, gc.geom_idx, dc.description;
+    GROUP BY -- noqa: AM06
+        gc.schema, gc.name, gc.geom, gc.srid, gc.type, gc.is_view, gc.geom_idx, dc.description
+)
+SELECT * FROM available_tables


### PR DESCRIPTION
Fix to `query_available_tables` allowing the function to take a list of configured tables if `auto_publish: false`.
Prevents configuration instantiation of tables that will not be used and addresses issue where WARN level logs appear for tables not used .