### PR TITLE
style: restrict `unused_trait_names` for trait imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ unused_qualifications = "warn"
 
 [workspace.lints.clippy]
 # Restrictions
-unimplemented = "warn"
-panic_in_result_fn = "warn"
 panic = "warn"
+panic_in_result_fn = "warn"
 todo = "warn"
+unimplemented = "warn"
+unused_trait_names = "warn"
+
 # Pedantics without being too noisy
 pedantic = { level = "warn", priority = -1 }
 derive_partial_eq_without_eq = "allow"

--- a/martin-core/examples/pmtiles-tileserver.rs
+++ b/martin-core/examples/pmtiles-tileserver.rs
@@ -1,6 +1,6 @@
 use actix_web::{App, HttpResponse, HttpServer, Result as ActixResult, web};
 use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesSource};
-use martin_core::tiles::{Source, UrlQuery};
+use martin_core::tiles::{Source as _, UrlQuery};
 use martin_tile_utils::TileCoord;
 use serde::Deserialize;
 

--- a/martin-core/src/config/env.rs
+++ b/martin-core/src/config/env.rs
@@ -110,7 +110,7 @@ mod tests {
     #[cfg(unix)]
     fn test_bad_os_str() {
         use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::ffi::OsStrExt as _;
 
         let bad_utf8 = [0x66, 0x6f, 0x80, 0x6f];
         let os_str = OsStr::from_bytes(&bad_utf8[..]);

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -26,7 +26,7 @@ use bit_set::BitSet;
 use dashmap::{DashMap, Entry};
 use itertools::Itertools as _;
 use pbf_font_tools::freetype::{Face, Library};
-use pbf_font_tools::prost::Message;
+use pbf_font_tools::prost::Message as _;
 use pbf_font_tools::{Fontstack, Glyphs, render_sdf_glyph};
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 pub use spreet::Spritesheet;
 use spreet::resvg::usvg::{Options, Tree};
 use spreet::{Sprite, SpritesheetBuilder, get_svg_input_paths, sprite_name};
-use tokio::io::AsyncReadExt;
+use tokio::io::AsyncReadExt as _;
 use tracing::{info, warn};
 
 use self::SpriteError::{SpriteInstError, SpriteParsingError, SpriteProcessingError};

--- a/martin-core/src/tiles/postgres/tls.rs
+++ b/martin-core/src/tiles/postgres/tls.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io;
 use std::io::BufReader;
 use std::path::PathBuf;
-use std::str::FromStr;
+use std::str::FromStr as _;
 
 use deadpool_postgres::tokio_postgres::Config;
 use deadpool_postgres::tokio_postgres::config::SslMode;

--- a/martin-core/src/tiles/tile.rs
+++ b/martin-core/src/tiles/tile.rs
@@ -1,4 +1,4 @@
-use base64::Engine;
+use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use martin_tile_utils::{TileData, TileInfo};
 

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use martin_core::tiles::Source;
+use martin_core::tiles::Source as _;
 use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesError, PmtilesSource};
 use martin_tile_utils::{Encoding, Format, TileCoord};
 use object_store::local::LocalFileSystem;
@@ -479,7 +479,7 @@ async fn shared_cache_with_unique_instance_ids_can_fetch_same_tile() {
 
 #[tokio::test]
 async fn cache_invalidation_clears_entries() {
-    use pmtiles::DirectoryCache;
+    use pmtiles::DirectoryCache as _;
 
     let cache = test_cache_bytes(CACHE_SIZE_10MB);
     let tile_id = pmtiles::TileId::new(1).unwrap();

--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -509,7 +509,7 @@ mod tests {
 
     #[test]
     fn test_compressed_json_zlib() {
-        use std::io::Write;
+        use std::io::Write as _;
 
         use flate2::write::ZlibEncoder;
 
@@ -533,7 +533,7 @@ mod tests {
 
     #[test]
     fn test_compressed_mlt_zlib() {
-        use std::io::Write;
+        use std::io::Write as _;
 
         use flate2::write::ZlibEncoder;
 
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_compressed_mvt_zlib_fallback() {
-        use std::io::Write;
+        use std::io::Write as _;
 
         use flate2::write::ZlibEncoder;
 

--- a/martin/benches/postgres_discovery.rs
+++ b/martin/benches/postgres_discovery.rs
@@ -5,8 +5,8 @@ use martin::config::file::init_aws_lc_tls;
 use martin::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig};
 use martin_core::config::IdResolver;
 use testcontainers_modules::postgres::Postgres;
-use testcontainers_modules::testcontainers::ImageExt;
-use testcontainers_modules::testcontainers::runners::SyncRunner;
+use testcontainers_modules::testcontainers::ImageExt as _;
+use testcontainers_modules::testcontainers::runners::SyncRunner as _;
 
 // Benchmark sizes
 const SIZES: &[usize] = &[10, 100, 200];

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -13,8 +13,8 @@ use actix_web::http::header::{ACCEPT_ENCODING, AcceptEncoding, Header as _};
 use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
-use futures::TryStreamExt;
-use futures::stream::{self, StreamExt};
+use futures::TryStreamExt as _;
+use futures::stream::{self, StreamExt as _};
 use martin::config::args::{Args, ExtraArgs, MetaArgs, SrvArgs};
 use martin::config::file::{Config, ServerState, read_config};
 use martin::logging::{ensure_martin_core_log_level_matches, init_tracing};
@@ -639,7 +639,7 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use async_trait::async_trait;
     use insta::assert_yaml_snapshot;
@@ -790,7 +790,7 @@ mod tests {
     #[case("-120.0,-90.0,-110.0,40.0", Err("latitude".to_string()))]
     #[case("-120.0,30.0,-110.0,90.0", Err("latitude".to_string()))]
     fn test_check_bboxes(#[case] bbox_str: &str, #[case] expected: Result<String, String>) {
-        use std::str::FromStr;
+        use std::str::FromStr as _;
 
         let bbox_vec = if bbox_str.is_empty() {
             vec![]

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use clap::Parser;
+use clap::Parser as _;
 use martin::MartinResult;
 use martin::config::args::Args;
 use martin::config::file::{Config, read_config};

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -31,7 +31,7 @@ use crate::config::file::FileConfigEnum;
 #[cfg(any(feature = "_tiles", feature = "sprites", feature = "fonts"))]
 use crate::config::file::cache::CacheConfig;
 use crate::config::file::{
-    ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks, UnrecognizedKeys,
+    ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks as _, UnrecognizedKeys,
     UnrecognizedValues, copy_unrecognized_keys_from_config,
 };
 #[cfg(feature = "_tiles")]

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use crate::config::file::mbtiles::MbtConfig;
     use crate::config::file::{
-        ConfigurationLivecycleHooks, FileConfigEnum, FileConfigSource, FileConfigSrc,
+        ConfigurationLivecycleHooks as _, FileConfigEnum, FileConfigSource, FileConfigSrc,
     };
 
     #[test]

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
-use std::str::FromStr;
+use std::str::FromStr as _;
 
 use martin_core::tiles::BoxedSource;
 use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesSource};

--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -767,8 +767,8 @@ mod tests {
     #[tracing_test::traced_test]
     async fn test_nonexistent_tables_functions_generate_warning() {
         use testcontainers_modules::postgres::Postgres;
-        use testcontainers_modules::testcontainers::ImageExt;
-        use testcontainers_modules::testcontainers::runners::AsyncRunner;
+        use testcontainers_modules::testcontainers::ImageExt as _;
+        use testcontainers_modules::testcontainers::runners::AsyncRunner as _;
 
         let container = Postgres::default()
             .with_name("postgis/postgis")

--- a/martin/src/config/file/tiles/postgres/config.rs
+++ b/martin/src/config/file/tiles/postgres/config.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use std::ops::Add as _;
 use std::time::Duration;
 
 use futures::future::try_join;

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -14,7 +14,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::config::args::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT};
-use crate::config::file::postgres::{PostgresInfo, TableInfo};
+use crate::config::file::postgres::{PostgresInfo as _, TableInfo};
 
 /// Map of `PostgreSQL` tables organized by schema, table, and geometry column.
 pub type SqlTableInfoMapMapMap = BTreeMap<String, BTreeMap<String, BTreeMap<String, TableInfo>>>;
@@ -281,7 +281,7 @@ FROM {schema}.{table};
 
 #[must_use]
 pub fn polygon_to_bbox(polygon: &ewkb::Polygon) -> Option<Bounds> {
-    use postgis::{LineString, Point, Polygon};
+    use postgis::{LineString as _, Point as _, Polygon as _};
 
     polygon.rings().next().and_then(|linestring| {
         let mut points = linestring.points();

--- a/martin/src/config/file/tiles/postgres/utils.rs
+++ b/martin/src/config/file/tiles/postgres/utils.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use itertools::Itertools;
+use itertools::Itertools as _;
 use tilejson::TileJSON;
 use tracing::{error, info};
 

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -1,4 +1,4 @@
-use std::string::ToString;
+use std::string::ToString as _;
 
 use actix_middleware_etag::Etag;
 use actix_web::error::{ErrorBadRequest, ErrorNotFound};

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -1,13 +1,13 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::string::ToString;
+use std::string::ToString as _;
 use std::time::Duration;
 
 use actix_web::http::header::CACHE_CONTROL;
 use actix_web::middleware::{NormalizePath, TrailingSlash};
 use actix_web::web::Data;
 use actix_web::{App, HttpResponse, HttpServer, Responder, middleware, route, web};
-use futures::TryFutureExt;
+use futures::TryFutureExt as _;
 #[cfg(feature = "lambda")]
 use lambda_web::{is_running_on_lambda, run_actix_on_lambda};
 use tracing_actix_web::TracingLogger;

--- a/martin/src/srv/sprites.rs
+++ b/martin/src/srv/sprites.rs
@@ -1,4 +1,4 @@
-use std::string::ToString;
+use std::string::ToString as _;
 
 use actix_middleware_etag::Etag;
 use actix_web::error::ErrorNotFound;

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -6,7 +6,7 @@ use actix_web::http::header::{
     Preference,
 };
 use actix_web::web::{Data, Path, Query};
-use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result as ActixResult, route};
+use actix_web::{HttpMessage as _, HttpRequest, HttpResponse, Result as ActixResult, route};
 use futures::future::try_join_all;
 use martin_core::tiles::{BoxedSource, OptTileCache, Tile, TileCache, UrlQuery};
 use martin_tile_utils::{
@@ -323,7 +323,7 @@ pub fn to_encoding(val: ContentEncoding) -> Option<Encoding> {
 
 #[cfg(test)]
 mod tests {
-    use actix_http::header::TryIntoHeaderValue;
+    use actix_http::header::TryIntoHeaderValue as _;
     use rstest::rstest;
     use tilejson::tilejson;
 

--- a/martin/src/srv/tiles/metadata.rs
+++ b/martin/src/srv/tiles/metadata.rs
@@ -1,4 +1,4 @@
-use std::string::ToString;
+use std::string::ToString as _;
 
 use actix_middleware_etag::Etag;
 use actix_web::error::ErrorBadRequest;

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -368,7 +368,7 @@ async fn meta_set_value(file: &Path, key: &str, value: Option<&str>) -> MbtResul
 mod tests {
     use std::path::PathBuf;
 
-    use clap::Parser;
+    use clap::Parser as _;
     use clap::error::ErrorKind;
     use mbtiles::CopyDuplicateMode;
 

--- a/mbtiles/src/bindiff.rs
+++ b/mbtiles/src/bindiff.rs
@@ -6,12 +6,12 @@ use std::time::Instant;
 
 use enum_display::EnumDisplay;
 use flume::{Receiver, Sender, bounded};
-use futures::TryStreamExt;
+use futures::TryStreamExt as _;
 use log::{debug, error, info};
 use martin_tile_utils::{TileCoord, decode_brotli, decode_gzip, encode_brotli, encode_gzip};
 use serde::{Deserialize, Serialize};
 use sqlite_compressions::{BsdiffRawDiffer, Differ as _};
-use sqlx::{Executor, Row, SqliteConnection, query};
+use sqlx::{Executor as _, Row as _, SqliteConnection, query};
 use xxhash_rust::xxh3::xxh3_64;
 
 use crate::MbtType::{Flat, FlatWithHash, Normalized};

--- a/mbtiles/src/copier.rs
+++ b/mbtiles/src/copier.rs
@@ -6,7 +6,7 @@ use log::{debug, info, trace, warn};
 use martin_tile_utils::{MAX_ZOOM, bbox_to_xyz};
 use serde::{Deserialize, Serialize};
 use sqlite_hashes::rusqlite::Connection;
-use sqlx::{Connection as _, Executor as _, Row, SqliteConnection, query};
+use sqlx::{Connection as _, Executor as _, Row as _, SqliteConnection, query};
 use tilejson::Bounds;
 
 use crate::AggHashType::Verify;

--- a/mbtiles/src/mbtiles.rs
+++ b/mbtiles/src/mbtiles.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use sqlite_compressions::{register_bsdiffraw_functions, register_gzip_functions};
 use sqlite_hashes::register_md5_functions;
 use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::{Connection as _, Executor, Row, SqliteConnection, SqliteExecutor, Statement, query};
+use sqlx::{
+    Connection as _, Executor as _, Row as _, SqliteConnection, SqliteExecutor, Statement as _,
+    query,
+};
 
 use crate::bindiff::PatchType;
 use crate::errors::{MbtError, MbtResult};
@@ -334,7 +337,7 @@ impl Mbtiles {
     where
         &'e mut T: SqliteExecutor<'e>,
     {
-        use futures::StreamExt;
+        use futures::StreamExt as _;
 
         let query = query! {"SELECT zoom_level, tile_column, tile_row FROM tiles"};
         let stream = query.fetch(conn);
@@ -381,7 +384,7 @@ impl Mbtiles {
     where
         &'e mut T: SqliteExecutor<'e>,
     {
-        use futures::StreamExt;
+        use futures::StreamExt as _;
 
         let query = query! {"SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles"};
         let stream = query.fetch(conn);

--- a/mbtiles/src/metadata.rs
+++ b/mbtiles/src/metadata.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 use std::path::PathBuf;
-use std::str::FromStr;
+use std::str::FromStr as _;
 
-use futures::TryStreamExt;
+use futures::TryStreamExt as _;
 use log::{info, warn};
 use serde::Serialize;
 use serde_json::{Value as JSONValue, Value, json};

--- a/mbtiles/src/queries.rs
+++ b/mbtiles/src/queries.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use martin_tile_utils::MAX_ZOOM;
 use sqlite_compressions::rusqlite::Connection;
-use sqlx::{Executor as _, Row, SqliteConnection, SqliteExecutor, query};
+use sqlx::{Executor as _, Row as _, SqliteConnection, SqliteExecutor, query};
 
 use crate::MbtError::InvalidZoomValue;
 use crate::MbtType;

--- a/mbtiles/src/summary.rs
+++ b/mbtiles/src/summary.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
-use std::str::FromStr;
+use std::str::FromStr as _;
 
 use martin_tile_utils::{get_zoom_precision, xyz_to_bbox};
 use serde::Serialize;

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -7,7 +7,7 @@ use martin_tile_utils::{Format, MAX_ZOOM, TileInfo};
 use serde::Serialize;
 use serde_json::Value;
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Row, SqliteConnection, SqliteExecutor, query};
+use sqlx::{Row as _, SqliteConnection, SqliteExecutor, query};
 use tilejson::TileJSON;
 
 use crate::MbtError::{

--- a/mbtiles/tests/copy.rs
+++ b/mbtiles/tests/copy.rs
@@ -18,7 +18,7 @@ use mbtiles::{
 use pretty_assertions::assert_eq as pretty_assert_eq;
 use rstest::{fixture, rstest};
 use serde::Serialize;
-use sqlx::{Executor as _, Row, SqliteConnection, query, query_as};
+use sqlx::{Executor as _, Row as _, SqliteConnection, query, query_as};
 use tokio::runtime::Handle;
 
 const GZIP_TILES: &str = "UPDATE tiles SET tile_data = gzip(tile_data);";

--- a/mbtiles/tests/streams.rs
+++ b/mbtiles/tests/streams.rs
@@ -1,4 +1,4 @@
-use futures::{StreamExt, TryStreamExt};
+use futures::{StreamExt as _, TryStreamExt as _};
 use martin_tile_utils::{Tile, TileCoord};
 use mbtiles::{MbtError, Mbtiles, create_metadata_table};
 use sqlx::{Executor as _, SqliteConnection, query};


### PR DESCRIPTION
pedantic is just too weak... restrictions are so much more fun!