### PR TITLE
chore: More restrictive expects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ unused_qualifications = "warn"
 
 [workspace.lints.clippy]
 # Restrictions
+as_underscore = "warn"
 panic = "warn"
 panic_in_result_fn = "warn"
 todo = "warn"

--- a/martin-core/src/tiles/cog/image.rs
+++ b/martin-core/src/tiles/cog/image.rs
@@ -3,8 +3,9 @@ use std::io::{BufWriter, Read as _, Seek as _, SeekFrom};
 use std::path::Path;
 
 use martin_tile_utils::{Format, TileCoord, TileData};
+use tiff::ColorType;
+use tiff::decoder::Decoder;
 use tiff::tags::CompressionMethod;
-use tiff::{ColorType, decoder::Decoder};
 
 use crate::tiles::cog::CogError;
 
@@ -32,7 +33,6 @@ pub struct Image {
 }
 
 impl Image {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ifd_index: usize,
         zoom_level: u8,
@@ -281,8 +281,9 @@ fn encode_as_png(
 
 #[cfg(test)]
 mod tests {
-    use crate::tiles::cog::image::{Image, merge_jpeg_tables_with_tile};
     use martin_tile_utils::TileCoord;
+
+    use crate::tiles::cog::image::{Image, merge_jpeg_tables_with_tile};
 
     #[test]
     fn can_calculate_correct_chunk_index() {

--- a/martin-core/src/tiles/cog/source.rs
+++ b/martin-core/src/tiles/cog/source.rs
@@ -36,7 +36,7 @@ pub struct CogSource {
 
 impl CogSource {
     /// Creates a new COG tile source from a file path.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub fn new(id: String, path: PathBuf) -> Result<Self, CogError> {
         let tif_file =
             File::open(&path).map_err(|e: std::io::Error| CogError::IoError(e, path.clone()))?;
@@ -381,13 +381,13 @@ fn get_tiles_origin(tile_size: u32, resolution: f64, origin: [f64; 2]) -> Option
     let xf = ((origin[0] + (EARTH_CIRCUMFERENCE / 2.0)) / tile_size_mercator_metres).floor();
     let yf = (((EARTH_CIRCUMFERENCE / 2.0) - origin[1]) / tile_size_mercator_metres).floor();
     let tile_origin_x = if xf.is_finite() && xf >= 0.0 && xf <= f64::from(u32::MAX) {
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         Some(xf as u32)
     } else {
         None
     }?;
     let tile_origin_y = if yf.is_finite() && yf >= 0.0 && yf <= f64::from(u32::MAX) {
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         Some(yf as u32)
     } else {
         None
@@ -544,10 +544,12 @@ fn get_extent(
 
 #[cfg(test)]
 mod tests {
-    use crate::tiles::cog::CogSource;
-    use rstest::rstest;
     use std::path::Path;
+
+    use rstest::rstest;
     use tilejson::{Bounds, Center};
+
+    use crate::tiles::cog::CogSource;
 
     #[rstest]
     #[case("usda_naip_256_lzw_z3".to_string(), Center {

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -307,9 +307,11 @@ fn write_duration(f: &mut impl std::fmt::Write, secs: f32) -> std::fmt::Result {
     } else if secs < 1. {
         write!(f, "<1s")
     } else {
-        // we've already handled cases of inf, or negative
-        #[allow(clippy::cast_possible_truncation)]
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "we've already handled cases of inf, or negative"
+        )]
         let secs = secs.ceil() as u64;
 
         let (mins, secs) = (secs / 60, secs % 60);

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -102,7 +102,7 @@ impl Args {
         #[cfg_attr(
             not(feature = "_tiles"),
             expect(
-                clippy::unused_mut,
+                unused_mut,
                 reason = "postgres may modify the cli strings to process input params"
             )
         )]

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -99,7 +99,13 @@ impl Args {
 
         self.srv.merge_into_config(&mut config.srv);
 
-        #[allow(unused_mut)]
+        #[cfg_attr(
+            not(feature = "postgres"),
+            expect(
+                clippy::unused_mut,
+                reason = "postgres may modify the cli strings to process input params"
+            )
+        )]
         let mut cli_strings = Arguments::new(self.meta.connection);
 
         #[cfg(feature = "postgres")]

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -100,7 +100,7 @@ impl Args {
         self.srv.merge_into_config(&mut config.srv);
 
         #[cfg_attr(
-            not(feature = "postgres"),
+            not(feature = "_tiles"),
             expect(
                 clippy::unused_mut,
                 reason = "postgres may modify the cli strings to process input params"

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -334,7 +334,7 @@ impl Config {
     #[cfg(feature = "_tiles")]
     async fn resolve_tile_sources(
         &mut self,
-        #[allow(unused_variables)] idr: &IdResolver,
+        idr: &IdResolver,
         #[cfg(feature = "pmtiles")] pmtiles_cache: PmtCache,
     ) -> MartinResult<(TileSources, Vec<TileSourceWarning>)> {
         let mut sources_and_warnings: Vec<BoxFuture<_>> = Vec::new();

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -29,20 +29,22 @@ pub struct InnerStyleConfig {
 
 impl ConfigurationLivecycleHooks for InnerStyleConfig {
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
-        #[allow(unused_mut)]
-        let mut keys = self
+        let keys = self
             .unrecognized
             .keys()
             .cloned()
             .collect::<UnrecognizedKeys>();
         #[cfg(all(feature = "unstable-rendering", target_os = "linux"))]
-        match &self.rendering {
-            OptBoolObj::NoValue | OptBoolObj::Bool(_) => {}
-            OptBoolObj::Object(o) => keys.extend(
-                o.get_unrecognized_keys()
-                    .iter()
-                    .map(|k| format!("rendering.{k}")),
-            ),
+        {
+            let mut keys = keys;
+            if let OptBoolObj::Object(o) = &self.rendering {
+                keys.extend(
+                    o.get_unrecognized_keys()
+                        .iter()
+                        .map(|k| format!("rendering.{k}")),
+                );
+            };
+            return keys;
         }
         keys
     }

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -29,22 +29,22 @@ pub struct InnerStyleConfig {
 
 impl ConfigurationLivecycleHooks for InnerStyleConfig {
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
-        let keys = self
+        #[cfg_attr(
+            not(all(feature = "unstable-rendering", target_os = "linux")),
+            expect(unused_mut, reason = "to warn for unrecognized keys")
+        )]
+        let mut keys = self
             .unrecognized
             .keys()
             .cloned()
             .collect::<UnrecognizedKeys>();
         #[cfg(all(feature = "unstable-rendering", target_os = "linux"))]
-        {
-            let mut keys = keys;
-            if let OptBoolObj::Object(o) = &self.rendering {
-                keys.extend(
-                    o.get_unrecognized_keys()
-                        .iter()
-                        .map(|k| format!("rendering.{k}")),
-                );
-            };
-            return keys;
+        if let OptBoolObj::Object(o) = &self.rendering {
+            keys.extend(
+                o.get_unrecognized_keys()
+                    .iter()
+                    .map(|k| format!("rendering.{k}")),
+            );
         }
         keys
     }

--- a/mbtiles/src/bindiff.rs
+++ b/mbtiles/src/bindiff.rs
@@ -279,7 +279,10 @@ impl BinDiffer<DifferBefore, DifferAfter> for BinDiffDiffer {
     }
 
     async fn insert(&self, value: DifferAfter, conn: &mut SqliteConnection) -> MbtResult<()> {
-        #[expect(clippy::cast_possible_wrap)]
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "the hash wrapping does not change the invariants and sqlite does not support u64"
+        )]
         query(self.insert_sql.as_str())
             .bind(value.coord.z)
             .bind(value.coord.x)


### PR DESCRIPTION
This PR resolves more of the `allow(..)`s in our code and replaces them with `expect(..)` or removes them.

Reasons were added where apparent and cfg_attrs were added where absolutely nessesary.

I also enabled `clippy::as_underscore` because it seemed like a nice thing to enable, but did not provide any occurance. Not sure why this is a restriction, it is fairly bug-prown to do this.