### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5996,15 +5996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_tuple"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7121,11 +7112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "serde_core",
- "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -7137,12 +7125,6 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.3"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+checksum = "248b42847813a1550dafd15296fd9748c651d0c32194559dbc05d804d54b21e8"
 dependencies = [
  "console",
  "once_cell",
@@ -3368,7 +3368,9 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "toml",
+ "tempfile",
+ "toml_edit",
+ "toml_writer",
 ]
 
 [[package]]
@@ -3583,18 +3585,18 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
+checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
+checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -3751,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3804,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "actix-web",
  "approx",
@@ -3852,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -3901,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -5996,6 +5998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_tuple"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,15 +7099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7112,8 +7114,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -7125,6 +7130,12 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.1"
+version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248b42847813a1550dafd15296fd9748c651d0c32194559dbc05d804d54b21e8"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
 dependencies = [
  "console",
  "once_cell",
@@ -3368,9 +3368,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "tempfile",
- "toml_edit",
- "toml_writer",
+ "toml",
 ]
 
 [[package]]
@@ -3585,18 +3583,18 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
+checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
+checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -7096,6 +7094,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.1"
-martin-core = { path = "./martin-core", version = "0.2.5", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.8" }
-mbtiles = { path = "./mbtiles", version = "0.15.0" }
+martin-core = { path = "./martin-core", version = "0.2.6", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.9" }
+mbtiles = { path = "./mbtiles", version = "0.15.1" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.2.0
+    image: ghcr.io/maplibre/martin:1.3.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.2.0 \
+           ghcr.io/maplibre/martin:1.3.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/src/run-with-docker-compose.md
+++ b/docs/src/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.2.0
+    image: ghcr.io/maplibre/martin:1.3.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/src/run-with-docker.md
+++ b/docs/src/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.2.0
+  ghcr.io/maplibre/martin:1.3.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.2.0 \
+  ghcr.io/maplibre/martin:1.3.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.2.0
+  ghcr.io/maplibre/martin:1.3.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.2.0
+  ghcr.io/maplibre/martin:1.3.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.2.0
+  ghcr.io/maplibre/martin:1.3.0
 ```

--- a/docs/src/run-with-lambda.md
+++ b/docs/src/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.2.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.3.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.2.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.3.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -159,7 +159,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.2.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.3.0 {{args}}
 
 # Build and open code documentation
 docs *args='--open':

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -11,18 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
+- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494), [#2500](https://github.com/maplibre/martin/pull/2500))
 - *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))
 
 ### Fixed
 
-- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
+- *(perf)* Remove FontSources.masks as constructing it was consuming large amounts of memory and some startup time even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
 - improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))
 
 ### Other
 
-- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
-- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
+- *(deps)* `cargo-shear` out unused dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
 
 ## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03
 

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* `cargo-shear` out unused dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
+- *(deps)* `cargo-shear` out unused dependencies ([#2497](https://github.com/maplibre/martin/pull/2497))
 
 ## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03
 

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/maplibre/martin/compare/martin-core-v0.2.5...martin-core-v0.2.6) - 2026-01-27
+
+### Added
+
+- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
+- *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))
+
+### Fixed
+
+- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
+- improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))
+
+### Other
+
+- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
+- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
+
 ## [0.2.5](https://github.com/maplibre/martin/compare/martin-core-v0.2.4...martin-core-v0.2.5) - 2026-01-03
 
 - *(deps)* bump spreet to fix Scale SDF buffer and radius by pixel ratio leading to weird artefacts when using retina sdf sprites ([#2458](https://github.com/maplibre/martin/pull/2458))

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.6.8"
+version = "0.6.9"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -43,7 +43,7 @@ Done in ([#2523](https://github.com/maplibre/martin/pull/2523))
 
 Martin now supports the MapLibre Tiles Specification.
 This means that if you want to serve MLT based tiles with this tileserver, you now can.
-Read more about what the MapLibre Tile Specification is and why we are "reinventing the weel on this one" in our [blog post](https://maplibre.org/news/2026-01-23-mlt-release/).
+Read more about what the MapLibre Tile Specification is and why we are "reinventing the wheel on this one" in our [blog post](https://maplibre.org/news/2026-01-23-mlt-release/).
 
 Done in ([#2512](https://github.com/maplibre/martin/pull/2512))
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -61,7 +61,7 @@ Done in ([#2512](https://github.com/maplibre/martin/pull/2512))
 ### Other
 
 
-- *(deps)* `cargo-shear` our dependencys for improved compile times ([#2497](https://github.com/maplibre/martin/pull/2497))
+- *(deps)* `cargo-shear` our dependencies for improved compile times ([#2497](https://github.com/maplibre/martin/pull/2497))
 - *(mbtiles)* improve a few test cases ([#2478](https://github.com/maplibre/martin/pull/2478), [#2480](https://github.com/maplibre/martin/pull/2480), [#2477](https://github.com/maplibre/martin/pull/2477))
 
 ## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -19,7 +19,7 @@ Done in [#2494](https://github.com/maplibre/martin/pull/2494), [#2508](https://g
 
 ### Glyph ranges beyond `0xFFFF`
 
-If you are using fonts which span beyond the `0xFFFF`
+If you are using fonts which span beyond the `0xFFFF` range, this release improves how Martin loads and renders those glyphs so they are handled correctly.
 
 Here is a short explanation of why this might matter to you based on <https://en.wikipedia.org/wiki/Unicode_block>.
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/maplibre/martin/compare/martin-v1.2.0...martin-v1.3.0) - 2026-01-27
+
+### Added
+
+- *(srv)* Add `route_prefix` configuration for native subpath support without the need of a reverse proxy override ([#2523](https://github.com/maplibre/martin/pull/2523))
+- add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
+- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
+- improve martin-cp progress output time estimate ([#2491](https://github.com/maplibre/martin/pull/2491))
+- *(pg)* include ID column info for tables ([#2485](https://github.com/maplibre/martin/pull/2485))
+- *(pg)* support PostgreSQL materialized views ([#2279](https://github.com/maplibre/martin/pull/2279))
+- *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))
+
+### Fixed
+
+- *(ui)* clipboard copy for http://0.0.0.0:3000 and unify implementations ([#2487](https://github.com/maplibre/martin/pull/2487))
+- the `Copy` icon displaying nicely, next to the text and with enough padding ot all items ([#2483](https://github.com/maplibre/martin/pull/2483))
+- update copy text to include icon for better visibility ([#2482](https://github.com/maplibre/martin/pull/2482))
+- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
+- improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))
+
+### Other
+
+- move our request logging to tracing ([#2508](https://github.com/maplibre/martin/pull/2508))
+- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
+- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
+- *(ui)* adjust margin for copy icon in URL component ([#2489](https://github.com/maplibre/martin/pull/2489))
+- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
+- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
+- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
+
 ## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03
 
 ### Optionally fail config loading/resolution for missing sources

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,33 +9,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0](https://github.com/maplibre/martin/compare/martin-v1.2.0...martin-v1.3.0) - 2026-01-27
 
+### More flexible log formatting
+
+We migrated our `log` library to `tracing`.
+This gives us a few internal improvements, but also allows us to introduce a new `RUST_LOG_FORMAT` environment variable.
+The avaliable values are: `json`, `full`, `compact` (default), `bare` or `pretty`.
+
+Done in [#2494](https://github.com/maplibre/martin/pull/2494), [#2508](https://github.com/maplibre/martin/pull/2508), [#2500](https://github.com/maplibre/martin/pull/2500) by @CommanderStorm
+
+### Glyph ranges beyond `0xFFFF`
+
+If you are using fonts which span beyond the `0xFFFF`
+
+Here is a short explaination of why this might matter to you based on <https://en.wikipedia.org/wiki/Unicode_block>.
+
+- `U+0000` - `U+FFFF` is Basic Multilingual Plane, which covers characters for almost all modern languages
+- `U+10000` - `U+3347F` covers minor characters such as historic scripts and emojis
+- `U+E0000` - `U+E01EF` is for tags and variation selectors
+- `U+F0000` - `U+10FFFF` is for private use (i.e. can be assigned arbitrary custom characters without worrying about possible conflict with the future standards)
+
+Done in ([#2438](https://github.com/maplibre/martin/pull/2438)) by @yutannihilation
+
+As a related performance optimisation, we also removed `FontSources.masks` as it was consuming large amounts of memory and some startup time, even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519)) by @Auspicus
+
+### Simpler native subpath support
+
+We added the `route_prefix` configuration and `--route-prefix` cli arguments.
+This allows you to configure the subpath martin is serving from without the need for your reverse proxy to strip these subpaths before getting to us.
+
+Done in ([#2523](https://github.com/maplibre/martin/pull/2523))
+
+### MLT decoding support
+
+Martin now supports the MapLibre Tiles Specification.
+This means that if you want to serve MLT based tiles with this tileserver, you now can.
+Read more about what the MapLibre Tile Specification is and why we are "reinventing the weel on this one" in our [blog post](https://maplibre.org/news/2026-01-23-mlt-release/).
+
+Done in ([#2512](https://github.com/maplibre/martin/pull/2512))
+
 ### Added
 
-- *(srv)* Add `route_prefix` configuration for native subpath support without the need of a reverse proxy override ([#2523](https://github.com/maplibre/martin/pull/2523))
-- add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
-- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
-- improve martin-cp progress output time estimate ([#2491](https://github.com/maplibre/martin/pull/2491))
-- *(pg)* include ID column info for tables ([#2485](https://github.com/maplibre/martin/pull/2485))
+- improve martin-cp progress output time estimate by displaying in human time instead of seconds ([#2491](https://github.com/maplibre/martin/pull/2491))
 - *(pg)* support PostgreSQL materialized views ([#2279](https://github.com/maplibre/martin/pull/2279))
-- *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))
+- *(pg)* include ID column info for tables ([#2485](https://github.com/maplibre/martin/pull/2485))
 
 ### Fixed
 
-- *(ui)* clipboard copy for http://0.0.0.0:3000 and unify implementations ([#2487](https://github.com/maplibre/martin/pull/2487))
-- the `Copy` icon displaying nicely, next to the text and with enough padding ot all items ([#2483](https://github.com/maplibre/martin/pull/2483))
-- update copy text to include icon for better visibility ([#2482](https://github.com/maplibre/martin/pull/2482))
-- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
 - improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))
+- *(ui)* Fix clipboard copy for <http://0.0.0.0:3000> and unify implementations and their design ([#2487](https://github.com/maplibre/martin/pull/2487), [#2489](https://github.com/maplibre/martin/pull/2489), [#2483](https://github.com/maplibre/martin/pull/2483), [#2482](https://github.com/maplibre/martin/pull/2482))
 
 ### Other
 
-- move our request logging to tracing ([#2508](https://github.com/maplibre/martin/pull/2508))
-- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
-- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
-- *(ui)* adjust margin for copy icon in URL component ([#2489](https://github.com/maplibre/martin/pull/2489))
-- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
-- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
-- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
+
+- *(deps)* `cargo-shear` our dependencys for improved compile times ([#2497](https://github.com/maplibre/martin/pull/2497))
+- *(mbtiles)* improve a few test cases ([#2478](https://github.com/maplibre/martin/pull/2478), [#2480](https://github.com/maplibre/martin/pull/2480), [#2477](https://github.com/maplibre/martin/pull/2477))
 
 ## [1.2.0](https://github.com/maplibre/martin/compare/martin-v1.1.0...martin-v1.2.0) - 2026-01-03
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -21,7 +21,7 @@ Done in [#2494](https://github.com/maplibre/martin/pull/2494), [#2508](https://g
 
 If you are using fonts which span beyond the `0xFFFF`
 
-Here is a short explaination of why this might matter to you based on <https://en.wikipedia.org/wiki/Unicode_block>.
+Here is a short explanation of why this might matter to you based on <https://en.wikipedia.org/wiki/Unicode_block>.
 
 - `U+0000` - `U+FFFF` is Basic Multilingual Plane, which covers characters for almost all modern languages
 - `U+10000` - `U+3347F` covers minor characters such as historic scripts and emojis

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 We migrated our `log` library to `tracing`.
 This gives us a few internal improvements, but also allows us to introduce a new `RUST_LOG_FORMAT` environment variable.
-The avaliable values are: `json`, `full`, `compact` (default), `bare` or `pretty`.
+The available values are: `json`, `full`, `compact` (default), `bare` or `pretty`.
 
 Done in [#2494](https://github.com/maplibre/martin/pull/2494), [#2508](https://github.com/maplibre/martin/pull/2508), [#2500](https://github.com/maplibre/martin/pull/2500) by @CommanderStorm
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.2.0"
+version = "1.3.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -60,5 +60,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - *(test)* unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
-- *(test)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
+- *(test)* remove the prefix-ism around how files are named for binary diff copy and simplify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
 - *(test)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
 
 ## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
-- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
+- migrate our `log` library to `tracing`. For practical usecases this does not have an effect, since we enable the `log` feature by default ([#2494](https://github.com/maplibre/martin/pull/2494))
 
 ### Other
 
-- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
-- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
-- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
+- *(test)* unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
+- *(test)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
+- *(test)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
 
 ## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03
 

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/maplibre/martin/compare/mbtiles-v0.15.0...mbtiles-v0.15.1) - 2026-01-27
+
+### Added
+
+- add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
+- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
+
+### Other
+
+- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
+- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
+- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
+
 ## [0.15.0](https://github.com/maplibre/martin/compare/mbtiles-v0.14.3...mbtiles-v0.15.0) - 2026-01-03
 
 ### Added

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
-- migrate our `log` library to `tracing`. For practical usecases this does not have an effect, since we enable the `log` feature by default ([#2494](https://github.com/maplibre/martin/pull/2494))
+- migrate our `log` library to `tracing`. For practical use cases this does not have an effect, since we enable the `log` feature by default ([#2494](https://github.com/maplibre/martin/pull/2494))
 
 ### Other
 

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.6.8 -> 0.6.9 (✓ API compatible changes)
* `mbtiles`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `martin-core`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `martin`: 1.2.0 -> 1.3.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.15.1](https://github.com/maplibre/martin/compare/mbtiles-v0.15.0...mbtiles-v0.15.1) - 2026-01-27

### Added

- add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))

### Other

- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
</blockquote>

## `martin-core`

<blockquote>

## [0.2.6](https://github.com/maplibre/martin/compare/martin-core-v0.2.5...martin-core-v0.2.6) - 2026-01-27

### Added

- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
- *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))

### Fixed

- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
- improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))

### Other

- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
</blockquote>

## `martin`

<blockquote>

## [1.3.0](https://github.com/maplibre/martin/compare/martin-v1.2.0...martin-v1.3.0) - 2026-01-27

### Added

- *(srv)* Add `route_prefix` configuration for native subpath support without the need of a reverse proxy override ([#2523](https://github.com/maplibre/martin/pull/2523))
- add MLT decoding support ([#2512](https://github.com/maplibre/martin/pull/2512))
- migrate our log library to tracing ([#2494](https://github.com/maplibre/martin/pull/2494))
- improve martin-cp progress output time estimate ([#2491](https://github.com/maplibre/martin/pull/2491))
- *(pg)* include ID column info for tables ([#2485](https://github.com/maplibre/martin/pull/2485))
- *(pg)* support PostgreSQL materialized views ([#2279](https://github.com/maplibre/martin/pull/2279))
- *(martin-core)* Allow glyph ranges more than 0xFFFF ([#2438](https://github.com/maplibre/martin/pull/2438))

### Fixed

- *(ui)* clipboard copy for http://0.0.0.0:3000 and unify implementations ([#2487](https://github.com/maplibre/martin/pull/2487))
- the `Copy` icon displaying nicely, next to the text and with enough padding ot all items ([#2483](https://github.com/maplibre/martin/pull/2483))
- update copy text to include icon for better visibility ([#2482](https://github.com/maplibre/martin/pull/2482))
- *(perf)* Remove FontSources.masks as they were consuming large amounts of memory even when no font sources were set ([#2519](https://github.com/maplibre/martin/pull/2519))
- improve error message if no SVG sprite files are present ([#2516](https://github.com/maplibre/martin/pull/2516))

### Other

- move our request logging to tracing ([#2508](https://github.com/maplibre/martin/pull/2508))
- move our imports to tracing ([#2500](https://github.com/maplibre/martin/pull/2500))
- *(deps)* shear our dependencys ([#2497](https://github.com/maplibre/martin/pull/2497))
- *(ui)* adjust margin for copy icon in URL component ([#2489](https://github.com/maplibre/martin/pull/2489))
- unignore `diff_and_patch_bsdiff` test with unique SQLite database names ([#2480](https://github.com/maplibre/martin/pull/2480))
- *(mbtiles)* remove the prefix-ism around how files are named for binary diff copy and simpify their naming ([#2478](https://github.com/maplibre/martin/pull/2478))
- *(mbtiles)* add assertion messages what we are checking to the copy tests ([#2477](https://github.com/maplibre/martin/pull/2477))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).