### PR TITLE
fix(mbtiles): meta-all with empty mbtiles

### DIFF
--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -331,7 +331,17 @@ async fn meta_print_all(file: &Path) -> anyhow::Result<()> {
     let mbt = Mbtiles::new(file)?;
     let mut conn = mbt.open_readonly().await?;
     let metadata = mbt.get_metadata(&mut conn).await?;
-    println!("{}", serde_yaml::to_string(&metadata)?);
+    print!("{}", serde_yaml::to_string(&metadata)?);
+    let tile_info = mbt.detect_format(&metadata.tilejson, &mut conn).await?;
+    // For compatibility, pretend tile_info is part of metadata YAML output
+    if let Some(tile_info) = tile_info {
+        let encoding = tile_info.encoding.content_encoding().unwrap_or("''");
+        println!("tile_info:");
+        println!("  format: {}", tile_info.format);
+        println!("  encoding: {encoding}");
+    } else {
+        println!("tile_info: null");
+    }
     Ok(())
 }
 

--- a/mbtiles/src/metadata.rs
+++ b/mbtiles/src/metadata.rs
@@ -376,6 +376,7 @@ mod tests {
 
     use super::*;
     use crate::mbtiles::tests::open;
+    use crate::{MbtType, init_mbtiles_schema};
 
     #[actix_rt::test]
     async fn mbtiles_meta() {
@@ -515,5 +516,20 @@ mod tests {
             mbt.get_metadata_value(&mut conn, "bounds").await.unwrap(),
             None
         );
+    }
+
+    #[actix_rt::test]
+    async fn metadata_empty_tileset() {
+        let mbt = Mbtiles::new(":memory:").unwrap();
+        let mut conn = mbt.open().await.unwrap();
+        init_mbtiles_schema(&mut conn, MbtType::Flat).await.unwrap();
+
+        // get_metadata should work on empty tileset
+        let meta = mbt.get_metadata(&mut conn).await;
+        let meta = meta.expect("get_metadata works on empty tileset");
+
+        // detect_format should return None for empty tileset
+        let tile_info = mbt.detect_format(&meta.tilejson, &mut conn).await.unwrap();
+        assert_eq!(tile_info, None);
     }
 }

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -146,7 +146,11 @@ impl Mbtiles {
     }
 
     /// Detect tile format and verify that it is consistent across some tiles
-    pub async fn detect_format<T>(&self, tilejson: &TileJSON, conn: &mut T) -> MbtResult<TileInfo>
+    pub async fn detect_format<T>(
+        &self,
+        tilejson: &TileJSON,
+        conn: &mut T,
+    ) -> MbtResult<Option<TileInfo>>
     where
         for<'e> &'e mut T: SqliteExecutor<'e>,
     {
@@ -217,13 +221,13 @@ impl Mbtiles {
         if let Some(info) = tile_info {
             if info.format != Format::Mvt && tilejson.vector_layers.is_some() {
                 warn!(
-                    "{} has vector_layers metadata but non-vector tiles",
+                    "{} has vector_layers metadata value, but the tiles are not MVT",
                     self.filename()
                 );
             }
-            Ok(info)
+            Ok(Some(info))
         } else {
-            Err(MbtError::NoTilesFound)
+            Ok(None)
         }
     }
 

--- a/tests/expected/martin-cp/composite_metadata.txt
+++ b/tests/expected/martin-cp/composite_metadata.txt
@@ -1,7 +1,4 @@
 id: cp_composite
-tile_info:
-  format: mvt
-  encoding: gzip
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -25,4 +22,6 @@ tilejson:
   format: pbf
   generator: martin-cp v0.0.0
 agg_tiles_hash: B088BC997177702E850E8E0F172D93F5
-
+tile_info:
+  format: mvt
+  encoding: gzip

--- a/tests/expected/martin-cp/flat-with-hash_metadata.txt
+++ b/tests/expected/martin-cp/flat-with-hash_metadata.txt
@@ -1,8 +1,4 @@
-[INFO ] Using 'mvt' tile format from metadata table in file cp_flat-with-hash
 id: cp_flat-with-hash
-tile_info:
-  format: mvt
-  encoding: ''
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -13,4 +9,7 @@ tilejson:
   format: pbf
   generator: martin-cp v0.0.0
 agg_tiles_hash: 9B931A386D6075D1DA55323BD4DBEDAE
-
+[INFO ] Using 'mvt' tile format from metadata table in file cp_flat-with-hash
+tile_info:
+  format: mvt
+  encoding: ''

--- a/tests/expected/martin-cp/flat_metadata.txt
+++ b/tests/expected/martin-cp/flat_metadata.txt
@@ -1,8 +1,5 @@
 [INFO ] cp_flat has an unrecognized metadata value foo={"bar":"foo"}
 id: cp_flat
-tile_info:
-  format: mvt
-  encoding: gzip
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -22,4 +19,6 @@ tilejson:
   format: pbf
   generator: martin-cp v0.0.0
 agg_tiles_hash: 7323D1D8A07A7176998822DB65E08567
-
+tile_info:
+  format: mvt
+  encoding: gzip

--- a/tests/expected/martin-cp/no-bbox_metadata.txt
+++ b/tests/expected/martin-cp/no-bbox_metadata.txt
@@ -1,8 +1,5 @@
 [INFO ] cp_no-bbox has an unrecognized metadata value foo={"bar":"foo"}
 id: cp_no-bbox
-tile_info:
-  format: mvt
-  encoding: gzip
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -22,4 +19,6 @@ tilejson:
   format: pbf
   generator: martin-cp v0.0.0
 agg_tiles_hash: 7323D1D8A07A7176998822DB65E08567
-
+tile_info:
+  format: mvt
+  encoding: gzip

--- a/tests/expected/martin-cp/no-source_metadata.txt
+++ b/tests/expected/martin-cp/no-source_metadata.txt
@@ -1,7 +1,4 @@
 id: cp_no-source
-tile_info:
-  format: mvt
-  encoding: gzip
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -29,4 +26,6 @@ tilejson:
   format: pbf
   generator: martin-cp v0.0.0
 agg_tiles_hash: 2AEC2DC0D41746C548A2ABEC8C4CF366
-
+tile_info:
+  format: mvt
+  encoding: gzip

--- a/tests/expected/martin-cp/normalized_metadata.txt
+++ b/tests/expected/martin-cp/normalized_metadata.txt
@@ -1,7 +1,4 @@
 id: cp_normalized
-tile_info:
-  format: png
-  encoding: ''
 tilejson:
   tilejson: 3.0.0
   tiles: []
@@ -37,4 +34,6 @@ tilejson:
   format: png
   generator: martin-cp v0.0.0
 agg_tiles_hash: A85C80BA1CE047E2D93DAC25C5179775
-
+tile_info:
+  format: png
+  encoding: ''

--- a/tests/expected/mbtiles/meta-all.txt
+++ b/tests/expected/mbtiles/meta-all.txt
@@ -1,7 +1,4 @@
 id: world_cities
-tile_info:
-  format: mvt
-  encoding: gzip
 layer_type: overlay
 tilejson:
   tilejson: 3.0.0
@@ -110,4 +107,6 @@ json:
       geometry: Point
       layer: cities
 agg_tiles_hash: 84792BF4EE9AEDDC5B1A60E707011FEE
-
+tile_info:
+  format: mvt
+  encoding: gzip


### PR DESCRIPTION
* Separate metadata from the detected tile format
* treat it as an error when creating a source for compatibility
* print it as `null` if the file is empty