### PR TITLE
chore(deps): make sure that the insta version is fixed in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ flume = "0.11"
 futures = "0.3"
 image = "0.25.8"
 indoc = "2"
-insta = "1"
+insta = "1.43.2"
 itertools = "0.14"
 json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }


### PR DESCRIPTION
insta is not supposed to be entirely stable.
Their snapshots may change, have changed in the past -> best we do this in a separate PR rather than munching it into another