### PR TITLE
docs: change the way mbtiles schemas are included to sylink instead of config driven inclusion

### DIFF
--- a/docs/content/files/init-flat-with-hash.sql
+++ b/docs/content/files/init-flat-with-hash.sql
@@ -1,0 +1,1 @@
+../../../mbtiles/sql/init-flat-with-hash.sql

--- a/docs/content/files/init-flat.sql
+++ b/docs/content/files/init-flat.sql
@@ -1,0 +1,1 @@
+../../../mbtiles/sql/init-flat.sql

--- a/docs/content/files/init-normalized.sql
+++ b/docs/content/files/init-normalized.sql
@@ -1,0 +1,1 @@
+../../../mbtiles/sql/init-normalized.sql

--- a/docs/content/mbtiles-schema.md
+++ b/docs/content/mbtiles-schema.md
@@ -7,7 +7,7 @@ The `mbtiles` tool builds on top of the original [MBTiles specification](https:/
 Flat schema is the closest to the original MBTiles specification. It stores all tiles in a single table. This schema is the most efficient when the tileset contains no duplicate tiles.
 
 ```sql
---8<-- "mbtiles/sql/init-flat.sql"
+--8<-- "files/init-flat.sql"
 ```
 
 ## flat-with-hash
@@ -15,7 +15,7 @@ Flat schema is the closest to the original MBTiles specification. It stores all 
 Similar to the `flat` schema, but also includes a `tile_hash` column that contains a hash value of the `tile_data` column. Use this schema when the tileset has no duplicate tiles, but you still want to be able to validate the content of each tile individually.
 
 ```sql
---8<-- "mbtiles/sql/init-flat-with-hash.sql"
+--8<-- "files/init-flat-with-hash.sql"
 ```
 
 ## normalized
@@ -23,11 +23,11 @@ Similar to the `flat` schema, but also includes a `tile_hash` column that contai
 Normalized schema is the most efficient when the tileset contains duplicate tiles. It stores all tile blobs in the `images` table, and stores the tile Z,X,Y coordinates in a `map` table. The `map` table contains a `tile_id` column that is a foreign key to the `images` table. The `tile_id` column is a hash of the `tile_data` column, making it possible to both validate each individual tile like in the `flat-with-hash` schema, and also to optimize storage by storing each unique tile only once.
 
 ```sql
---8<-- "mbtiles/sql/init-normalized.sql"
+--8<-- "files/init-normalized.sql"
 ```
 
 Optionally, `.mbtiles` files with `normalized` schema can include a `tiles_with_hash` view. All `normalized` files created by the `mbtiles` tool will contain this view.
 
 ```sql
---8<-- "mbtiles/sql/init-normalized.sql:26:"
+--8<-- "files/init-normalized.sql:26:"
 ```

--- a/docs/content/mbtiles-schema.md
+++ b/docs/content/mbtiles-schema.md
@@ -23,11 +23,11 @@ Similar to the `flat` schema, but also includes a `tile_hash` column that contai
 Normalized schema is the most efficient when the tileset contains duplicate tiles. It stores all tile blobs in the `images` table, and stores the tile Z,X,Y coordinates in a `map` table. The `map` table contains a `tile_id` column that is a foreign key to the `images` table. The `tile_id` column is a hash of the `tile_data` column, making it possible to both validate each individual tile like in the `flat-with-hash` schema, and also to optimize storage by storing each unique tile only once.
 
 ```sql
---8<-- "files/init-normalized.sql"
+--8<-- "files/init-normalized.sql:0:28"
 ```
 
 Optionally, `.mbtiles` files with `normalized` schema can include a `tiles_with_hash` view. All `normalized` files created by the `mbtiles` tool will contain this view.
 
 ```sql
---8<-- "files/init-normalized.sql:26:"
+--8<-- "files/init-normalized.sql:30:39"
 ```

--- a/zensical.toml
+++ b/zensical.toml
@@ -377,7 +377,7 @@ pygments_lang_class = true
 [project.markdown_extensions.pymdownx.inlinehilite]
 
 [project.markdown_extensions.pymdownx.snippets]
-base_path = ["docs/content", "/"]
+base_path = ["docs/content"]
 
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [


### PR DESCRIPTION
This does not quite work as I would expect. Not sure why it does not throw an error.