### PR TITLE
fix: restrict zooming and panning on data inspector

### DIFF
--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { type ErrorInfo, useCallback, useId, useRef, useEffect } from "react";
+import { useAsyncOperation } from "@/hooks/use-async-operation";
+import { Layer, Map as MapLibreMap, Source } from "@vis.gl/react-maplibre";
+import { buildMartinUrl } from "@/lib/api";
+import type { MapRef } from "@vis.gl/react-maplibre";
+import MaplibreInspect from "@maplibre/maplibre-gl-inspect";
+import { Popup } from "maplibre-gl";
+import { TileSource } from "@/lib/types";
+import { ErrorBoundary } from "../error/error-boundary";
+import { Toaster } from "@/components/ui/toaster";
+import { useToast } from "@/hooks/use-toast";
+
+interface TileInspectDialogMapProps {
+  name: string;
+  source: TileSource;
+}
+
+interface TileJson {
+  bounds: [number, number, number, number];
+  maxzoom?: number;
+  minzoom?: number;
+  center?: [number, number, number];
+}
+
+const fetchTileJson = async (endpoint: string): Promise<TileJson> => {
+  const response = await fetch(buildMartinUrl(`/${endpoint}`));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tileJson: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+export function TileInspectDialogMap({
+  name,
+  source,
+}: TileInspectDialogMapProps) {
+  const { toast } = useToast();
+  const id = useId();
+  const mapRef = useRef<MapRef>(null);
+  const inspectControlRef = useRef<MaplibreInspect>(null);
+
+  const tileJsonOperation = useAsyncOperation<TileJson>(
+    () => fetchTileJson(name),
+    {
+      onError: (error: Error) => console.error("TileJson Fetch Failed:", error),
+      showErrorToast: false,
+    },
+  );
+
+  const isImageSource = [
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+  ].includes(source.content_type);
+
+  useEffect(() => {
+    tileJsonOperation.execute();
+  }, []);
+
+  const configureMap = () => {
+    if (!tileJsonOperation.data) {
+      return;
+    }
+    if (!mapRef.current) {
+      console.error(
+        "Map not found despite being initialized, this cannot happen",
+      );
+      return;
+    }
+    const map = mapRef.current.getMap();
+    const tileJson: TileJson = tileJsonOperation.data;
+    //Error when first value set to -180. it gets resolved on setting to -179 or lower. Other values work fine.
+    map.setMaxBounds([
+      [
+        tileJson.bounds[0] == -180 ? -179 : tileJson.bounds[0],
+        tileJson.bounds[1],
+      ],
+      [tileJson.bounds[2], tileJson.bounds[3]],
+    ]);
+    if (tileJson.minzoom) {
+      map.setMinZoom(tileJson.minzoom);
+      map.setZoom(tileJson.minzoom);
+    }
+    if (tileJson.maxzoom) {
+      map.setMaxZoom(tileJson.maxzoom);
+    }
+    if (tileJson.center) {
+      map.setCenter([tileJson.center[0], tileJson.center[1]]);
+    }
+  };
+
+  const addInspectorToMap = useCallback(() => {
+    if (!mapRef.current) {
+      console.error(
+        "Map not found despite being initialized, this cannot happen",
+      );
+      return;
+    }
+    const map = mapRef.current.getMap();
+
+    map.addSource(name, { type: "vector", url: buildMartinUrl(`/${name}`) });
+    // Import and add the inspect control
+    if (inspectControlRef.current) {
+      map.removeControl(inspectControlRef.current);
+    }
+
+    inspectControlRef.current = new MaplibreInspect({
+      popup: new Popup({
+        closeButton: false,
+        closeOnClick: false,
+      }),
+      showInspectButton: false,
+      showInspectMap: true,
+      showInspectMapPopup: true,
+      showInspectMapPopupOnHover: true,
+      showMapPopup: true,
+    });
+
+    map.addControl(inspectControlRef.current);
+
+    configureMap();
+  }, [name]);
+
+  return (
+    <ErrorBoundary
+      onError={(error: Error, errorInfo: ErrorInfo) => {
+        console.error("Application error:", error, errorInfo);
+        toast({
+          description:
+            "An unexpected error occurred. The page will reload automatically.",
+          title: "Application Error",
+          variant: "destructive",
+        });
+
+        // Auto-reload after 3 seconds
+        setTimeout(() => {
+          window.location.reload();
+        }, 3000);
+      }}
+    >
+      {isImageSource ? (
+        <MapLibreMap
+          onLoad={configureMap}
+          ref={mapRef}
+          reuseMaps={false}
+          style={{
+            height: "500px",
+            width: "100%",
+          }}
+        >
+          <Source
+            id={`${id}tile-source`}
+            type="raster"
+            url={buildMartinUrl(`/${name}`)}
+          />
+          <Layer
+            id={`${id}tile-layer`}
+            source={`${id}tile-source`}
+            type="raster"
+          />
+        </MapLibreMap>
+      ) : (
+        <MapLibreMap
+          onLoad={addInspectorToMap}
+          ref={mapRef}
+          reuseMaps={false}
+          style={{
+            height: "500px",
+            width: "100%",
+          }}
+        ></MapLibreMap>
+      )}
+      <Toaster />
+    </ErrorBoundary>
+  );
+}

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -64,14 +64,12 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     const tileJson: TileJson = tileJsonOperation.data;
     if (tileJson.bounds) {
       const [west, south, east, north] = tileJson.bounds;
-      const isWorld =
-        west <= -179 &&
-        east >= 179;
+      const isWorld = west <= -179 && east >= 179;
       if (!isWorld) {
-          map.setMaxBounds([
-            [west, south],
-            [east, north],
-          ]);
+        map.setMaxBounds([
+          [west, south],
+          [east, north],
+        ]);
       }
     }
     if (tileJson.minzoom) {

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -62,11 +62,18 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     }
     const map = mapRef.current.getMap();
     const tileJson: TileJson = tileJsonOperation.data;
-    //Error when first value set to -180. it gets resolved on setting to -179 or lower. Other values work fine.
-    map.setMaxBounds([
-      [tileJson.bounds[0] === -180 ? -179 : tileJson.bounds[0], tileJson.bounds[1]],
-      [tileJson.bounds[2], tileJson.bounds[3]],
-    ]);
+    if (tileJson.bounds) {
+      const [west, south, east, north] = tileJson.bounds;
+      const isWorld =
+        west <= -179 &&
+        east >= 179;
+      if (!isWorld) {
+          map.setMaxBounds([
+            [west, south],
+            [east, north],
+          ]);
+      }
+    }
     if (tileJson.minzoom) {
       map.setMinZoom(tileJson.minzoom);
       map.setZoom(tileJson.minzoom);

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -1,16 +1,16 @@
-"use client";
+'use client';
 
-import { type ErrorInfo, useCallback, useId, useRef, useEffect } from "react";
-import { useAsyncOperation } from "@/hooks/use-async-operation";
-import { Layer, Map as MapLibreMap, Source } from "@vis.gl/react-maplibre";
-import { buildMartinUrl } from "@/lib/api";
-import type { MapRef } from "@vis.gl/react-maplibre";
-import MaplibreInspect from "@maplibre/maplibre-gl-inspect";
-import { Popup } from "maplibre-gl";
-import { TileSource } from "@/lib/types";
-import { ErrorBoundary } from "../error/error-boundary";
-import { Toaster } from "@/components/ui/toaster";
-import { useToast } from "@/hooks/use-toast";
+import MaplibreInspect from '@maplibre/maplibre-gl-inspect';
+import type { MapRef } from '@vis.gl/react-maplibre';
+import { Layer, Map as MapLibreMap, Source } from '@vis.gl/react-maplibre';
+import { Popup } from 'maplibre-gl';
+import { type ErrorInfo, useCallback, useEffect, useId, useRef } from 'react';
+import { Toaster } from '@/components/ui/toaster';
+import { useAsyncOperation } from '@/hooks/use-async-operation';
+import { useToast } from '@/hooks/use-toast';
+import { buildMartinUrl } from '@/lib/api';
+import type { TileSource } from '@/lib/types';
+import { ErrorBoundary } from '../error/error-boundary';
 
 interface TileInspectDialogMapProps {
   name: string;
@@ -32,29 +32,20 @@ const fetchTileJson = async (endpoint: string): Promise<TileJson> => {
   return response.json();
 };
 
-export function TileInspectDialogMap({
-  name,
-  source,
-}: TileInspectDialogMapProps) {
+export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps) {
   const { toast } = useToast();
   const id = useId();
   const mapRef = useRef<MapRef>(null);
   const inspectControlRef = useRef<MaplibreInspect>(null);
 
-  const tileJsonOperation = useAsyncOperation<TileJson>(
-    () => fetchTileJson(name),
-    {
-      onError: (error: Error) => console.error("TileJson Fetch Failed:", error),
-      showErrorToast: false,
-    },
-  );
+  const tileJsonOperation = useAsyncOperation<TileJson>(() => fetchTileJson(name), {
+    onError: (error: Error) => console.error('TileJson Fetch Failed:', error),
+    showErrorToast: false,
+  });
 
-  const isImageSource = [
-    "image/gif",
-    "image/jpeg",
-    "image/png",
-    "image/webp",
-  ].includes(source.content_type);
+  const isImageSource = ['image/gif', 'image/jpeg', 'image/png', 'image/webp'].includes(
+    source.content_type,
+  );
 
   useEffect(() => {
     tileJsonOperation.execute();
@@ -65,19 +56,14 @@ export function TileInspectDialogMap({
       return;
     }
     if (!mapRef.current) {
-      console.error(
-        "Map not found despite being initialized, this cannot happen",
-      );
+      console.error('Map not found despite being initialized, this cannot happen');
       return;
     }
     const map = mapRef.current.getMap();
     const tileJson: TileJson = tileJsonOperation.data;
     //Error when first value set to -180. it gets resolved on setting to -179 or lower. Other values work fine.
     map.setMaxBounds([
-      [
-        tileJson.bounds[0] == -180 ? -179 : tileJson.bounds[0],
-        tileJson.bounds[1],
-      ],
+      [tileJson.bounds[0] == -180 ? -179 : tileJson.bounds[0], tileJson.bounds[1]],
       [tileJson.bounds[2], tileJson.bounds[3]],
     ]);
     if (tileJson.minzoom) {
@@ -94,14 +80,12 @@ export function TileInspectDialogMap({
 
   const addInspectorToMap = useCallback(() => {
     if (!mapRef.current) {
-      console.error(
-        "Map not found despite being initialized, this cannot happen",
-      );
+      console.error('Map not found despite being initialized, this cannot happen');
       return;
     }
     const map = mapRef.current.getMap();
 
-    map.addSource(name, { type: "vector", url: buildMartinUrl(`/${name}`) });
+    map.addSource(name, { type: 'vector', url: buildMartinUrl(`/${name}`) });
     // Import and add the inspect control
     if (inspectControlRef.current) {
       map.removeControl(inspectControlRef.current);
@@ -127,12 +111,11 @@ export function TileInspectDialogMap({
   return (
     <ErrorBoundary
       onError={(error: Error, errorInfo: ErrorInfo) => {
-        console.error("Application error:", error, errorInfo);
+        console.error('Application error:', error, errorInfo);
         toast({
-          description:
-            "An unexpected error occurred. The page will reload automatically.",
-          title: "Application Error",
-          variant: "destructive",
+          description: 'An unexpected error occurred. The page will reload automatically.',
+          title: 'Application Error',
+          variant: 'destructive',
         });
 
         // Auto-reload after 3 seconds
@@ -147,20 +130,12 @@ export function TileInspectDialogMap({
           ref={mapRef}
           reuseMaps={false}
           style={{
-            height: "500px",
-            width: "100%",
+            height: '500px',
+            width: '100%',
           }}
         >
-          <Source
-            id={`${id}tile-source`}
-            type="raster"
-            url={buildMartinUrl(`/${name}`)}
-          />
-          <Layer
-            id={`${id}tile-layer`}
-            source={`${id}tile-source`}
-            type="raster"
-          />
+          <Source id={`${id}tile-source`} type="raster" url={buildMartinUrl(`/${name}`)} />
+          <Layer id={`${id}tile-layer`} source={`${id}tile-source`} type="raster" />
         </MapLibreMap>
       ) : (
         <MapLibreMap
@@ -168,8 +143,8 @@ export function TileInspectDialogMap({
           ref={mapRef}
           reuseMaps={false}
           style={{
-            height: "500px",
-            width: "100%",
+            height: '500px',
+            width: '100%',
           }}
         ></MapLibreMap>
       )}

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -47,11 +47,12 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     source.content_type,
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: if we list tileJson below, this is an infinte loop
   useEffect(() => {
     tileJsonOperation.execute();
   }, []);
 
-  const configureMap = () => {
+  const configureMap = useCallback(() => {
     if (!tileJsonOperation.data) {
       return;
     }
@@ -63,7 +64,7 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     const tileJson: TileJson = tileJsonOperation.data;
     //Error when first value set to -180. it gets resolved on setting to -179 or lower. Other values work fine.
     map.setMaxBounds([
-      [tileJson.bounds[0] == -180 ? -179 : tileJson.bounds[0], tileJson.bounds[1]],
+      [tileJson.bounds[0] === -180 ? -179 : tileJson.bounds[0], tileJson.bounds[1]],
       [tileJson.bounds[2], tileJson.bounds[3]],
     ]);
     if (tileJson.minzoom) {
@@ -76,7 +77,7 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     if (tileJson.center) {
       map.setCenter([tileJson.center[0], tileJson.center[1]]);
     }
-  };
+  }, [tileJsonOperation.data]);
 
   const addInspectorToMap = useCallback(() => {
     if (!mapRef.current) {
@@ -106,7 +107,7 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     map.addControl(inspectControlRef.current);
 
     configureMap();
-  }, [name]);
+  }, [name, configureMap]);
 
   return (
     <ErrorBoundary

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -11,8 +11,8 @@ import {
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
 import { Database } from 'lucide-react';
-import { TileInspectDialogMap } from './tile-inspect-map';
 import { LoadingSpinner } from '../loading/loading-spinner';
+import { TileInspectDialogMap } from './tile-inspect-map';
 
 interface TileInspectDialogProps {
   name: string;
@@ -22,14 +22,13 @@ interface TileInspectDialogProps {
 
 function TileMapLoading() {
   return (
-    <div className='flex justify-center items-center text-white text-3xl w-full h-125'>
-      <LoadingSpinner/>
+    <div className="flex justify-center items-center text-white text-3xl w-full h-125">
+      <LoadingSpinner />
     </div>
-  )
+  );
 }
 
 export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDialogProps) {
-
   return (
     <Dialog onOpenChange={(v) => !v && onCloseAction()} open={true}>
       <DialogContent className="max-w-6xl w-full p-6 max-h-[90vh] overflow-auto">
@@ -46,8 +45,8 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
 
         <div className="space-y-4">
           <section className="border rounded-lg overflow-hidden">
-            <Suspense fallback={<TileMapLoading/>}>
-              <TileInspectDialogMap name={name} source={source}/>
+            <Suspense fallback={<TileMapLoading />}>
+              <TileInspectDialogMap name={name} source={source} />
             </Suspense>
           </section>
           {/* Source Information */}


### PR DESCRIPTION
This PR fixes #2325

The TileJson is being fetched again to set the bounds and zoom values properly. The main map component has been shifted to a new component, wrapping it inside suspense to fetch the tileJson asynchronously. The tiles now load in the restricted area if the data is local.

One peculiar thing I noticed:
When setting the bounds, if the first value for west is -180, it leads to the following error:
<img width="342" height="183" alt="Screenshot 2026-02-26 at 7 58 32 PM" src="https://github.com/user-attachments/assets/651436b5-908c-4712-8199-4aa0419b213e" />

If the value is less than -180 or you set it to -179 or less if it is -180, the error vanishes. I haven't looked too deep as to why this is happening. Maybe it's because of how setMaxBounds internally manipulates these values that lead to a NaN. But not too sure.