### PR TITLE
feat: improve martin-cp progress output time estimate

### DIFF
--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -319,7 +319,10 @@ fn write_duration(f: &mut impl Write, secs: f32) -> std::fmt::Result {
         let (weeks, days) = (days / 7, days % 7);
 
         if years > 0 {
-            write!(f, "{years}y{weeks:02}w{days:02}d{hrs:02}h{mins:02}m{secs:02}s")
+            write!(
+                f,
+                "{years}y{weeks:02}w{days:02}d{hrs:02}h{mins:02}m{secs:02}s"
+            )
         } else if weeks > 0 {
             write!(f, "{weeks}w{days:02}d{hrs:02}h{mins:02}m{secs:02}s")
         } else if days > 0 {

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -298,6 +298,42 @@ enum MartinCpError {
     InvalidBoundingBox(&'static str, Bounds, RangeInclusive<f64>),
 }
 
+fn write_duration(f: &mut impl Write, secs: f32) -> std::fmt::Result {
+    if !secs.is_normal() || secs < 0. {
+        // Nonsense input
+        f.write_str("???")
+    } else if secs < 1. {
+        write!(f, "<1s")
+    } else {
+        // we've already handled cases of inf, or negative
+        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_sign_loss)]
+        let secs = secs.ceil() as u64;
+
+        let (mins, secs) = (secs / 60, secs % 60);
+        let (hrs, mins) = (mins / 60, mins % 60);
+        let (days, hrs) = (hrs / 24, hrs % 24);
+
+        // yes, the order is different. Calc years & days, then calc weeks
+        let (years, days) = (days / 365, days % 365);
+        let (weeks, days) = (days / 7, days % 7);
+
+        if years > 0 {
+            write!(f, "{years}y{weeks:02}w{days:02}d{hrs:02}h{mins:02}m{secs:02}s")
+        } else if weeks > 0 {
+            write!(f, "{weeks}w{days:02}d{hrs:02}h{mins:02}m{secs:02}s")
+        } else if days > 0 {
+            write!(f, "{days}d{hrs:02}h{mins:02}m{secs:02}s")
+        } else if hrs > 0 {
+            write!(f, "{hrs}h{mins:02}m{secs:02}s")
+        } else if mins > 0 {
+            write!(f, "{mins}m{secs:02}s")
+        } else {
+            write!(f, "{secs}s")
+        }
+    }
+}
+
 impl Display for Progress {
     #[expect(clippy::cast_precision_loss)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -312,19 +348,24 @@ impl Display for Progress {
         } else {
             0.0
         };
+        write!(f, "[")?;
+        write_duration(f, elapsed_s)?;
+
         write!(
             f,
-            "[{elapsed:.1?}] {percent:.2}% @ {speed:.1}/s | ✓ {non_empty} □ {empty}"
+            "] {percent:.2}% @ {speed:.1}/s | ✓ {non_empty} □ {empty}"
         )?;
 
         let left = self.total - done;
+        f.write_str(" | ")?;
         if left == 0 {
-            f.write_str(" | done")
+            f.write_str("done")
         } else if done == 0 {
-            f.write_str(" | ??? left")
+            f.write_str("??? left")
         } else {
-            let left = Duration::from_secs_f32(elapsed_s * left as f32 / done as f32);
-            write!(f, " | {left:.0?} left")
+            let secs = elapsed_s * left as f32 / done as f32;
+            write_duration(f, secs)?;
+            f.write_str(" left")
         }
     }
 }


### PR DESCRIPTION
`martin-cp` will print a simple progress bar. This change makes the elapsed and remaining time be displayed in a human readable hours/minutes/seconds display instead of just a raw number of seconds.

Namely, instead of this

```
[2026-01-09T16:40:22Z INFO  martin_cp] [71.5s] 44% @ 547.8/s | ✓ 7393 □ 31800 | 88s left
[2026-01-09T16:40:24Z INFO  martin_cp] [73.8s] 46% @ 555.1/s | ✓ 7754 □ 33200 | 84s left
[2026-01-09T16:40:26Z INFO  martin_cp] [75.9s] 47% @ 551.9/s | ✓ 8000 □ 33882 | 82s left
```

You get something like this:

```
[2026-01-09T16:30:01Z INFO  martin_cp] [1m05s] 29% @ 400.5/s | ✓ 5382 □ 20300 | 2m35s left
[2026-01-09T16:30:03Z INFO  martin_cp] [1m07s] 36% @ 486.0/s | ✓ 6000 □ 26173 | 1m54s left
[2026-01-09T16:30:05Z INFO  martin_cp] [1m09s] 40% @ 514.3/s | ✓ 6592 □ 28500 | 1m42s left
```