### PR TITLE
fix: improve error message if no SVG sprite files are present

### DIFF
--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -26,7 +26,7 @@ pub enum SpriteError {
     InvalidSpriteFilePath(String, PathBuf),
 
     /// No SVG files found in directory.
-    #[error("No sprite files found in {0}")]
+    #[error("No sprite SVG files found in {0}")]
     NoSpriteFilesFound(PathBuf),
 
     /// Failed to read sprite file.

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -166,6 +166,10 @@ pub async fn get_spritesheet(
     for source in sources {
         let paths = get_svg_input_paths(&source.path, true)
             .map_err(|e| SpriteProcessingError(e, source.path.clone()))?;
+        // SpritesheetBuilder::generate will return None if the folder does not contain any SVGs
+        if paths.is_empty() {
+            return Err(SpriteError::NoSpriteFilesFound(source.path.clone()));
+        }
         for path in paths {
             let name = sprite_name(&path, &source.path)
                 .map_err(|e| SpriteProcessingError(e, source.path.clone()))?;


### PR DESCRIPTION
Closes issue #2136 by checking if the returned SVG file paths vector is empty. Also, the error message includes the word SVG now to indicate to the user that they should put SVG files into the folder.