### PR TITLE
chore(ci): Tighten CI security a bit more by enforcing zizmore in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,9 +569,11 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
             export DATABASE_URL="postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ env.PGPORT }}/${{ env.PGDATABASE }}?sslmode=require"
           else
-            export DATABASE_URL="${{ steps.pg.outputs.connection-uri }}"
+            export DATABASE_URL="${STEPS_PG_OUTPUTS_CONNECTION_URI}"
           fi
           tests/test.sh
+        env:
+          STEPS_PG_OUTPUTS_CONNECTION_URI: ${{ steps.pg.outputs.connection-uri }}
       - name: Compare test output results (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
@@ -692,8 +694,10 @@ jobs:
         run: |
           set -x
           mkdir -p target/certs
-          docker cp ${{ job.services.postgres.id }}:/etc/ssl/certs/ssl-cert-snakeoil.pem target/certs/server.crt
-          docker cp ${{ job.services.postgres.id }}:/etc/ssl/private/ssl-cert-snakeoil.key target/certs/server.key
+          docker cp ${JOB_SERVICES_POSTGRES_ID}:/etc/ssl/certs/ssl-cert-snakeoil.pem target/certs/server.crt
+          docker cp ${JOB_SERVICES_POSTGRES_ID}:/etc/ssl/private/ssl-cert-snakeoil.key target/certs/server.key
+        env:
+          JOB_SERVICES_POSTGRES_ID: ${{ job.services.postgres.id }}
       - name: Download build artifact build-x86_64-unknown-linux-gnu
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target_releases/' }
@@ -845,7 +849,7 @@ jobs:
 
           # Extract Github release version only without the "martin-v" prefix from release tag names (martin-vX.Y.Z)
           # On non-release events, this still generates a config with not-a-release as the version to test the release process
-          MARTIN_VERSION=$(echo "${{ github.event.release.tag_name || 'not-a-release' }}" | sed -e 's/martin-v//')
+          MARTIN_VERSION=$(echo "$GITHUB_EVENT_RELEASE_TAG_NAME" | sed -e 's/martin-v//')
 
           mkdir -p target/homebrew
           cd target
@@ -857,6 +861,8 @@ jobs:
           linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name || 'not-a-release' }}
 
       - name: Save Homebrew Config
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
-    branches: [ main ]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-          with: {persist-credentials: false}
+          with: { persist-credentials: false }
         - name: Run zizmor
           uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
   audit:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,13 +3,27 @@ name: Security audit
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
+  push:
     branches: ["main"]
+  pull_request:
+    branches: ["**"]
 
 permissions:
   contents: read
 
 jobs:
+  zizmor:
+      runs-on: ubuntu-latest
+      permissions:
+        security-events: write
+        contents: read
+        actions: read
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+          with: {persist-credentials: false}
+        - name: Run zizmor
+          uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
   audit:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
The changes to `ci.yml` are to prevent "suspected template injections" (not exploitable).

I also added a zizmore action because now we can do this.