### PR TITLE
test(mbtiles): remove inner testing loop from `diff_and_patch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4972,7 +4972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4992,7 +4992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.112",


### PR DESCRIPTION
this test is already fairly hard to read and this inner testing loop is not helping with this.

There are other things that need to happen before this can be better debugged, but this is one of them.

Yes, the tests will be a bit slower, I don't care. They are fast enough.