### PR TITLE
test(pmtiles): add pmtiles test in `martin-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bit-set",
+ "bytes",
  "dashmap",
  "deadpool-postgres",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ async-trait = "0.1"
 base64 = "0.22.1"
 bit-set = "0.8"
 brotli = ">=5, <9"
+bytes = "1"
 clap = { version = "4", features = ["derive", "unstable-markdown", "wrap_help"] }
 criterion = { version = "0.5", features = ["async_futures", "async_tokio", "html_reports"] }
 ctor = "0.5.0"

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -98,6 +98,7 @@ xxhash-rust.workspace = true
 [dev-dependencies]
 actix-web.workspace = true
 approx.workspace = true
+bytes.workspace = true
 env_logger.workspace = true
 futures.workspace = true
 insta = { workspace = true, features = ["json", "yaml"] }

--- a/martin-core/src/tiles/pmtiles/cache.rs
+++ b/martin-core/src/tiles/pmtiles/cache.rs
@@ -64,6 +64,14 @@ impl PmtCacheInstance {
         log::info!("Invalidated PMTiles directory cache for id={}", self.id);
     }
 
+    /// Syncs pending operations to make cache statistics consistent.
+    ///
+    /// This forces the cache to apply pending operations immediately,
+    /// ensuring that `entry_count()` and `weighted_size()` return accurate values.
+    pub async fn sync(&self) {
+        self.cache.0.run_pending_tasks().await;
+    }
+
     /// Returns the number of cached entries.
     #[must_use]
     pub fn entry_count(&self) -> u64 {

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -193,7 +193,6 @@ async fn missing_tile_returns_empty() {
     assert_eq!(tile.len(), 0, "Non-existent tile should return empty data");
 }
 
-#[tokio::test]
 #[rstest]
 #[case::coord_0_0_0(0, 0, 0)]
 #[case::coord_1_0_0(1, 0, 0)]
@@ -201,6 +200,7 @@ async fn missing_tile_returns_empty() {
 #[case::coord_2_0_0(2, 0, 0)]
 #[case::coord_2_3_2(2, 3, 2)]
 #[case::coord_3_7_7(3, 7, 7)]
+#[tokio::test]
 async fn retrieve_tiles_at_various_coordinates(#[case] z: u8, #[case] x: u32, #[case] y: u32) {
     let cache = test_cache_bytes(0);
     let source = create_source(

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -1,0 +1,440 @@
+#![cfg(feature = "pmtiles")]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use martin_core::tiles::Source;
+use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesError, PmtilesSource};
+use martin_tile_utils::{Encoding, Format, TileCoord};
+use object_store::local::LocalFileSystem;
+use rstest::rstest;
+
+const PNG_MAGIC: &[u8] = &[0x89, 0x50, 0x4E, 0x47];
+static NEXT_CACHE_ID: AtomicUsize = AtomicUsize::new(0);
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/pmtiles")
+}
+
+async fn create_source(filename: &str, id: &str, cache: PmtCacheInstance) -> PmtilesSource {
+    let path = fixtures_dir().join(filename);
+    let store = Box::new(LocalFileSystem::new());
+    let path = object_store::path::Path::from_filesystem_path(&path)
+        .expect("Failed to convert filesystem path");
+
+    PmtilesSource::new(cache, id.to_string(), store, path)
+        .await
+        .expect("Failed to create PMTiles source")
+}
+
+fn test_cache_bytes(size_mb: u64) -> PmtCacheInstance {
+    let cache_id = NEXT_CACHE_ID.fetch_add(1, Ordering::SeqCst);
+    let cache = PmtCache::new(size_mb);
+    PmtCacheInstance::new(cache_id, cache)
+}
+
+#[tokio::test]
+async fn png_source_metadata() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "png_source", cache).await;
+
+    assert_eq!(source.get_id(), "png_source");
+    assert_eq!(source.get_tile_info().format, Format::Png);
+    assert_eq!(source.get_tile_info().encoding, Encoding::Internal);
+}
+
+#[tokio::test]
+async fn raster_source_metadata() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "raster_source",
+        cache,
+    )
+    .await;
+
+    assert_eq!(source.get_id(), "raster_source");
+    assert_eq!(source.get_tile_info().format, Format::Png);
+}
+
+#[tokio::test]
+async fn nonexistent_file_returns_error() {
+    let cache = test_cache_bytes(0);
+    let store = Box::new(LocalFileSystem::new());
+    let path = object_store::path::Path::from("nonexistent/file.pmtiles");
+
+    let result = PmtilesSource::new(cache, "invalid".to_string(), store, path).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            PmtilesError::PmtError(_) | PmtilesError::PmtErrorWithCtx(_, _)
+        ),
+        "Expected PMTiles error, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn multiple_sources_have_unique_ids() {
+    let cache1 = test_cache_bytes(0);
+
+    let source1 = create_source("png.pmtiles", "source1", cache1.clone()).await;
+    let source2 = create_source("png.pmtiles", "source2", cache1.clone()).await;
+    let source3 = create_source("png.pmtiles", "source3", cache1.clone()).await;
+
+    assert_eq!(source1.get_id(), "source1");
+    assert_eq!(source2.get_id(), "source2");
+    assert_eq!(source3.get_id(), "source3");
+}
+
+#[tokio::test]
+async fn zero_size_cache() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "zero_cache", cache).await;
+
+    assert_eq!(source.get_id(), "zero_cache");
+}
+
+#[tokio::test]
+async fn png_tilejson() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "png_tilejson", cache).await;
+    let tilejson = source.get_tilejson();
+
+    assert!(tilejson.minzoom.is_some());
+    assert!(tilejson.maxzoom.is_some());
+    assert!(tilejson.bounds.is_some() || tilejson.center.is_some());
+}
+
+#[tokio::test]
+async fn raster_tilejson() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "raster_tilejson",
+        cache,
+    )
+    .await;
+    let tilejson = source.get_tilejson();
+
+    assert!(tilejson.bounds.is_some());
+    assert!(tilejson.center.is_some());
+    assert!(tilejson.minzoom.is_some());
+    assert!(tilejson.maxzoom.is_some());
+}
+
+#[tokio::test]
+async fn retrieve_valid_tile() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "tile_test",
+        cache,
+    )
+    .await;
+
+    let tile = source
+        .get_tile(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("Should get tile");
+
+    assert!(!tile.is_empty());
+    assert_eq!(&tile[0..4], PNG_MAGIC);
+}
+
+#[tokio::test]
+async fn missing_tile_returns_empty() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "missing_tile_test", cache).await;
+
+    let tile = source
+        .get_tile(
+            TileCoord {
+                z: 20,
+                x: 999_999,
+                y: 999_999,
+            },
+            None,
+        )
+        .await
+        .expect("Should succeed with empty tile");
+
+    assert!(tile.is_empty());
+}
+
+#[rstest]
+#[case(0, 0, 0)]
+#[case(1, 0, 0)]
+#[case(1, 1, 1)]
+#[case(2, 0, 0)]
+#[case(2, 3, 2)]
+#[case(3, 7, 7)]
+#[tokio::test]
+async fn retrieve_tiles_at_various_coordinates(#[case] z: u8, #[case] x: u32, #[case] y: u32) {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "coord_test",
+        cache,
+    )
+    .await;
+
+    let result = source.get_tile(TileCoord { z, x, y }, None).await;
+    assert!(result.is_ok(), "z={z}, x={x}, y={y}: {result:?}");
+}
+
+#[tokio::test]
+async fn repeated_tile_requests_return_same_data() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "consistency_test", cache).await;
+
+    let coord = TileCoord { z: 0, x: 0, y: 0 };
+
+    let tile1 = source.get_tile(coord, None).await.expect("First request");
+    let tile2 = source.get_tile(coord, None).await.expect("Second request");
+    let tile3 = source.get_tile(coord, None).await.expect("Third request");
+
+    assert_eq!(tile1, tile2);
+    assert_eq!(tile2, tile3);
+    assert!(!tile1.is_empty());
+}
+
+#[tokio::test]
+async fn retrieve_tile_at_max_zoom() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "max_zoom_test",
+        cache,
+    )
+    .await;
+
+    let tilejson = source.get_tilejson();
+    if let Some(max_zoom) = tilejson.maxzoom {
+        let result = source
+            .get_tile(
+                TileCoord {
+                    z: max_zoom,
+                    x: 0,
+                    y: 0,
+                },
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+}
+
+#[tokio::test]
+async fn tile_beyond_max_zoom_returns_empty() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "beyond_zoom_test", cache).await;
+
+    let tilejson = source.get_tilejson();
+    let max_zoom = tilejson.maxzoom.unwrap_or(0);
+
+    let tile = source
+        .get_tile(
+            TileCoord {
+                z: max_zoom + 5,
+                x: 0,
+                y: 0,
+            },
+            None,
+        )
+        .await
+        .expect("Should succeed");
+
+    assert!(tile.is_empty());
+}
+
+#[tokio::test]
+async fn tile_with_etag() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "etag_test",
+        cache,
+    )
+    .await;
+
+    let tile = source
+        .get_tile_with_etag(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("Should get tile with etag");
+
+    assert!(!tile.data.is_empty());
+    assert!(!tile.etag.is_empty());
+    assert_eq!(tile.info.format, Format::Png);
+}
+
+#[tokio::test]
+async fn repeated_requests_return_same_etag() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "etag_consistency_test", cache).await;
+
+    let coord = TileCoord { z: 0, x: 0, y: 0 };
+
+    let tile1 = source.get_tile_with_etag(coord, None).await.expect("First");
+    let tile2 = source
+        .get_tile_with_etag(coord, None)
+        .await
+        .expect("Second");
+    let tile3 = source.get_tile_with_etag(coord, None).await.expect("Third");
+
+    assert_eq!(tile1.etag, tile2.etag);
+    assert_eq!(tile2.etag, tile3.etag);
+    assert_eq!(tile1.data, tile2.data);
+}
+
+#[tokio::test]
+async fn empty_tile_has_etag() {
+    let cache = test_cache_bytes(0);
+    let source = create_source("png.pmtiles", "empty_etag_test", cache).await;
+
+    let tile = source
+        .get_tile_with_etag(
+            TileCoord {
+                z: 20,
+                x: 999_999,
+                y: 999_999,
+            },
+            None,
+        )
+        .await
+        .expect("Should get empty tile");
+
+    assert!(tile.data.is_empty());
+    assert!(!tile.etag.is_empty());
+}
+
+#[tokio::test]
+async fn different_tiles_have_different_etags() {
+    let cache = test_cache_bytes(0);
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "etag_diff_test",
+        cache,
+    )
+    .await;
+
+    let tile1 = source
+        .get_tile_with_etag(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("First tile");
+    let tile2 = source
+        .get_tile_with_etag(TileCoord { z: 1, x: 0, y: 0 }, None)
+        .await
+        .expect("Second tile");
+
+    if !tile1.data.is_empty() && !tile2.data.is_empty() {
+        assert_ne!(tile1.etag, tile2.etag);
+    }
+}
+
+#[tokio::test]
+async fn cache_entry_only_root_directory() {
+    // NOTE: PMTiles directory cache only stores "leaf directories".
+    // The root directory (which must fit in the first 16KB) is read once at source creation and not cached.
+    // Leaf directories are optional and only exist in very large tilesets where the root
+    // directory can't hold all tile entries.
+    // All available test files (including the 20MB cb_2018_us_zcta510_500k.pmtiles) have no Leaf Directories.
+    //
+    // This test validates the cache infrastructure (tracking, sharing, invalidation) works
+    // correctly, even though it won't actually populate with these test files.
+
+    let shared_cache = PmtCache::new(10 * 1024 * 1024);
+    let cache = PmtCacheInstance::new(0, shared_cache.clone());
+    assert_eq!(cache.entry_count(), 0, "Cache should start empty");
+
+    // Create first source
+    let source = create_source(
+        "stamen_toner__raster_CC-BY+ODbL_z3.pmtiles",
+        "cache_test0",
+        cache.clone(),
+    )
+    .await;
+
+    // Fetch tiles from first source
+    let tile1 = source
+        .get_tile(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("Should get tile from source1");
+    assert!(!tile1.is_empty(), "Tile should have data");
+
+    // Test files have no leaf directories, so cache remains empty
+    assert_eq!(
+        cache.entry_count(),
+        0,
+        "Test files have no leaf directories to cache"
+    );
+    assert_eq!(
+        cache.weighted_size(),
+        0,
+        "Cache not populated for files without leaf directories"
+    );
+}
+
+#[tokio::test]
+async fn shared_cache_with_unique_instance_ids_can_fetch_same_tile() {
+    let shared_cache = PmtCache::new(10 * 1024 * 1024);
+
+    let cache_id_1 = NEXT_CACHE_ID.fetch_add(1, Ordering::SeqCst);
+    let cache_id_2 = NEXT_CACHE_ID.fetch_add(1, Ordering::SeqCst);
+
+    let cache1 = PmtCacheInstance::new(cache_id_1, shared_cache.clone());
+    let cache2 = PmtCacheInstance::new(cache_id_2, shared_cache);
+
+    assert_ne!(cache1.id(), cache2.id());
+
+    let source1 = create_source("png.pmtiles", "shared1", cache1.clone()).await;
+    let source2 = create_source("png.pmtiles", "shared2", cache2.clone()).await;
+
+    let tile1 = source1
+        .get_tile(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("Source1 tile");
+    let tile2 = source2
+        .get_tile(TileCoord { z: 0, x: 0, y: 0 }, None)
+        .await
+        .expect("Source2 tile");
+
+    assert!(!tile1.is_empty());
+    assert!(!tile2.is_empty());
+    assert_eq!(tile1, tile2);
+}
+
+#[tokio::test]
+async fn cache_invalidation_clears_entries() {
+    let cache = test_cache_bytes(10 * 1024 * 1024);
+    create_source("png.pmtiles", "invalidation_test", cache.clone()).await;
+
+    cache.invalidate_all();
+
+    assert_eq!(cache.entry_count(), 0);
+    assert_eq!(cache.weighted_size(), 0);
+}
+
+#[tokio::test]
+async fn various_cache_sizes() {
+    let small_cache = test_cache_bytes(1024);
+    let medium_cache = test_cache_bytes(1024 * 1024);
+    let large_cache = test_cache_bytes(1024 * 1024 * 1024);
+
+    let small_id = small_cache.id();
+    let medium_id = medium_cache.id();
+    let large_id = large_cache.id();
+
+    assert_ne!(small_id, medium_id);
+    assert_ne!(small_id, large_id);
+    assert_ne!(medium_id, large_id);
+
+    create_source("png.pmtiles", "small", small_cache).await;
+    create_source("png.pmtiles", "medium", medium_cache).await;
+    create_source("png.pmtiles", "large", large_cache).await;
+}

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -31,9 +31,9 @@ async fn create_source(filename: &str, id: &str, cache: PmtCacheInstance) -> Pmt
         .expect("Failed to create PMTiles source")
 }
 
-fn test_cache_bytes(size_mb: u64) -> PmtCacheInstance {
+fn test_cache_bytes(size_bytes: u64) -> PmtCacheInstance {
     let cache_id = NEXT_CACHE_ID.fetch_add(1, Ordering::SeqCst);
-    let cache = PmtCache::new(size_mb);
+    let cache = PmtCache::new(size_bytes);
     PmtCacheInstance::new(cache_id, cache)
 }
 

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -48,28 +48,17 @@ fn test_cache_bytes(size_mb: u64) -> PmtCacheInstance {
 ///
 /// This creates a minimal valid directory structure for cache testing.
 fn create_test_directory() -> Result<pmtiles::Directory, pmtiles::PmtError> {
-    let mut buf = Vec::new();
-
-    // Write n_entries = 2
-    buf.push(2);
-
-    // Write tile_ids (delta encoded): first=1, second=2 (delta=1)
-    buf.push(1); // first tile_id = 1
-    buf.push(1); // delta = 1, so second tile_id = 2
-
-    // Write run_lengths = 1 for both entries
-    buf.push(1);
-    buf.push(1);
-
-    // Write lengths = 256 for both (0x80, 0x02 in varint for 256)
-    buf.extend_from_slice(&[0x80, 0x02]); // 256
-    buf.extend_from_slice(&[0x80, 0x02]); // 256
-
-    // Write offsets: first=1000, second=2000
-    // 1000 in varint = 0xE8, 0x07
-    buf.extend_from_slice(&[0xE8, 0x07]); // 1000
-    // 2000 in varint = 0xD0, 0x0F
-    buf.extend_from_slice(&[0xD0, 0x0F]); // 2000
+    let buf = vec![
+        2, // n_entries = 2
+        1, // first tile_id = 1
+        1, // delta = 1, so second tile_id = 2
+        1, // run_lengths = 1 for both entries
+        1, // run_lengths = 1 for both entries
+        0x80, 0x02, // lengths = 256 for both (0x80, 0x02 in varint for 256)
+        0x80, 0x02, // lengths = 256 for both (0x80, 0x02 in varint for 256)
+        0xE8, 0x07, // offsets: first=1000, second=2000
+        0xD0, 0x0F, // offsets: first=1000, second=2000
+    ];
 
     pmtiles::Directory::try_from(bytes::Bytes::from(buf))
 }

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -396,19 +396,17 @@ async fn different_tiles_have_different_etags() {
         .get_tile_with_etag(TileCoord { z: 0, x: 0, y: 0 }, None)
         .await
         .expect("First tile");
+    assert!(!tile1.data.is_empty(), "Tile 1 should have data");
     let tile2 = source
         .get_tile_with_etag(TileCoord { z: 1, x: 0, y: 0 }, None)
         .await
         .expect("Second tile");
+    assert!(!tile2.data.is_empty(), "Tile 2 should have data");
 
-    if !tile1.data.is_empty() && !tile2.data.is_empty() {
-        assert_ne!(
-            tile1.etag, tile2.etag,
-            "Different tiles should have different ETags"
-        );
-    } else {
-        println!("Skipping ETag comparison - one or both tiles are empty");
-    }
+    assert_ne!(
+        tile1.etag, tile2.etag,
+        "Different tiles should have different ETags"
+    );
 }
 
 #[tokio::test]

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -602,15 +602,17 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::str::FromStr;
+
     use async_trait::async_trait;
     use insta::assert_yaml_snapshot;
     use martin::TileSources;
     use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format};
     use rstest::{fixture, rstest};
-    use std::str::FromStr;
     use tilejson::{TileJSON, tilejson};
+
+    use super::*;
 
     #[derive(Debug, Clone)]
     pub struct MockSource {


### PR DESCRIPTION
codecov currently shows a small lack of tests in `martin-core`.

<img width="1836" height="345" alt="image" src="https://github.com/user-attachments/assets/7c7532f4-c5c3-4181-a99f-c9c2cd2d4d89" />

..Mostly for tiles

<img width="1876" height="378" alt="image" src="https://github.com/user-attachments/assets/c17af9ee-4c15-4a64-ab7a-ef87d1e97808" />

..partially for pmtiles

<img width="1863" height="545" alt="image" src="https://github.com/user-attachments/assets/3c25db2d-0876-4ed1-a323-faa9f55d2999" />

This is partially because the pmtiles cache is never excercised in the tests.
With this testcase, it is.