### PR TITLE
docs: reword some aspects of the demo site

### DIFF
--- a/demo/frontend/src/Components/App/App.jsx
+++ b/demo/frontend/src/Components/App/App.jsx
@@ -22,7 +22,6 @@ const App = () => (
       <p>
        Martin uses a database function to filter data by date, day of week, and hour, and to aggregate values by area.
       </p>
-
     </TryIt>
     <MaplibreMap />
     <Development />

--- a/demo/frontend/src/Components/App/App.jsx
+++ b/demo/frontend/src/Components/App/App.jsx
@@ -17,7 +17,7 @@ const App = () => (
     <Features />
     <TryIt>
       <p>
-       This demo uses a 2017 New York City taxi trips dataset — 114 million records served as vector tiles.
+       This demo uses a 2017 New York City taxi trips dataset - 114 million records served as vector tiles.
       </p>
       <p>
        Martin uses a database function to filter data by date, day of week, and hour, and to aggregate values by area.

--- a/demo/frontend/src/Components/App/App.jsx
+++ b/demo/frontend/src/Components/App/App.jsx
@@ -17,13 +17,12 @@ const App = () => (
     <Features />
     <TryIt>
       <p>
-        This is a demo of how Martin works. We used 2017 New York City taxi trips dataset: about 114
-        million records and a 13GB database.
+       This demo uses a 2017 New York City taxi trips dataset — 114 million records served as vector tiles.
       </p>
       <p>
-        Martin uses a database function to filter the data by selected dates, days of the week, and
-        hours and to sum or average the numbers by areas.
+       Martin uses a database function to filter data by date, day of week, and hour, and to aggregate values by area.
       </p>
+
     </TryIt>
     <MaplibreMap />
     <Development />

--- a/demo/frontend/src/config/features.ts
+++ b/demo/frontend/src/config/features.ts
@@ -1,19 +1,17 @@
 export default [
   {
-    description: 'Martin creates MVT vector tiles from any PostGIS table or view',
+    description: 'Serve vector tiles directly from your PostGIS database.',
     id: 1,
-    title: 'Turning Data into Vector Tiles',
+    title: 'Vector Tiles from PostGIS',
   },
   {
-    description:
-      'Martin is the only vector tile server capable of creating tiles using database functions directly',
+    description: 'Generate tiles dynamically using database functions.',
     id: 2,
-    title: 'Generating Tiles with Functions',
+    title: 'Function-Based Tile Generation',
   },
   {
-    description:
-      'Martin is ideal for large datasets as it allows passing parameters from a URL into a user function to filter features and aggregate attribute values',
+    description: 'Filter and aggregate data on the fly using URL parameters.',
     id: 3,
-    title: 'Filtering and Aggregating Data on the Fly',
+    title: 'Dynamic Filtering',
   },
 ];


### PR DESCRIPTION
Simplifies the feature descriptions and TryIt section on the Martin demo site for clarity and brevity.

- Shortened all 3 feature descriptions in `features.ts`
- Simplified TryIt copy in `App.jsx`

- [x] simplified feature desciptions in the demo site
- [ ] installer box