### PR TITLE
fix: extract Azure account name from URL path

### DIFF
--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -255,8 +255,7 @@ impl TileSourceConfiguration for PmtConfig {
                     {
                         trace!(
                             "Extracted Azure account '{}' from URL for source {}",
-                            account,
-                            id
+                            account, id
                         );
                         options.insert("account_name".to_string(), account);
                     }


### PR DESCRIPTION
## Summary

- Fixes Azure URL parsing for `az://`, `azure://`, and `adl://` schemes where account is in the URL path
- Extracts the account name from the first path segment when using documented URL format `az://account/container/path.pmtiles`

## Details

The Martin documentation shows `az://account/container/path.pmtiles` as a valid Azure URL format. However, the underlying `object_store` crate expects `az://container/path` with the account name configured separately via options or environment variables.

This PR bridges that gap by:
1. Detecting Azure URL schemes (`az`, `azure`, `adl`)
2. Extracting the account name from the first path segment
3. Reconstructing the URL as `az://container/path`
4. Passing the extracted account name as an option to `object_store`

This makes the documented URL format work as expected without requiring users to separately configure `account_name`.

## Test plan

- [ ] CI tests pass
- [ ] Manual testing with Azure Blob Storage (if available)
- [ ] Verify existing Azure configurations still work (when account_name is already provided, it's not overwritten)

Fixes #2498
