### PR TITLE
feat: add POST /_/reload endpoint for dynamic catalog updates (#288)

### DIFF
--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -68,6 +68,9 @@ pub struct ServerState {
 
     #[cfg(feature = "styles")]
     pub styles: martin_core::styles::StyleSources,
+
+    #[cfg(feature = "postgres")]
+    pub postgres_configs: OptOneMany<super::postgres::PostgresConfig>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -274,6 +277,9 @@ impl Config {
 
             #[cfg(feature = "styles")]
             styles: self.styles.resolve()?,
+
+            #[cfg(feature = "postgres")]
+            postgres_configs: self.postgres.clone(),
         })
     }
 

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -53,8 +53,7 @@ impl Catalog {
 )]
 async fn get_catalog(
     catalog: Data<Catalog>,
-    #[cfg(feature = "_tiles")]
-    tiles: Data<TileSources>,
+    #[cfg(feature = "_tiles")] tiles: Data<TileSources>,
 ) -> impl Responder {
     // Build a fresh catalog from current sources to reflect any refresh updates
     #[cfg(feature = "_tiles")]
@@ -67,10 +66,10 @@ async fn get_catalog(
         #[cfg(feature = "styles")]
         styles: catalog.styles.clone(),
     };
-    
+
     #[cfg(not(feature = "_tiles"))]
     let fresh_catalog = catalog.as_ref();
-    
+
     HttpResponse::Ok().json(fresh_catalog)
 }
 
