### PR TITLE
chore(ci): remove the rust caching from the docs build

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: { persist-credentials: false }
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
       - name: 'Validate .md files (use "just fmt-md" to fix)'
         uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0


### PR DESCRIPTION
without this, I need to run the following to fix the docs CI step

```bash
for id in $(gh api repos/maplibre/martin/actions/caches --paginate -q '.actions_caches[].id'); do                                                                                                               1 ✘  system  
  gh api --method DELETE repos/maplibre/martin/actions/caches/$id
done
```