### PR TITLE
refactor: move our request logging to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3796,6 +3796,7 @@ dependencies = [
  "tilejson",
  "tokio",
  "tracing",
+ "tracing-actix-web",
  "tracing-log",
  "tracing-subscriber",
  "tracing-test",
@@ -4040,6 +4041,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "mutually_exclusive_features"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
 
 [[package]]
 name = "native-tls"
@@ -7219,6 +7226,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-actix-web"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca6b15407f9bfcb35f82d0e79e603e1629ece4e91cc6d9e58f890c184dd20af"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ tilejson = "0.4"
 tokio = { version = "1", features = ["macros"] }
 tokio-postgres-rustls = "0.13"
 tracing = "0.1.44"
+tracing-actix-web = "0.7.21"
 tracing-log = { version = "0.2.0", features = ["interest-cache"] }
 tracing-subscriber = { version = "0.3", default-features = false }
 tracing-test = "0.2"

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -154,6 +154,7 @@ thiserror.workspace = true
 tilejson.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
 tracing.workspace = true
+tracing-actix-web.workspace = true
 tracing-log = { workspace = true, features = ["interest-cache"] }
 tracing-subscriber = { workspace = true, default-features = false, features = ["env-filter", "json", "fmt", "std", "ansi", "chrono"] }
 url.workspace = true

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -4,12 +4,13 @@ use std::string::ToString;
 use std::time::Duration;
 
 use actix_web::http::header::CACHE_CONTROL;
-use actix_web::middleware::{Logger, NormalizePath, TrailingSlash};
+use actix_web::middleware::{NormalizePath, TrailingSlash};
 use actix_web::web::Data;
 use actix_web::{App, HttpResponse, HttpServer, Responder, middleware, route, web};
 use futures::TryFutureExt;
 #[cfg(feature = "lambda")]
 use lambda_web::{is_running_on_lambda, run_actix_on_lambda};
+use tracing_actix_web::TracingLogger;
 
 #[cfg(all(feature = "webui", not(docsrs)))]
 use crate::config::args::WebUiMode;
@@ -147,7 +148,7 @@ pub fn new_server(config: SrvConfig, state: ServerState) -> MartinResult<(Server
         #[cfg(feature = "metrics")]
         let app = app.wrap(prometheus.clone());
 
-        app.wrap(Logger::default())
+        app.wrap(TracingLogger::default())
             .wrap(NormalizePath::new(TrailingSlash::MergeOnly))
             .configure(|c| router(c, &config))
     };


### PR DESCRIPTION
In most user facing things, we should be the same.

There are some differences in how this is logged if an error occurs, but being able to attach spans is something that is fairly helpfull.
Reminder: only pretty supports displaying them, as we have configured

https://github.com/maplibre/martin/blob/bb2b608df15e7c44d61b01d5440f1c7443484b83/martin/src/logging.rs#L62

Here is the `pretty` log example

<img width="1035" height="133" alt="image" src="https://github.com/user-attachments/assets/f6905c64-cefa-4564-b2b8-01ea4d5f46d8" />
