### PR TITLE
fix: redirect ignoring `--route-prefix` for .pbf tile requests

### DIFF
--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -86,7 +86,15 @@ pub async fn redirect_tile_ext(req: HttpRequest, path: Path<RedirectTileRequest>
         })
         .await;
 
-    redirect_tile_with_query(ids, *z, *x, *y, req.query_string())
+    redirect_tile_with_query(
+        ids,
+        *z,
+        *x,
+        *y,
+        req.query_string(),
+        req.app_data::<Data<SrvConfig>>()
+            .and_then(|cfg| cfg.route_prefix.as_deref()),
+    )
 }
 
 /// Redirect `/tiles/{source_ids}/{z}/{x}/{y}` to `/{source_ids}/{z}/{x}/{y}` (HTTP 301)
@@ -108,7 +116,15 @@ pub async fn redirect_tiles(req: HttpRequest, path: Path<TileRequest>) -> HttpRe
         })
         .await;
 
-    redirect_tile_with_query(source_ids, *z, *x, *y, req.query_string())
+    redirect_tile_with_query(
+        source_ids,
+        *z,
+        *x,
+        *y,
+        req.query_string(),
+        req.app_data::<Data<SrvConfig>>()
+            .and_then(|cfg| cfg.route_prefix.as_deref()),
+    )
 }
 
 /// Helper function to create a 301 redirect for tiles with query string preservation
@@ -118,8 +134,13 @@ fn redirect_tile_with_query(
     x: u32,
     y: u32,
     query_string: &str,
+    route_prefix: Option<&str>,
 ) -> HttpResponse {
-    let location = format!("/{source_ids}/{z}/{x}/{y}");
+    let location = if let Some(prefix) = route_prefix {
+        format!("{prefix}/{source_ids}/{z}/{x}/{y}")
+    } else {
+        format!("/{source_ids}/{z}/{x}/{y}")
+    };
     let location = if query_string.is_empty() {
         location
     } else {

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -74,7 +74,11 @@ pub struct RedirectTileRequest {
 /// Redirect `/{source_ids}/{z}/{x}/{y}.{extension}` to `/{source_ids}/{z}/{x}/{y}` (HTTP 301)
 /// Registered before main tile route to match more specific pattern first
 #[route("/{ids}/{z}/{x}/{y}.{ext}", method = "GET", method = "HEAD")]
-pub async fn redirect_tile_ext(req: HttpRequest, path: Path<RedirectTileRequest>) -> HttpResponse {
+pub async fn redirect_tile_ext(
+    req: HttpRequest,
+    path: Path<RedirectTileRequest>,
+    srv_config: Data<SrvConfig>,
+) -> HttpResponse {
     static WARNING: DebouncedWarning = DebouncedWarning::new();
     let RedirectTileRequest { ids, z, x, y, ext } = path.as_ref();
 
@@ -92,14 +96,17 @@ pub async fn redirect_tile_ext(req: HttpRequest, path: Path<RedirectTileRequest>
         *x,
         *y,
         req.query_string(),
-        req.app_data::<Data<SrvConfig>>()
-            .and_then(|cfg| cfg.route_prefix.as_deref()),
+        srv_config.route_prefix.as_deref(),
     )
 }
 
 /// Redirect `/tiles/{source_ids}/{z}/{x}/{y}` to `/{source_ids}/{z}/{x}/{y}` (HTTP 301)
 #[route("/tiles/{source_ids}/{z}/{x}/{y}", method = "GET", method = "HEAD")]
-pub async fn redirect_tiles(req: HttpRequest, path: Path<TileRequest>) -> HttpResponse {
+pub async fn redirect_tiles(
+    req: HttpRequest,
+    path: Path<TileRequest>,
+    srv_config: Data<SrvConfig>,
+) -> HttpResponse {
     static WARNING: DebouncedWarning = DebouncedWarning::new();
     let TileRequest {
         source_ids,
@@ -122,8 +129,7 @@ pub async fn redirect_tiles(req: HttpRequest, path: Path<TileRequest>) -> HttpRe
         *x,
         *y,
         req.query_string(),
-        req.app_data::<Data<SrvConfig>>()
-            .and_then(|cfg| cfg.route_prefix.as_deref()),
+        srv_config.route_prefix.as_deref(),
     )
 }
 

--- a/martin/tests/route_prefix_test.rs
+++ b/martin/tests/route_prefix_test.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "mbtiles")]
 
+use actix_web::http::header::LOCATION;
 use actix_web::test::{TestRequest, call_service, read_body, read_body_json};
 use indoc::formatdoc;
 use martin::config::file::srv::SrvConfig;
@@ -137,6 +138,30 @@ async fn test_route_prefix_tile_endpoints() {
     let req = test_get("/m_mvt/0/0/0").to_request();
     let response = call_service(&app, req).await;
     assert_eq!(response.status(), 404);
+}
+
+#[actix_rt::test]
+#[tracing_test::traced_test]
+async fn test_route_prefix_pbf_redirect_location() {
+    let (config, _conns) = config("test_route_prefix_pbf_redirect").await;
+    let srv_config = SrvConfig {
+        route_prefix: Some("/geotile".to_string()),
+        ..Default::default()
+    };
+    let app = create_app_with_prefix!(&config, srv_config);
+
+    let req = test_get("/geotile/m_mvt/0/0/0.pbf?foo=bar").to_request();
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status(), 301);
+
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .expect("Location header should be set")
+        .to_str()
+        .expect("Location header should be valid UTF-8");
+
+    assert_eq!(location, "/geotile/m_mvt/0/0/0?foo=bar");
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
Fixes #2596

Ensure redirect URLs include the configured route prefix when handling
`.pbf` tile requests behind a reverse proxy.

Previously the redirect logic constructed URLs without the route prefix,
causing incorrect redirects when Martin was deployed behind a reverse proxy.

This change prepends the configured route prefix to the redirect
Location header.

A regression test was added to verify correct behavior.