### PR TITLE
chore: release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,3 +124,16 @@ repos:
       language: system
       files: ^\.pre-commit-config\.yaml$
       pass_filenames: false
+      # below needs to be synced with deny.toml
+    - id: prevent-incompatible-dependencies
+      name: Hackily prevent incompatible dependencies
+      description: "Make sure that 'evil' dependencies are at the last compatible version"
+      entry: |
+        bash -c '
+          cargo update --precise 1.44.3 insta
+          cargo update --precise 1.24.0 libdeflater
+          cargo update --precise 1.24.0 libdeflate-sys
+        '
+      language: system
+      files: ^\.pre-commit-config\.yaml$
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,16 +124,3 @@ repos:
       language: system
       files: ^\.pre-commit-config\.yaml$
       pass_filenames: false
-      # below needs to be synced with deny.toml
-    - id: prevent-incompatible-dependencies
-      name: Hackily prevent incompatible dependencies
-      description: "Make sure that 'evil' dependencies are at the last compatible version"
-      entry: |
-        bash -c '
-          cargo update --precise 1.44.3 insta
-          cargo update --precise 1.24.0 libdeflater
-          cargo update --precise 1.24.0 libdeflate-sys
-        '
-      language: system
-      files: ^\.pre-commit-config\.yaml$
-      pass_filenames: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2266,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.3"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+checksum = "983e3b24350c84ab8a65151f537d67afbbf7153bb9f1110e03e9fa9b07f67a5c"
 dependencies = [
  "console",
  "once_cell",
@@ -3457,7 +3457,9 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "toml",
+ "tempfile",
+ "toml_edit",
+ "toml_writer",
 ]
 
 [[package]]
@@ -3495,7 +3497,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3683,18 +3685,18 @@ checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
+checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
+checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -3842,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3894,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "actix-web",
  "approx",
@@ -3943,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -3981,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -5098,7 +5100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5118,7 +5120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -5789,7 +5791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6085,6 +6087,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -6813,7 +6824,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7186,15 +7197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7210,8 +7212,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.12.1",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -7223,6 +7228,12 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -7796,7 +7807,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2266,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.45.1"
+version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983e3b24350c84ab8a65151f537d67afbbf7153bb9f1110e03e9fa9b07f67a5c"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
 dependencies = [
  "console",
  "once_cell",
@@ -3457,9 +3457,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "tempfile",
- "toml_edit",
- "toml_writer",
+ "toml",
 ]
 
 [[package]]
