### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       - run: npm clean-install --no-fund
         working-directory: martin/martin-ui
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       - name: Init database
         run: tests/fixtures/initdb.sh
@@ -111,9 +111,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - run: just env-info
       - run: just clippy
@@ -129,7 +129,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@69e777b377e4ec209ddad9426ae3e0c1008b0ef3 # v2.64.0
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'cargo-shear,just' }
 
       - run: just shear
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: "cargo-zigbuild,just" }
       - name: Install zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
@@ -207,7 +207,7 @@ jobs:
         run: tests/fixtures/initdb.sh
         env:
           PGPORT: ${{ job.services.postgres.ports[5432] }}
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: sqlx-cli }
 
       # we want to test our docker images before we push them to the registry
@@ -239,12 +239,12 @@ jobs:
         # https://github.com/docker/setup-buildx-action
         with: { install: true, platforms: 'linux/amd64,linux/arm64' }
       - name: Download build artifact build-aarch64-unknown-linux-musl
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-unknown-linux-musl', path: 'target_releases/linux/arm64/' }
       - name: Mark target_releases/linux/arm64/* as executable
         run: chmod +x target_releases/linux/arm64/*
       - name: Download build artifact build-x86_64-unknown-linux-musl
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-musl', path: 'target_releases/linux/amd64/' }
       - name: Mark target_releases/linux/amd64/* as executable
         run: chmod +x target_releases/linux/amd64/*
@@ -416,13 +416,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: "just" }
       # the macOS x86 runners are 3x slower than all other runners.
       # We need to cache here to not spend 30 minutes on each build.
       # We cannot cache the others as well because we only have 10GB of cache
       - if: matrix.target == 'x86_64-apple-darwin' && github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Rust Versions
         run: rustc --version && cargo --version
       - name: Install NASM for rustls/aws-lc-rs on Windows
@@ -450,10 +450,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       - name: Download build artifact build-x86_64-unknown-linux-musl
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/' }
       - run: just test-lambda target/martin
 
@@ -498,12 +498,12 @@ jobs:
         shell: powershell
       - name: Install and run Postgis (Windows)
         if: matrix.os == 'windows-latest'
-        uses: nyurik/action-setup-postgis@5183a5e26ade31809faed263cd4d638e144fe186 # v2.2
+        uses: nyurik/action-setup-postgis@e54fc643200ee809b4711c3f537c433dfbeba056 # v2.3
         id: pg
         with: { username: 'postgres', password: 'postgres', database: 'test', postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
       - name: Install and run Postgis (Macos)
         if: matrix.os == 'macos-13'
-        uses: nyurik/action-setup-postgis@5183a5e26ade31809faed263cd4d638e144fe186 # v2.2
+        uses: nyurik/action-setup-postgis@e54fc643200ee809b4711c3f537c433dfbeba056 # v2.3
         with: { username: 'postgres', password: 'postgres', database: 'test', postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
       - name: Install and run Postgis (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -544,7 +544,7 @@ jobs:
           HTML_DIR: ${{ steps.nginx.outputs.html-dir }}
         run: cp -r tests/fixtures/pmtiles2/* "$HTML_DIR"
       - name: Download build artifact build-${{ matrix.target }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-${{ matrix.target }}
           path: target/
@@ -584,7 +584,7 @@ jobs:
           fi
       - name: Download Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-debian-x86_64', path: 'target/' }
       - name: Tests Debian package (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -668,10 +668,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       # cache for the unit-test to be run against postgres to be acceptably slow
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Run NGINX
         uses: nyurik/action-setup-nginx@612ee9cb839ad727832cda16359452e7e14dd521 # v1.1
@@ -695,7 +695,7 @@ jobs:
         env:
           JOB_SERVICES_POSTGRES_ID: ${{ job.services.postgres.id }}
       - name: Download build artifact build-x86_64-unknown-linux-gnu
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target_releases/' }
       - name: Set up gdal-bin and sqlite3-tools
         run: sudo apt update && sudo apt-get install -y gdal-bin sqlite3-tools
@@ -716,7 +716,7 @@ jobs:
         env:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
       - name: Download Debian package
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-debian-x86_64', path: 'target_releases/' }
       - name: Tests Debian package
         run: |
@@ -786,31 +786,31 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@763e3324d4fd026c9bd284c504378585777a87d5 # v2.62.57
+      - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       - name: Download build artifact build-aarch64-apple-darwin
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-apple-darwin', path: 'target/aarch64-apple-darwin' }
       - name: Download build artifact build-x86_64-apple-darwin
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-apple-darwin', path: 'target/x86_64-apple-darwin' }
       - name: Download build artifact build-aarch64-unknown-linux-gnu
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-unknown-linux-gnu', path: 'target/aarch64-unknown-linux-gnu' }
       - name: Download build artifact build-x86_64-unknown-linux-gnu
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-gnu', path: 'target/x86_64-unknown-linux-gnu' }
       - name: Download build artifact build-aarch64-unknown-linux-musl
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-unknown-linux-musl', path: 'target/aarch64-unknown-linux-musl' }
       - name: Download build artifact build-x86_64-unknown-linux-musl
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/x86_64-unknown-linux-musl' }
       - name: Download build artifact build-x86_64-pc-windows-msvc
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-pc-windows-msvc', path: 'target/x86_64-pc-windows-msvc' }
       - name: Download build artifact build-debian-x86_64
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-debian-x86_64', path: 'target/debian-x86_64' }
 
       - name: Package
@@ -853,7 +853,7 @@ jobs:
         with: { subject-path: 'target/files/*' }
       - name: Publish with artifacts
         if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'martin-v') }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@1853d73993c8ca1b2c9c1a7fede39682d0ab5c2a # v2.5.3
         with:
           files: 'target/files/*'
           generate_release_notes: false
@@ -864,7 +864,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish without artifacts
         if: ${{ github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'martin-v') }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@1853d73993c8ca1b2c9c1a7fede39682d0ab5c2a # v2.5.3
         with:
           generate_release_notes: false
           draft: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5053,7 +5053,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "pmtiles"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c486a6a72478ada5c0b0275bed2ecdedb0f6de626432ee36bc4f45a3579450be"
+checksum = "e7bdf28ba26f64afe475f1f08f5f3b7b9d0388d1f267e411fb4352778432b1f3"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,24 +2573,23 @@ dependencies = [
 
 [[package]]
 name = "freetype-rs"
-version = "0.38.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d228d6de56c90dd7585341f341849441b3490180c62d27133e525eb726809b4"
+checksum = "d59c337e64822dd56a3a83ed75a662a470736bdb3a9fabfb588dff276b94a4e0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
  "freetype-sys",
  "libc",
 ]
 
 [[package]]
 name = "freetype-sys"
-version = "0.23.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab537ce43cab850c64b4cdc390ce7e4f47f877485ddc323208e268280c308ae"
+checksum = "643148ca6cbad6bec384b52fbe1968547d578c4efe83109e035c43a71734ff88"
 dependencies = [
  "cc",
- "libz-sys",
- "pkg-config",
+ "libc",
 ]
 
 [[package]]
@@ -3744,18 +3743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -6016,12 +6003,12 @@ dependencies = [
 
 [[package]]
 name = "sdf_glyph_renderer"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672e58ce949c46be42fae549e86cc32c869a292fb40913d5f985decb45c5bde3"
+checksum = "8b05c114d181e20b509e03b05856cc5823bc6189d581c276fe37c5ebc5e3b3b9"
 dependencies = [
  "freetype-rs",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,23 +2573,24 @@ dependencies = [
 
 [[package]]
 name = "freetype-rs"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59c337e64822dd56a3a83ed75a662a470736bdb3a9fabfb588dff276b94a4e0"
+checksum = "b1fad2be0bf06af23adddcf6cd143c94ff0ba3b329691f92d1a38dae5c5aeebf"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "freetype-sys",
  "libc",
 ]
 
 [[package]]
 name = "freetype-sys"
-version = "0.17.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643148ca6cbad6bec384b52fbe1968547d578c4efe83109e035c43a71734ff88"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3459,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
 dependencies = [
  "console 0.15.11",
  "once_cell",
@@ -3469,9 +3470,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "tempfile",
- "toml_edit 0.23.10+spec-1.0.0",
- "toml_writer",
+ "toml",
 ]
 
 [[package]]
@@ -3692,9 +3691,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.25.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
 dependencies = [
  "cc",
 ]
@@ -6003,12 +6002,12 @@ dependencies = [
 
 [[package]]
 name = "sdf_glyph_renderer"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b05c114d181e20b509e03b05856cc5823bc6189d581c276fe37c5ebc5e3b3b9"
+checksum = "b6a391d25396126750d0e42993e33727291db4d489d8b0d0138659acb71510d0"
 dependencies = [
  "freetype-rs",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7197,12 +7196,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+name = "toml"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -7216,27 +7215,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap 2.13.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
@@ -7249,12 +7233,6 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6108,15 +6108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_tuple"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "libdeflater"
-version = "1.25.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
 dependencies = [
  "libdeflate-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "freetype-rs"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fad2be0bf06af23adddcf6cd143c94ff0ba3b329691f92d1a38dae5c5aeebf"
+checksum = "6d228d6de56c90dd7585341f341849441b3490180c62d27133e525eb726809b4"
 dependencies = [
  "bitflags 2.11.0",
  "freetype-sys",
@@ -2584,12 +2584,12 @@ dependencies = [
 
 [[package]]
 name = "freetype-sys"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+checksum = "eab537ce43cab850c64b4cdc390ce7e4f47f877485ddc323208e268280c308ae"
 dependencies = [
  "cc",
- "libc",
+ "libz-sys",
  "pkg-config",
 ]
 
@@ -3460,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.3"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console 0.15.11",
  "once_cell",
@@ -3470,7 +3470,9 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "toml",
+ "tempfile",
+ "toml_edit 0.23.10+spec-1.0.0",
+ "toml_writer",
 ]
 
 [[package]]
@@ -3691,18 +3693,18 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805824325366c44599dfeb62850fe3c7d7b3e3d75f9ab46785bc7dba3676815c"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b270bcc7e9d6dce967a504a55b1b0444f966aa9184e8605b531bc0492abb30bb"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -3742,6 +3744,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3860,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3915,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix-web",
  "approx",
@@ -3963,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -4013,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -5053,7 +5067,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6002,9 +6016,9 @@ dependencies = [
 
 [[package]]
 name = "sdf_glyph_renderer"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a391d25396126750d0e42993e33727291db4d489d8b0d0138659acb71510d0"
+checksum = "672e58ce949c46be42fae549e86cc32c869a292fb40913d5f985decb45c5bde3"
 dependencies = [
  "freetype-rs",
  "thiserror 2.0.18",
@@ -6105,6 +6119,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -7187,12 +7210,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7206,12 +7229,27 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -7224,6 +7262,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.1"
-martin-core = { path = "./martin-core", version = "0.3.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.10" }
-mbtiles = { path = "./mbtiles", version = "0.15.2" }
+martin-core = { path = "./martin-core", version = "0.3.1", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.11" }
+mbtiles = { path = "./mbtiles", version = "0.15.3" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 object_store = { version = "0.13.1", features = ["gcp", "aws", "azure", "fs", "http"] }
 pbf_font_tools = { version = "3.1.0", features = ["freetype"] }
-pmtiles = { version = "0.20.0", features = ["tilejson", "object-store"] }
+pmtiles = { version = "0.21.0", features = ["tilejson", "object-store"] }
 png = "0.18.0"
 postgis = "0.9"
 postgres = { version = "0.19", features = ["with-time-0_3", "with-uuid-1", "with-serde_json-1"] }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.3.1
+    image: ghcr.io/maplibre/martin:1.4.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.3.1 \
+           ghcr.io/maplibre/martin:1.4.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.3.1
+    image: ghcr.io/maplibre/martin:1.4.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.3.1
+  ghcr.io/maplibre/martin:1.4.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.3.1 \
+  ghcr.io/maplibre/martin:1.4.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.3.1
+  ghcr.io/maplibre/martin:1.4.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.3.1
+  ghcr.io/maplibre/martin:1.4.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.3.1
+  ghcr.io/maplibre/martin:1.4.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.3.1 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.4.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.3.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.4.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -205,7 +205,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.3.1 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.4.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/maplibre/martin/compare/martin-core-v0.3.0...martin-core-v0.3.1) - 2026-03-14
+
+### Added
+
+- Add retry mechanism on locked/busy mbtiles files ([#2572](https://github.com/maplibre/martin/pull/2572))
+
+### Other
+
+- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
+- feature-gate PostgreSQL tests to remove external dependencies from `cargo test` ([#2558](https://github.com/maplibre/martin/pull/2558))
+
 ## [0.3.0](https://github.com/maplibre/martin/compare/martin-core-v0.2.6...martin-core-v0.3.0) - 2026-02-11
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -80,6 +80,7 @@ impl PmtilesSource {
             TileType::Jpeg => Format::Jpeg.into(),
             TileType::Webp => Format::Webp.into(),
             TileType::Avif => Format::Avif.into(),
+            TileType::Mlt => Format::Mlt.into(),
             TileType::Unknown => {
                 return Err(PmtilesError::UnknownTileType(
                     id.clone(),

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/maplibre/martin/compare/martin-v1.3.1...martin-v1.4.0) - 2026-03-14
+
+### Added
+
+- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))
+- Migrate mdbooks to zensical ([#2576](https://github.com/maplibre/martin/pull/2576))
+- *(martin-cp)* indicativ based progress bar ([#2495](https://github.com/maplibre/martin/pull/2495))
+- Add retry mechanism on locked/busy mbtiles files ([#2572](https://github.com/maplibre/martin/pull/2572))
+
+### Fixed
+
+- *(ui)* render MLT tiles correctly in Tile Inspector ([#2601](https://github.com/maplibre/martin/pull/2601))
+- redirect ignoring `--route-prefix` for .pbf tile requests ([#2599](https://github.com/maplibre/martin/pull/2599))
+- restrict zooming and panning on data inspector ([#2574](https://github.com/maplibre/martin/pull/2574))
+- Accept any INT-containing type in MBTiles validation to be an integer ([#2560](https://github.com/maplibre/martin/pull/2560))
+
+### Other
+
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 9 updates ([#2608](https://github.com/maplibre/martin/pull/2608))
+- *(deps-dev)* Bump undici from 7.21.0 to 7.24.1 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2602](https://github.com/maplibre/martin/pull/2602))
+- *(deps)* autoupdate pre-commit ([#2592](https://github.com/maplibre/martin/pull/2592))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2577](https://github.com/maplibre/martin/pull/2577))
+- *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2575](https://github.com/maplibre/martin/pull/2575))
+- *(deps)* autoupdate pre-commit ([#2567](https://github.com/maplibre/martin/pull/2567))
+- rename the `webp.sql` fixture to `webp-no-primary.sql` ([#2564](https://github.com/maplibre/martin/pull/2564))
+- more cfg magic instead of #[allow(unused_variables)] ([#2563](https://github.com/maplibre/martin/pull/2563))
+- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
+- feature-gate PostgreSQL tests to remove external dependencies from `cargo test` ([#2558](https://github.com/maplibre/martin/pull/2558))
+
 ## [1.3.1](https://github.com/maplibre/martin/compare/martin-v1.3.0...martin-v1.3.1) - 2026-02-11
 
 ### Added

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -12,17 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ZSTD support
 
 If your browser prefers this, we will now start sending ZSTD (or deflate) compressed tiles your way.
-Done in [#2597](https://github.com/maplibre/martin/pull/2597) by [@
-nuts-rice](https://github.com/
-nuts-rice)
+Done in [#2597](https://github.com/maplibre/martin/pull/2597) by [@nuts-rice](https://github.com/nuts-rice)
 
 ### A new documentation site
 
 We migrated our documentation to zenzical, a more modern documentation platform.
 Just have a look for yourself, does it not look pretty? -> https://maplibre.org/martin
 Done in [#2576](https://github.com/maplibre/martin/pull/2576) by [@
-nuts-rice](https://github.com/
-nuts-rice)
+manbhav234](https://github.com/
+manbhav234)
 
 ### Added
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,12 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0](https://github.com/maplibre/martin/compare/martin-v1.3.1...martin-v1.4.0) - 2026-03-14
 
+### ZSTD support
+
+If your browser prefers this, we will now start sending ZSTD (or deflate) compressed tiles your way.
+Done in [#2597](https://github.com/maplibre/martin/pull/2597) by [@
+nuts-rice](https://github.com/
+nuts-rice)
+
+### A new documentation site
+
+We migrated our documentation to zenzical, a more modern documentation platform.
+Just have a look for yourself, does it not look pretty? -> https://maplibre.org/martin
+Done in [#2576](https://github.com/maplibre/martin/pull/2576) by [@
+nuts-rice](https://github.com/
+nuts-rice)
+
 ### Added
 
-- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))
-- Migrate mdbooks to zensical ([#2576](https://github.com/maplibre/martin/pull/2576))
-- *(martin-cp)* indicativ based progress bar ([#2495](https://github.com/maplibre/martin/pull/2495))
-- Add retry mechanism on locked/busy mbtiles files ([#2572](https://github.com/maplibre/martin/pull/2572))
+- *(martin-cp)* now has a prettier, indicativ based progress bar ([#2495](https://github.com/maplibre/martin/pull/2495))
+- Add retry mechanism on locked/busy mbtiles files was added ([#2572](https://github.com/maplibre/martin/pull/2572))
 
 ### Fixed
 
@@ -25,16 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 9 updates ([#2608](https://github.com/maplibre/martin/pull/2608))
-- *(deps-dev)* Bump undici from 7.21.0 to 7.24.1 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2602](https://github.com/maplibre/martin/pull/2602))
-- *(deps)* autoupdate pre-commit ([#2592](https://github.com/maplibre/martin/pull/2592))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2577](https://github.com/maplibre/martin/pull/2577))
-- *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2575](https://github.com/maplibre/martin/pull/2575))
-- *(deps)* autoupdate pre-commit ([#2567](https://github.com/maplibre/martin/pull/2567))
 - rename the `webp.sql` fixture to `webp-no-primary.sql` ([#2564](https://github.com/maplibre/martin/pull/2564))
 - more cfg magic instead of #[allow(unused_variables)] ([#2563](https://github.com/maplibre/martin/pull/2563))
 - More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
 - feature-gate PostgreSQL tests to remove external dependencies from `cargo test` ([#2558](https://github.com/maplibre/martin/pull/2558))
+- Bump some dependencys ([#2608](https://github.com/maplibre/martin/pull/2608), [#2602](https://github.com/maplibre/martin/pull/2602), [#2592](https://github.com/maplibre/martin/pull/2592), [#2577](https://github.com/maplibre/martin/pull/2577), [#2575](https://github.com/maplibre/martin/pull/2575), [#2567](https://github.com/maplibre/martin/pull/2567))
 
 ## [1.3.1](https://github.com/maplibre/martin/compare/martin-v1.3.0...martin-v1.3.1) - 2026-02-11
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.3.1"
+version = "1.4.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -60,5 +60,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/maplibre/martin/compare/mbtiles-v0.15.2...mbtiles-v0.15.3) - 2026-03-14
+
+### Added
+
+- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))
+
+### Fixed
+
+- Accept any INT-containing type in MBTiles validation to be an integer ([#2560](https://github.com/maplibre/martin/pull/2560))
+
+### Other
+
+- rename the `webp.sql` fixture to `webp-no-primary.sql` ([#2564](https://github.com/maplibre/martin/pull/2564))
+- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
+
 ## [0.15.2](https://github.com/maplibre/martin/compare/mbtiles-v0.15.1...mbtiles-v0.15.2) - 2026-02-11
 
 ### Other

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))
+- *(srv)* resolve some compression TODOS which adds zstd support ([#2597](https://github.com/maplibre/martin/pull/2597))
 
 ### Fixed
 

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.6.10 -> 0.6.11 (✓ API compatible changes)
* `mbtiles`: 0.15.2 -> 0.15.3 (✓ API compatible changes)
* `martin-core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `martin`: 1.3.1 -> 1.4.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.15.3](https://github.com/maplibre/martin/compare/mbtiles-v0.15.2...mbtiles-v0.15.3) - 2026-03-14

### Added

- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))

### Fixed

- Accept any INT-containing type in MBTiles validation to be an integer ([#2560](https://github.com/maplibre/martin/pull/2560))

### Other

- rename the `webp.sql` fixture to `webp-no-primary.sql` ([#2564](https://github.com/maplibre/martin/pull/2564))
- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
</blockquote>

## `martin-core`

<blockquote>

## [0.3.1](https://github.com/maplibre/martin/compare/martin-core-v0.3.0...martin-core-v0.3.1) - 2026-03-14

### Added

- Add retry mechanism on locked/busy mbtiles files ([#2572](https://github.com/maplibre/martin/pull/2572))

### Other

- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
- feature-gate PostgreSQL tests to remove external dependencies from `cargo test` ([#2558](https://github.com/maplibre/martin/pull/2558))
</blockquote>

## `martin`

<blockquote>

## [1.4.0](https://github.com/maplibre/martin/compare/martin-v1.3.1...martin-v1.4.0) - 2026-03-14

### Added

- *(srv)* resolve some compression TODOS ([#2597](https://github.com/maplibre/martin/pull/2597))
- Migrate mdbooks to zensical ([#2576](https://github.com/maplibre/martin/pull/2576))
- *(martin-cp)* indicativ based progress bar ([#2495](https://github.com/maplibre/martin/pull/2495))
- Add retry mechanism on locked/busy mbtiles files ([#2572](https://github.com/maplibre/martin/pull/2572))

### Fixed

- *(ui)* render MLT tiles correctly in Tile Inspector ([#2601](https://github.com/maplibre/martin/pull/2601))
- redirect ignoring `--route-prefix` for .pbf tile requests ([#2599](https://github.com/maplibre/martin/pull/2599))
- restrict zooming and panning on data inspector ([#2574](https://github.com/maplibre/martin/pull/2574))
- Accept any INT-containing type in MBTiles validation to be an integer ([#2560](https://github.com/maplibre/martin/pull/2560))

### Other

- *(deps)* Bump the all-npm-version-updates group across 2 directories with 9 updates ([#2608](https://github.com/maplibre/martin/pull/2608))
- *(deps-dev)* Bump undici from 7.21.0 to 7.24.1 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2602](https://github.com/maplibre/martin/pull/2602))
- *(deps)* autoupdate pre-commit ([#2592](https://github.com/maplibre/martin/pull/2592))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 13 updates ([#2577](https://github.com/maplibre/martin/pull/2577))
- *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2575](https://github.com/maplibre/martin/pull/2575))
- *(deps)* autoupdate pre-commit ([#2567](https://github.com/maplibre/martin/pull/2567))
- rename the `webp.sql` fixture to `webp-no-primary.sql` ([#2564](https://github.com/maplibre/martin/pull/2564))
- more cfg magic instead of #[allow(unused_variables)] ([#2563](https://github.com/maplibre/martin/pull/2563))
- More restrictive expects ([#2562](https://github.com/maplibre/martin/pull/2562))
- feature-gate PostgreSQL tests to remove external dependencies from `cargo test` ([#2558](https://github.com/maplibre/martin/pull/2558))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).