@@ -119,7 +118,9 @@ async fn post_reload(
                         total_updated += updated;
 
                         let current_count = tiles.source_names().len();
-                        info!("Discovered {added} new sources, updated {updated} existing sources, total now: {current_count}");
+                        info!(
+                            "Discovered {added} new sources, updated {updated} existing sources, total now: {current_count}"
+                        );
                     }
                     Err(e) => {
                         tracing::error!("Failed to instantiate tables: {e}");
@@ -143,9 +144,9 @@ async fn post_reload(
     let source_count = tiles.source_names().len();
     let sources = tiles.source_names();
 
-        info!(
-            "Reload complete - {total_added} added, {total_updated} updated, {source_count} total sources"
-        );
+    info!(
+        "Reload complete - {total_added} added, {total_updated} updated, {source_count} total sources"
+    );
 
     Ok(HttpResponse::Ok().json(json!({
         "status": "success",

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "_tiles")]
+use actix_web::post;
 use actix_web::web::Data;
-use actix_web::{HttpResponse, Responder, middleware, post, route};
+use actix_web::{HttpResponse, Responder, middleware, route};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "_tiles")]
 use serde_json::json;
+#[cfg(feature = "_tiles")]
 use tracing::info;
 
 use crate::MartinResult;

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -53,8 +53,7 @@ impl Catalog {
 )]
 async fn get_catalog(
     _catalog: Data<Catalog>,
-    #[cfg(feature = "_tiles")]
-    tiles: Data<TileSources>,
+    #[cfg(feature = "_tiles")] tiles: Data<TileSources>,
 ) -> impl Responder {
     // Build a fresh catalog from current sources to reflect any refresh updates
     #[cfg(feature = "_tiles")]
@@ -67,10 +66,10 @@ async fn get_catalog(
         #[cfg(feature = "styles")]
         styles: _catalog.styles.clone(),
     };
-    
+
     #[cfg(not(feature = "_tiles"))]
     let fresh_catalog = _catalog.as_ref();
-    
+
     HttpResponse::Ok().json(fresh_catalog)
 }
 
@@ -119,7 +118,9 @@ async fn post_reload(
                         total_updated += updated;
 
                         let current_count = tiles.source_names().len();
-                        info!("Discovered {added} new sources, updated {updated} existing sources, total now: {current_count}");
+                        info!(
+                            "Discovered {added} new sources, updated {updated} existing sources, total now: {current_count}"
+                        );
                     }
                     Err(e) => {
                         tracing::error!("Failed to instantiate tables: {e}");
@@ -143,9 +144,9 @@ async fn post_reload(
     let source_count = tiles.source_names().len();
     let sources = tiles.source_names();
 
-        info!(
-            "Reload complete - {total_added} added, {total_updated} updated, {source_count} total sources"
-        );
+    info!(
+        "Reload complete - {total_added} added, {total_updated} updated, {source_count} total sources"
+    );
 
     Ok(HttpResponse::Ok().json(json!({
         "status": "success",

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -11,6 +11,10 @@ use tracing::info;
 use crate::MartinResult;
 #[cfg(feature = "_catalog")]
 use crate::config::file::ServerState;
+#[cfg(feature = "postgres")]
+use crate::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig};
+#[cfg(feature = "postgres")]
+use crate::config::primitives::{IdResolver, OptOneMany};
 #[cfg(feature = "_tiles")]
 use crate::source::TileSources;
 
@@ -47,46 +51,123 @@ impl Catalog {
     method = "HEAD",
     wrap = "middleware::Compress::default()"
 )]
-async fn get_catalog(catalog: Data<Catalog>) -> impl Responder {
-    HttpResponse::Ok().json(catalog)
+async fn get_catalog(
+    _catalog: Data<Catalog>,
+    #[cfg(feature = "_tiles")]
+    tiles: Data<TileSources>,
+) -> impl Responder {
+    // Build a fresh catalog from current sources to reflect any refresh updates
+    #[cfg(feature = "_tiles")]
+    let fresh_catalog = Catalog {
+        tiles: tiles.get_catalog(),
+        #[cfg(feature = "sprites")]
+        sprites: _catalog.sprites.clone(),
+        #[cfg(feature = "fonts")]
+        fonts: _catalog.fonts.clone(),
+        #[cfg(feature = "styles")]
+        styles: _catalog.styles.clone(),
+    };
+    
+    #[cfg(not(feature = "_tiles"))]
+    let fresh_catalog = _catalog.as_ref();
+    
+    HttpResponse::Ok().json(fresh_catalog)
 }
 
-/// Refresh endpoint to re-discover tile sources.
+/// Reload endpoint to re-discover tile sources.
 ///
 /// Re-runs table/function discovery and updates the catalog
 /// without requiring a server restart.
 ///
-/// # Current Implementation
-/// This endpoint provides the infrastructure for dynamic catalog updates.
-/// Currently returns the current catalog state. Full `PostgreSQL` re-discovery
-/// requires passing the database configuration and pool to this endpoint,
-/// which will be implemented in a follow-up PR.
+/// # Implementation
+/// This endpoint re-discovers `PostgreSQL` tables and functions by:
+/// 1. Re-running the discovery process for each configured `PostgreSQL` connection
+/// 2. Updating the `Arc<DashMap>`-based catalog with newly discovered sources
+/// 3. Returning statistics about added and updated sources
 ///
-/// The `TileSources` struct now includes `upsert_sources()` and `remove_sources()`
-/// methods that enable thread-safe catalog updates using the underlying `DashMap`.
+/// The catalog is updated atomically using `DashMap`, ensuring thread-safety
+/// without explicit locking.
 ///
 /// # Security
 /// Should be restricted to localhost or internal networks only in production.
-#[cfg(feature = "_tiles")]
-#[post("/_/refresh", wrap = "middleware::Compress::default()")]
-async fn post_refresh(tiles: Data<TileSources>) -> impl Responder {
-    info!("Refresh endpoint called");
+#[cfg(all(feature = "_tiles", feature = "postgres"))]
+#[post("/_/reload", wrap = "middleware::Compress::default()")]
+async fn post_reload(
+    tiles: Data<TileSources>,
+    postgres_configs: Data<OptOneMany<PostgresConfig>>,
+) -> actix_web::Result<impl Responder> {
+    info!("Reload endpoint called - re-discovering PostgreSQL sources");
 
-    // TODO: Re-run PostgreSQL discovery when config/pool are available
-    // For now, return current state to prove endpoint works
-    // Example future implementation:
-    // let builder = PostgresAutoDiscoveryBuilder::new(&config, id_resolver).await?;
-    // let (new_sources, _, _) = builder.instantiate_tables().await?;
-    // let (added, updated) = tiles.upsert_sources(new_sources);
+    let mut total_added = 0;
+    let mut total_updated = 0;
+    let id_resolver = IdResolver::default();
+
+    // Re-discover sources for each PostgreSQL configuration
+    for config in postgres_configs.iter() {
+        match PostgresAutoDiscoveryBuilder::new(config, id_resolver.clone()).await {
+            Ok(builder) => {
+                match builder.instantiate_tables().await {
+                    Ok((new_sources, _, warnings)) => {
+                        // Log any warnings
+                        for warning in warnings {
+                            tracing::warn!("Discovery warning: {warning}");
+                        }
+
+                        // Update the catalog
+                        let (added, updated) = tiles.upsert_sources(new_sources);
+                        total_added += added;
+                        total_updated += updated;
+
+                        let current_count = tiles.source_names().len();
+                        info!("Discovered {added} new sources, updated {updated} existing sources, total now: {current_count}");
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to instantiate tables: {e}");
+                        return Ok(HttpResponse::InternalServerError().json(json!({
+                            "status": "error",
+                            "message": format!("Failed to discover tables: {e}"),
+                        })));
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to create PostgreSQL builder: {e}");
+                return Ok(HttpResponse::InternalServerError().json(json!({
+                    "status": "error",
+                    "message": format!("Failed to connect to PostgreSQL: {e}"),
+                })));
+            }
+        }
+    }
 
     let source_count = tiles.source_names().len();
     let sources = tiles.source_names();
 
-    info!("Refresh complete - {source_count} sources in catalog");
+        info!(
+            "Reload complete - {total_added} added, {total_updated} updated, {source_count} total sources"
+        );
+
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "success",
+        "added": total_added,
+        "updated": total_updated,
+        "total_sources": source_count,
+        "sources": sources,
+    })))
+}
+
+// Stub endpoint when postgres feature is not enabled
+#[cfg(all(feature = "_tiles", not(feature = "postgres")))]
+#[post("/_/reload", wrap = "middleware::Compress::default()")]
+async fn post_reload(tiles: Data<TileSources>) -> impl Responder {
+    info!("Reload endpoint called (PostgreSQL feature not enabled)");
+
+    let source_count = tiles.source_names().len();
+    let sources = tiles.source_names();
 
     HttpResponse::Ok().json(json!({
         "status": "ok",
-        "message": "Refresh endpoint is operational. Full PostgreSQL re-discovery will be added in a follow-up PR.",
+        "message": "Reload endpoint requires PostgreSQL feature to be enabled",
         "source_count": source_count,
         "sources": sources,
     }))

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -101,6 +101,8 @@ fn register_services(
 
     #[cfg(feature = "_tiles")]
     {
+        cfg.service(crate::srv::admin::post_refresh);
+
         // Register tile format suffix redirects BEFORE the main tile route
         // because Actix-Web matches routes in registration order
         cfg.service(crate::srv::tiles::content::redirect_tile_ext)

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -101,7 +101,7 @@ fn register_services(
 
     #[cfg(feature = "_tiles")]
     {
-        cfg.service(crate::srv::admin::post_refresh);
+        cfg.service(crate::srv::admin::post_reload);
 
         // Register tile format suffix redirects BEFORE the main tile route
         // because Actix-Web matches routes in registration order
@@ -209,6 +209,9 @@ pub fn new_server(
         let app = app
             .app_data(Data::new(state.tiles.clone()))
             .app_data(Data::new(state.tile_cache.clone()));
+
+        #[cfg(feature = "postgres")]
+        let app = app.app_data(Data::new(state.postgres_configs.clone()));
 
         #[cfg(feature = "sprites")]
         let app = app


### PR DESCRIPTION
feat: add POST /_/reload endpoint for dynamic catalog updates

Add reload endpoint infrastructure to enable dynamic catalog updates without server restarts, addressing issue #288.

Changes:
- Add POST /_/reload endpoint in srv/admin.rs
- Register endpoint in srv/server.rs
- Add upsert_sources() method to TileSources for adding/updating sources
- Add remove_sources() method to TileSources for cleanup
- Methods leverage existing DashMap for thread-safe concurrent updates

The infrastructure is now in place for dynamic source updates:
- DashMap provides thread-safe concurrent access
- upsert_sources() can add or update sources atomically
- remove_sources() can clean up stale sources