@@ -3497,7 +3495,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3685,18 +3683,18 @@ checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
+checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
+checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -5778,7 +5776,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5791,7 +5789,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6087,15 +6085,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -6824,7 +6813,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7197,6 +7186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7212,11 +7210,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.12.1",
- "serde_core",
- "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -7228,12 +7223,6 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -7807,7 +7796,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.1"
-martin-core = { path = "./martin-core", version = "0.2.4", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.7" }
-mbtiles = { path = "./mbtiles", version = "0.14.3" }
+martin-core = { path = "./martin-core", version = "0.2.5", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.8" }
+mbtiles = { path = "./mbtiles", version = "0.15.0" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.1.0
+    image: ghcr.io/maplibre/martin:1.2.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,7 @@ skip = []
 skip-tree = []
 
 # List of crates to deny
-# changes here needs to be synced `just update`
+# changes here need to be synced `just update`
 deny = [
     { crate = "libdeflater@1.25.0", reason = "does not compile under musl" },
     { crate = "libdeflate-sys@1.25.0", reason = "does not compile under musl" },

--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,7 @@ skip = []
 skip-tree = []
 
 # List of crates to deny
-# changes here needs to be synced with pre-commit's prevent-incompatible-dependencies check
+# changes here needs to be synced `just update`
 deny = [
     { crate = "libdeflater@1.25.0", reason = "does not compile under musl" },
     { crate = "libdeflate-sys@1.25.0", reason = "does not compile under musl" },

--- a/deny.toml
+++ b/deny.toml
@@ -61,9 +61,12 @@ skip = []
 skip-tree = []
 
 # List of crates to deny
+# changes here needs to be synced with pre-commit's prevent-incompatible-dependencies check
 deny = [
     { crate = "libdeflater@1.25.0", reason = "does not compile under musl" },
     { crate = "libdeflate-sys@1.25.0", reason = "does not compile under musl" },
+    { crate = "insta@1.45.0", reason = "fails cargo test -- diff_and_patch" },
+    { crate = "insta@1.45.1", reason = "fails cargo test -- diff_and_patch" },
 ]
 
 [sources]

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.1.0 \
+           ghcr.io/maplibre/martin:1.2.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.1.0
+    image: ghcr.io/maplibre/martin:1.2.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/run-with-docker.md
+++ b/docs/src/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.1.0
+  ghcr.io/maplibre/martin:1.2.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.1.0 \
+  ghcr.io/maplibre/martin:1.2.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.1.0
+  ghcr.io/maplibre/martin:1.2.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.1.0
+  ghcr.io/maplibre/martin:1.2.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.1.0
+  ghcr.io/maplibre/martin:1.2.0
 ```

--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.1.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.2.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.1.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.2.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -159,7 +159,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.1.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.2.0 {{args}}
 
 # Build and open code documentation
 docs *args='--open':

--- a/justfile
+++ b/justfile
@@ -396,6 +396,11 @@ type-check:
 update:
     cargo +nightly -Z unstable-options update --breaking
     cargo update
+    # Make sure that 'evil' dependencies are at the last compatible version
+    # below needs to be synced with deny.toml
+    cargo update --precise 1.44.3 insta
+    cargo update --precise 1.24.0 libdeflater
+    cargo update --precise 1.24.0 libdeflate-sys
 
 # Validate that all required development tools are installed
 validate-tools:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03
+
+### Fixed
+
+- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
+
+### Other
+
+- *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
+- *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
+
 ## [0.2.4](https://github.com/maplibre/martin/compare/martin-core-v0.2.3...martin-core-v0.2.4) - 2025-12-11
 
 ### Added

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03
 
-### Fixed
-
-- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
-
-### Other
-
 - *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
 - *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
 

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,31 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03
 
-### Added
+### Optionally fail config loading/resolution for missing sources
 
-- *(martin-ui)* Add click to copy ([#2427](https://github.com/maplibre/martin/pull/2427))
-- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))
-- *(config)* optionally fail config loading/resolution for missing sources ([#2412](https://github.com/maplibre/martin/pull/2412))
+We added the `on_invalid: abort` (default) and `on_invalid: warn` settings, which controls what happens when martin encounters an missing/invalid source.
+
+Done in [#2412](https://github.com/maplibre/martin/pull/2412), [#2426](https://github.com/maplibre/martin/pull/2426) by @gabeschine
+
+### Click to copy when clicking on various IDs in the UI
+
+When clicking on various IDs in the UI, a click to copy feature is now available.
+
+<img width="720" height="393" alt="image" src="https://github.com/user-attachments/assets/6d062bb1-18f1-4827-a378-44b141eb11d5" />
+
+Done in [#2427](https://github.com/maplibre/martin/pull/2427)) by @todtb
 
 ### Fixed
 
-- filter available tables result when auto publish false ([#2411](https://github.com/maplibre/martin/pull/2411))
-- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
+- *(pg)* Instead of reporting on all available tables, we now filter the result to the configured sources when `auto_publish: false` ([#2411](https://github.com/maplibre/martin/pull/2411))
+- *(sprites)* Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
 
 ### Other
 
-- *(mbtiles)* Generate mbtiles dynamically from SQL files to increase debuggability and transparency ([#2380](https://github.com/maplibre/martin/pull/2380))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2455](https://github.com/maplibre/martin/pull/2455))
-- *(ci)* not installing our npm dependencys accoring to the lockfile when testing code ([#2442](https://github.com/maplibre/martin/pull/2442))
-- *(deps)* autoupdate pre-commit ([#2439](https://github.com/maplibre/martin/pull/2439))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 17 updates ([#2435](https://github.com/maplibre/martin/pull/2435))
-- *(bench)* add black_box for tables/functions ([#2413](https://github.com/maplibre/martin/pull/2413))
-- *(deps)* sync pre-commit and biomejs versions ([#2429](https://github.com/maplibre/martin/pull/2429))
-- *(config)* no-op refactor to pull out "build_one_(table|function)_info" ([#2426](https://github.com/maplibre/martin/pull/2426))
-- *(deps)* Bump the all-npm-ui-version-updates group in /martin/martin-ui with 9 updates ([#2418](https://github.com/maplibre/martin/pull/2418))
-- *(ci)* More pinning of our dependencys in CI ([#2415](https://github.com/maplibre/martin/pull/2415))
-- *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
+- made our dependency management more reproducible/stable ([#2442](https://github.com/maplibre/martin/pull/2442), [#2429](https://github.com/maplibre/martin/pull/2429), [#2415](https://github.com/maplibre/martin/pull/2415))
+- various dependency bumps ([#2439](https://github.com/maplibre/martin/pull/2439), [#2435](https://github.com/maplibre/martin/pull/2435), [#2418](https://github.com/maplibre/martin/pull/2418))
+- *(bench)* improve benchmark accuracy by adding black_box for tables/functions ([#2413](https://github.com/maplibre/martin/pull/2413))
 - *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
+
+
 - update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
 
 ## [1.1.0](https://github.com/maplibre/martin/compare/martin-v1.0.0...martin-v1.1.0) - 2025-12-11

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03
+
+### Added
+
+- *(martin-ui)* Add click to copy ([#2427](https://github.com/maplibre/martin/pull/2427))
+- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))
+- *(config)* optionally fail config loading/resolution for missing sources ([#2412](https://github.com/maplibre/martin/pull/2412))
+
+### Fixed
+
+- filter available tables result when auto publish false ([#2411](https://github.com/maplibre/martin/pull/2411))
+- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
+
+### Other
+
+- *(mbtiles)* Generate mbtiles dynamically from SQL files to increase debuggability and transparency ([#2380](https://github.com/maplibre/martin/pull/2380))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2455](https://github.com/maplibre/martin/pull/2455))
+- *(ci)* not installing our npm dependencys accoring to the lockfile when testing code ([#2442](https://github.com/maplibre/martin/pull/2442))
+- *(deps)* autoupdate pre-commit ([#2439](https://github.com/maplibre/martin/pull/2439))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 17 updates ([#2435](https://github.com/maplibre/martin/pull/2435))
+- *(bench)* add black_box for tables/functions ([#2413](https://github.com/maplibre/martin/pull/2413))
+- *(deps)* sync pre-commit and biomejs versions ([#2429](https://github.com/maplibre/martin/pull/2429))
+- *(config)* no-op refactor to pull out "build_one_(table|function)_info" ([#2426](https://github.com/maplibre/martin/pull/2426))
+- *(deps)* Bump the all-npm-ui-version-updates group in /martin/martin-ui with 9 updates ([#2418](https://github.com/maplibre/martin/pull/2418))
+- *(ci)* More pinning of our dependencys in CI ([#2415](https://github.com/maplibre/martin/pull/2415))
+- *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
+- *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
+- update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
+
 ## [1.1.0](https://github.com/maplibre/martin/compare/martin-v1.0.0...martin-v1.1.0) - 2025-12-11
 
 ### Added

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -31,12 +31,9 @@ Done in [#2427](https://github.com/maplibre/martin/pull/2427)) by @todtb
 ### Other
 
 - made our dependency management more reproducible/stable ([#2442](https://github.com/maplibre/martin/pull/2442), [#2429](https://github.com/maplibre/martin/pull/2429), [#2415](https://github.com/maplibre/martin/pull/2415))
-- various dependency bumps ([#2439](https://github.com/maplibre/martin/pull/2439), [#2435](https://github.com/maplibre/martin/pull/2435), [#2418](https://github.com/maplibre/martin/pull/2418))
+- various dependency bumps ([#2439](https://github.com/maplibre/martin/pull/2439), [#2435](https://github.com/maplibre/martin/pull/2435), [#2418](https://github.com/maplibre/martin/pull/2418), [#2471](https://github.com/maplibre/martin/pull/2471))
 - *(bench)* improve benchmark accuracy by adding black_box for tables/functions ([#2413](https://github.com/maplibre/martin/pull/2413))
 - *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
-
-
-- update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
 
 ## [1.1.0](https://github.com/maplibre/martin/compare/martin-v1.0.0...martin-v1.1.0) - 2025-12-11
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -21,7 +21,7 @@ When clicking on various IDs in the UI, a click to copy feature is now available
 
 <img width="720" height="393" alt="image" src="https://github.com/user-attachments/assets/6d062bb1-18f1-4827-a378-44b141eb11d5" />
 
-Done in [#2427](https://github.com/maplibre/martin/pull/2427)) by @todtb
+Done in [#2427](https://github.com/maplibre/martin/pull/2427) by @todtb
 
 ### Fixed
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -60,5 +60,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03
 
-### Added configurable output formats for `mbtiles summary`
+### Added
 
+Configurable output formats for `mbtiles summary`.
 You can now control the output format using the `--format` option:
 - `json-pretty` — multi-line, human-readable JSON
 - `json` — compact JSON

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03
+
+### Added
+
+- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))
+
+### Fixed
+
+- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
+
+### Other
+
+- *(mbtiles)* Generate mbtiles dynamically from SQL files to increase debuggability and transparency ([#2380](https://github.com/maplibre/martin/pull/2380))
+- update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
+
 ## [0.14.3](https://github.com/maplibre/martin/compare/mbtiles-v0.14.2...mbtiles-v0.14.3) - 2025-12-11
 
 ### Other

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -9,13 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03
 
-### Added
+### Added configurable output formats for `mbtiles summary`
 
-- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))
+You can now control the output format using the `--format` option:
+- `json-pretty` — multi-line, human-readable JSON
+- `json` — compact JSON
+- `text` — plain text (default)
 
-### Fixed
+Implemented in [#2447](https://github.com/maplibre/martin/pull/2447) by @nyurik.
 
-- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))
+### Fixed handling of empty MBTiles archives in `mbtiles meta-all`
+
+The command now:
+- Separates metadata from the detected tile format
+- Treats missing metadata as an error when creating a source for compatibility
+- Outputs `null` metadata when the archive is empty
+
+Fixed in [#2448](https://github.com/maplibre/martin/pull/2448) by @nyurik.
 
 ### Other
 

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.14.3"
+version = "0.15.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.6.7 -> 0.6.8 (✓ API compatible changes)
* `mbtiles`: 0.14.3 -> 0.15.0 (⚠ API breaking changes)
* `martin-core`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `martin`: 1.1.0 -> 1.2.0

### ⚠ `mbtiles` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field tile_info of struct Metadata, previously in file /tmp/.tmpZdh9YX/mbtiles/src/metadata.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03

### Added

- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))

### Fixed

- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))

### Other

- *(mbtiles)* Generate mbtiles dynamically from SQL files to increase debuggability and transparency ([#2380](https://github.com/maplibre/martin/pull/2380))
- update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
</blockquote>

## `martin-core`

<blockquote>

## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03

### Fixed

- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))

### Other

- *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
- *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
</blockquote>

## `martin`

<blockquote>

## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03

### Added

- *(martin-ui)* Add click to copy ([#2427](https://github.com/maplibre/martin/pull/2427))
- *(mbtiles)* improve mbtiles summary output ([#2447](https://github.com/maplibre/martin/pull/2447))
- *(config)* optionally fail config loading/resolution for missing sources ([#2412](https://github.com/maplibre/martin/pull/2412))

### Fixed

- filter available tables result when auto publish false ([#2411](https://github.com/maplibre/martin/pull/2411))
- *(mbtiles)* meta-all with empty mbtiles ([#2448](https://github.com/maplibre/martin/pull/2448))

### Other

- *(mbtiles)* Generate mbtiles dynamically from SQL files to increase debuggability and transparency ([#2380](https://github.com/maplibre/martin/pull/2380))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2455](https://github.com/maplibre/martin/pull/2455))
- *(ci)* not installing our npm dependencys accoring to the lockfile when testing code ([#2442](https://github.com/maplibre/martin/pull/2442))
- *(deps)* autoupdate pre-commit ([#2439](https://github.com/maplibre/martin/pull/2439))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 17 updates ([#2435](https://github.com/maplibre/martin/pull/2435))
- *(bench)* add black_box for tables/functions ([#2413](https://github.com/maplibre/martin/pull/2413))
- *(deps)* sync pre-commit and biomejs versions ([#2429](https://github.com/maplibre/martin/pull/2429))
- *(config)* no-op refactor to pull out "build_one_(table|function)_info" ([#2426](https://github.com/maplibre/martin/pull/2426))
- *(deps)* Bump the all-npm-ui-version-updates group in /martin/martin-ui with 9 updates ([#2418](https://github.com/maplibre/martin/pull/2418))
- *(ci)* More pinning of our dependencys in CI ([#2415](https://github.com/maplibre/martin/pull/2415))
- *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))
- *(pmtiles)* add pmtiles test in `martin-core` ([#2443](https://github.com/maplibre/martin/pull/2443))
- update a variety of likely uncritical dependencys ([#2471](https://github.com/maplibre/martin/pull/2471))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).