### PR TITLE
feat(srv): resolve some compression TODOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3938,6 +3938,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ tracing-test = "0.2"
 url = "2.5"
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+zstd = "0.13"
 
 [profile.dev.package]
 # See https://github.com/launchbadge/sqlx#compile-time-verification

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -21,6 +21,7 @@ flate2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -10,6 +10,12 @@ pub fn decode_gzip(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     Ok(decompressed)
 }
 
+pub fn encode_zlib(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
 pub fn decode_zlib(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut decoder = ZlibDecoder::new(data);
     let mut decompressed = Vec::new();
@@ -34,4 +40,17 @@ pub fn encode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = brotli::CompressorWriter::new(Vec::new(), 4096, 11, 22);
     encoder.write_all(data)?;
     Ok(encoder.into_inner())
+}
+
+pub fn decode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let mut decoder = zstd::Decoder::new(data)?;
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed)?;
+    Ok(decompressed)
+}
+
+pub fn encode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let mut encoder = zstd::Encoder::new(Vec::new(), 0)?;
+    encoder.write_all(data)?;
+    Ok(encoder.finish()?)
 }

--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -52,5 +52,5 @@ pub fn decode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 pub fn encode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = zstd::Encoder::new(Vec::new(), 0)?;
     encoder.write_all(data)?;
-    Ok(encoder.finish()?)
+    encoder.finish()
 }

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -26,7 +26,7 @@ const SUPPORTED_ENC: &[HeaderEnc] = &[
     HeaderEnc::gzip(),
     HeaderEnc::brotli(),
     HeaderEnc::zstd(),
-    HeaderEnc::deflate(),
+    //probably dont need deflate here, most clients don't support
     HeaderEnc::identity(),
 ];
 
@@ -240,8 +240,8 @@ impl<'a> DynTileSource<'a> {
                 (tile.data, tile.etag, tile.info)
             }
             _ => {
-                let can_join = self.info.format == Format::Mvt
-                    && tiles.iter().all(|t| t.info.format == Format::Mvt);
+                let can_join = (self.info.format == Format::Mvt || self.info.format == Format::Mlt)
+                    && tiles.iter().all(|t| t.info.format == self.info.format);
                 if !can_join {
                     return Err(ErrorBadRequest(format!(
                         "Cannot merge non-MVT formats. Format is {:?} with encoding {:?} ",
@@ -441,7 +441,7 @@ mod tests {
     use tilejson::tilejson;
 
     use super::*;
-    use crate::srv::tiles::tests::TestSource;
+    use crate::srv::tiles::tests::{CompressedTestSource, TestSource};
 
     #[rstest]
     #[trace]
@@ -451,6 +451,8 @@ mod tests {
     #[case(&["br;q=1", "gzip;q=1"], Some(PreferredEncoding::Gzip), Encoding::Gzip)]
     #[case(&["gzip;q=1", "br;q=1"], Some(PreferredEncoding::Brotli), Encoding::Brotli)]
     #[case(&["gzip;q=1", "br;q=0.5"], Some(PreferredEncoding::Brotli), Encoding::Gzip)]
+    #[case(&["gzip;q=0.5", "br;q=0.5", "zstd;q=1.0"], None, Encoding::Zstd)]
+    #[case(&["gzip;q=0.5", "br;q=0.5", "zstd;q=1.0"], Some(PreferredEncoding::Brotli), Encoding::Zstd)]
     #[actix_rt::test]
     async fn test_enc_preference(
         #[case] accept_enc: &[&'static str],
@@ -557,5 +559,87 @@ mod tests {
             let xyz = TileCoord { z: 0, x: 0, y: 0 };
             assert_eq!(expected, &src.get_tile_content(xyz).await.unwrap().data);
         }
+    }
+
+    fn compress_with(data: &[u8], encoding: Encoding) -> Vec<u8> {
+        match encoding {
+            Encoding::Brotli => encode_brotli(data).unwrap(),
+            Encoding::Zlib => encode_zlib(data).unwrap(),
+            Encoding::Zstd => encode_zstd(data).unwrap(),
+            _ => panic!("compress_with: unsupported encoding {encoding:?}"),
+        }
+    }
+
+    fn decompress_tile(data: &[u8], encoding: Encoding) -> Vec<u8> {
+        match encoding {
+            Encoding::Uncompressed => data.to_vec(),
+            Encoding::Gzip => decode_gzip(data).unwrap(),
+            Encoding::Brotli => decode_brotli(data).unwrap(),
+            Encoding::Zlib => decode_zlib(data).unwrap(),
+            Encoding::Zstd => decode_zstd(data).unwrap(),
+            enc => panic!("decompress_tile: unsupported encoding {enc:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case(Encoding::Brotli, None, Encoding::Uncompressed)]
+    #[case(Encoding::Zlib, None, Encoding::Uncompressed)]
+    #[case(Encoding::Zstd, None, Encoding::Uncompressed)]
+    #[case(Encoding::Brotli, Some("zstd"), Encoding::Zstd)]
+    #[case(Encoding::Zlib, Some("br"), Encoding::Brotli)]
+    #[case(Encoding::Zstd, Some("gzip"), Encoding::Gzip)]
+    #[actix_rt::test]
+    async fn test_compressed_mvt_merge(
+        #[case] src_enc: Encoding,
+        #[case] accept: Option<&str>,
+        #[case] expected_enc: Encoding,
+    ) {
+        let raw1: Vec<u8> = vec![1, 2, 3];
+        let raw2: Vec<u8> = vec![4, 5, 6];
+
+        let src1 = CompressedTestSource {
+            id: "src1",
+            tj: tilejson! { tiles: vec![] },
+            data: compress_with(&raw1, src_enc),
+            encoding: src_enc,
+        };
+        let src2 = CompressedTestSource {
+            id: "src2",
+            tj: tilejson! { tiles: vec![] },
+            data: compress_with(&raw2, src_enc),
+            encoding: src_enc,
+        };
+
+        let sources = TileSources::new(vec![vec![Box::new(src1), Box::new(src2)]]);
+
+        let accept_enc = accept.map(|s| AcceptEncoding(vec![s.parse().unwrap()]));
+        let src = DynTileSource::new(
+            &sources,
+            "src1,src2",
+            None,
+            "",
+            accept_enc,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let tile = src
+            .get_tile_content(TileCoord { z: 0, x: 0, y: 0 })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tile.info.encoding, expected_enc,
+            "wrong output encoding for src={src_enc:?}, accept={accept:?}"
+        );
+
+        let decoded = decompress_tile(&tile.data, tile.info.encoding);
+        let expected_raw: Vec<u8> = raw1.iter().chain(raw2.iter()).copied().collect();
+        assert_eq!(
+            decoded, expected_raw,
+            "decoded content mismatch for src={src_enc:?}, accept={accept:?}"
+        );
     }
 }

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -26,6 +26,7 @@ const SUPPORTED_ENC: &[HeaderEnc] = &[
     HeaderEnc::gzip(),
     HeaderEnc::brotli(),
     HeaderEnc::zstd(),
+    HeaderEnc::deflate(),
     HeaderEnc::identity(),
 ];
 
@@ -242,9 +243,10 @@ impl<'a> DynTileSource<'a> {
                 let can_join = self.info.format == Format::Mvt
                     && tiles.iter().all(|t| t.info.format == Format::Mvt);
                 if !can_join {
-                    return Err(ErrorBadRequest(
-                        "Cannot merge tiles with incompatible formats",
-                    ));
+                    return Err(ErrorBadRequest(format!(
+                        "Cannot merge non-MVT formats. Format is {:?} with encoding {:?} ",
+                        self.info.format, self.info.encoding,
+                    )));
                 }
 
                 // Build combined etag before consuming tiles
@@ -258,13 +260,17 @@ impl<'a> DynTileSource<'a> {
                     || self.info.encoding == Encoding::Gzip
                 {
                     // Gzip multi-stream is valid; uncompressed concat is fine
-                    let data = tiles.into_iter().map(|t| t.data).collect::<Vec<_>>().concat();
+                    let data = tiles
+                        .into_iter()
+                        .map(|t| t.data)
+                        .collect::<Vec<_>>()
+                        .concat();
                     (data, self.info)
                 } else {
                     // Decompress first, concat raw MVT, let recompress re-encode
                     let mut raw = Vec::new();
                     for tile_data in tiles {
-                        let t = Tile::new_hash_etag(tile_data.data, tile_data.info);
+                        let t = Tile::new_with_etag(tile_data.data, tile_data.info, tile_data.etag);
                         let decoded = decode(t)?;
                         raw.extend_from_slice(&decoded.data);
                     }
@@ -303,11 +309,17 @@ impl<'a> DynTileSource<'a> {
         }
         if let (Some(qg), Some(qb)) = (q_gzip, q_brotli) {
             let qz = q_zstd.unwrap_or(Quality::ZERO);
-            let max_q = if qg >= qb && qg >= qz { qg } else if qb >= qz { qb } else { qz };
+            let max_q = if qg >= qb && qg >= qz {
+                qg
+            } else if qb >= qz {
+                qb
+            } else {
+                qz
+            };
             if max_q == Quality::ZERO {
                 return Ok(None);
             }
-            let at_max = (qg == max_q) as u8 + (qb == max_q) as u8 + (qz == max_q) as u8;
+            let at_max = u8::from(qg == max_q) + u8::from(qb == max_q) + u8::from(qz == max_q);
             return Ok(Some(if at_max > 1 {
                 self.get_preferred_enc()
             } else if qb == max_q {

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -577,7 +577,9 @@ mod tests {
             Encoding::Brotli => decode_brotli(data).unwrap(),
             Encoding::Zlib => decode_zlib(data).unwrap(),
             Encoding::Zstd => decode_zstd(data).unwrap(),
-            enc => panic!("decompress_tile: unsupported encoding {enc:?}"),
+            Encoding::Internal => {
+                panic!("decompress_tile: cannot decompress tile with internal encoding")
+            }
         }
     }
 

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -20,10 +20,12 @@ use crate::config::args::PreferredEncoding;
 use crate::config::file::srv::SrvConfig;
 use crate::source::TileSources;
 use crate::srv::server::{DebouncedWarning, map_internal_error};
+use martin_tile_utils::{decode_zlib, decode_zstd, encode_zlib, encode_zstd};
 
 const SUPPORTED_ENC: &[HeaderEnc] = &[
     HeaderEnc::gzip(),
     HeaderEnc::brotli(),
+    HeaderEnc::zstd(),
     HeaderEnc::identity(),
 ];
 
@@ -230,42 +232,51 @@ impl<'a> DynTileSource<'a> {
         }
 
         // Minor optimization to prevent concatenation if there are less than 2 tiles
-        let (data, etag) = match layer_count {
+        let (data, etag, effective_info) = match layer_count {
             0 => return Ok(Tile::new_hash_etag(Vec::new(), self.info)),
             1 => {
                 let tile = tiles.swap_remove(last_non_empty_layer);
-                (tile.data, tile.etag)
+                (tile.data, tile.etag, tile.info)
             }
             _ => {
-                // Make sure tiles can be concatenated, or if not, that there is only one non-empty tile for each zoom level
-                // TODO: can zlib, brotli, or zstd be concatenated?
-                // TODO: implement decompression step for other concatenate-able formats
                 let can_join = self.info.format == Format::Mvt
-                    && (self.info.encoding == Encoding::Uncompressed
-                        || self.info.encoding == Encoding::Gzip);
+                    && tiles.iter().all(|t| t.info.format == Format::Mvt);
                 if !can_join {
-                    return Err(ErrorBadRequest(format!(
-                        "Can't merge {} tiles. Make sure there is only one non-empty tile source at zoom level {}",
-                        self.info, xyz.z
-                    )))?;
+                    return Err(ErrorBadRequest(
+                        "Cannot merge tiles with incompatible formats",
+                    ));
                 }
-                // When concatenating tiles, we can't use pre-computed etags since the data changes
-                let total_etag_len = tiles.iter().map(|t| t.etag.len()).sum();
-                let mut concatenated_hash = String::with_capacity(total_etag_len);
+
+                // Build combined etag before consuming tiles
+                let total_etag_len: usize = tiles.iter().map(|t| t.etag.len()).sum();
+                let mut combined_etag = String::with_capacity(total_etag_len);
                 for tile in &tiles {
-                    concatenated_hash.push_str(&tile.etag);
+                    combined_etag.push_str(&tile.etag);
                 }
-                let concatenated_data = tiles
-                    .into_iter()
-                    .map(|t| t.data)
-                    .collect::<Vec<_>>()
-                    .concat();
-                (concatenated_data, concatenated_hash)
+
+                let (concat_data, effective_info) = if self.info.encoding == Encoding::Uncompressed
+                    || self.info.encoding == Encoding::Gzip
+                {
+                    // Gzip multi-stream is valid; uncompressed concat is fine
+                    let data = tiles.into_iter().map(|t| t.data).collect::<Vec<_>>().concat();
+                    (data, self.info)
+                } else {
+                    // Decompress first, concat raw MVT, let recompress re-encode
+                    let mut raw = Vec::new();
+                    for tile_data in tiles {
+                        let t = Tile::new_hash_etag(tile_data.data, tile_data.info);
+                        let decoded = decode(t)?;
+                        raw.extend_from_slice(&decoded.data);
+                    }
+                    (raw, self.info.encoding(Encoding::Uncompressed))
+                };
+
+                (concat_data, combined_etag, effective_info)
             }
         };
 
         // decide if (re-)encoding of the tile data is needed, and recompress if so
-        let mut tile = self.recompress(data)?;
+        let mut tile = self.recompress(data, effective_info)?;
         // Set the etag for the final tile
         tile.etag = etag;
         Ok(tile)
@@ -275,36 +286,43 @@ impl<'a> DynTileSource<'a> {
     fn decide_encoding(&self, accept_enc: &AcceptEncoding) -> ActixResult<Option<ContentEncoding>> {
         let mut q_gzip = None;
         let mut q_brotli = None;
+        let mut q_zstd = None;
         for enc in accept_enc.iter() {
             if let Preference::Specific(HeaderEnc::Known(e)) = enc.item {
                 match e {
                     ContentEncoding::Gzip => q_gzip = Some(enc.quality),
                     ContentEncoding::Brotli => q_brotli = Some(enc.quality),
+                    ContentEncoding::Zstd => q_zstd = Some(enc.quality),
                     _ => {}
                 }
             } else if let Preference::Any = enc.item {
                 q_gzip.get_or_insert(enc.quality);
                 q_brotli.get_or_insert(enc.quality);
+                q_zstd.get_or_insert(enc.quality);
             }
         }
-        Ok(match (q_gzip, q_brotli) {
-            (Some(q_gzip), Some(q_brotli)) if q_gzip == q_brotli => {
-                if q_gzip > Quality::ZERO {
-                    Some(self.get_preferred_enc())
-                } else {
-                    None
-                }
+        if let (Some(qg), Some(qb)) = (q_gzip, q_brotli) {
+            let qz = q_zstd.unwrap_or(Quality::ZERO);
+            let max_q = if qg >= qb && qg >= qz { qg } else if qb >= qz { qb } else { qz };
+            if max_q == Quality::ZERO {
+                return Ok(None);
             }
-            (Some(q_gzip), Some(q_brotli)) if q_brotli > q_gzip => Some(ContentEncoding::Brotli),
-            (Some(_), Some(_)) => Some(ContentEncoding::Gzip),
-            _ => {
-                if let Some(HeaderEnc::Known(enc)) = accept_enc.negotiate(SUPPORTED_ENC.iter()) {
-                    Some(enc)
-                } else {
-                    return Err(ErrorNotAcceptable("No supported encoding found"));
-                }
-            }
-        })
+            let at_max = (qg == max_q) as u8 + (qb == max_q) as u8 + (qz == max_q) as u8;
+            return Ok(Some(if at_max > 1 {
+                self.get_preferred_enc()
+            } else if qb == max_q {
+                ContentEncoding::Brotli
+            } else if qz == max_q {
+                ContentEncoding::Zstd
+            } else {
+                ContentEncoding::Gzip
+            }));
+        }
+        if let Some(HeaderEnc::Known(enc)) = accept_enc.negotiate(SUPPORTED_ENC.iter()) {
+            Ok(Some(enc))
+        } else {
+            Err(ErrorNotAcceptable("No supported encoding found"))
+        }
     }
 
     fn get_preferred_enc(&self) -> ContentEncoding {
@@ -314,10 +332,10 @@ impl<'a> DynTileSource<'a> {
         }
     }
 
-    fn recompress(&self, tile: TileData) -> ActixResult<Tile> {
-        let mut tile = Tile::new_hash_etag(tile, self.info);
+    fn recompress(&self, tile: TileData, info: TileInfo) -> ActixResult<Tile> {
+        let mut tile = Tile::new_hash_etag(tile, info);
         if let Some(accept_enc) = &self.accept_enc {
-            if self.info.encoding.is_encoded() {
+            if info.encoding.is_encoded() {
                 // already compressed, see if we can send it as is, or need to re-compress
                 if !accept_enc.iter().any(|e| {
                     if let Preference::Specific(HeaderEnc::Known(enc)) = e.item {
@@ -337,7 +355,6 @@ impl<'a> DynTileSource<'a> {
                 // (re-)compress the tile into the preferred encoding
                 tile = encode(tile, enc)?;
             }
-
             Ok(tile)
         } else {
             // no accepted-encoding header, decode the tile if compressed
@@ -355,6 +372,12 @@ fn encode(tile: Tile, enc: ContentEncoding) -> ActixResult<Tile> {
         ContentEncoding::Gzip => {
             Tile::new_hash_etag(encode_gzip(&tile.data)?, tile.info.encoding(Encoding::Gzip))
         }
+        ContentEncoding::Deflate => {
+            Tile::new_hash_etag(encode_zlib(&tile.data)?, tile.info.encoding(Encoding::Zlib))
+        }
+        ContentEncoding::Zstd => {
+            Tile::new_hash_etag(encode_zstd(&tile.data)?, tile.info.encoding(Encoding::Zstd))
+        }
         _ => tile,
     })
 }
@@ -371,8 +394,16 @@ fn decode(tile: Tile) -> ActixResult<Tile> {
                 decode_brotli(&tile.data)?,
                 info.encoding(Encoding::Uncompressed),
             ),
+            Encoding::Zlib => Tile::new_hash_etag(
+                decode_zlib(&tile.data)?,
+                info.encoding(Encoding::Uncompressed),
+            ),
+            Encoding::Zstd => Tile::new_hash_etag(
+                decode_zstd(&tile.data)?,
+                info.encoding(Encoding::Uncompressed),
+            ),
             _ => Err(ErrorBadRequest(format!(
-                "Tile is is stored as {info}, but the client does not accept this encoding"
+                "Tile is stored as {info}, but the client does not accept this encoding"
             )))?,
         }
     } else {
@@ -385,7 +416,8 @@ pub fn to_encoding(val: ContentEncoding) -> Option<Encoding> {
         ContentEncoding::Identity => Encoding::Uncompressed,
         ContentEncoding::Gzip => Encoding::Gzip,
         ContentEncoding::Brotli => Encoding::Brotli,
-        // TODO: Deflate => Encoding::Zstd or Encoding::Zlib ?
+        ContentEncoding::Deflate => Encoding::Zlib,
+        ContentEncoding::Zstd => Encoding::Zstd,
         _ => None?,
     })
 }
@@ -398,11 +430,6 @@ mod tests {
 
     use super::*;
     use crate::srv::tiles::tests::TestSource;
-
-    #[actix_rt::test]
-    async fn test_deleteme() {
-        test_enc_preference(&["gzip", "deflate", "br", "zstd"], None, Encoding::Gzip).await;
-    }
 
     #[rstest]
     #[trace]

--- a/martin/src/srv/tiles/mod.rs
+++ b/martin/src/srv/tiles/mod.rs
@@ -41,4 +41,40 @@ pub mod tests {
             Ok(self.data.clone())
         }
     }
+
+    /// A test source that serves pre-compressed MVT data with a configurable encoding.
+    #[derive(Debug, Clone)]
+    pub struct CompressedTestSource {
+        pub id: &'static str,
+        pub tj: TileJSON,
+        pub data: TileData,
+        pub encoding: Encoding,
+    }
+
+    #[async_trait]
+    impl Source for CompressedTestSource {
+        fn get_id(&self) -> &str {
+            self.id
+        }
+
+        fn get_tilejson(&self) -> &TileJSON {
+            &self.tj
+        }
+
+        fn get_tile_info(&self) -> TileInfo {
+            TileInfo::new(Format::Mvt, self.encoding)
+        }
+
+        fn clone_source(&self) -> BoxedSource {
+            Box::new(self.clone())
+        }
+
+        async fn get_tile(
+            &self,
+            _xyz: TileCoord,
+            _url_query: Option<&UrlQuery>,
+        ) -> MartinCoreResult<TileData> {
+            Ok(self.data.clone())
+        }
+    }
 }


### PR DESCRIPTION
### Reasoning
Saw that there were some TODOs in `martin/src/srv/tiles/content.rs` with regards to compression negation

### Details
Moved `zstd` above `identity`  preference  over no encoding.

Builds a combined etag from sources before concating brotli/zlib/zstd merged tiles. 

Add zstd tracking to `decide_encoding` than returns tie-breaker for preferred encoder. 