### PR TITLE
chore(deps): Upgrade PBF font tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,9 +2609,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2624,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2634,15 +2634,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2662,15 +2662,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2679,15 +2679,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2697,9 +2697,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2709,7 +2709,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -4636,9 +4635,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbf_font_tools"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f621f25023f31c597de8b20a44d511d97eacea1943ccbcb709e6ed27156c144d"
+checksum = "6e5bc62a827b995c843b408596ae6e907e9767597b78ab04b7ada9c46ef75432"
 dependencies = [
  "futures",
  "prost",
@@ -7054,9 +7053,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 object_store = { version = "0.13.1", features = ["gcp", "aws", "azure", "fs", "http"] }
-pbf_font_tools = { version = "3.0.0", features = ["freetype"] }
+pbf_font_tools = { version = "3.1.0", features = ["freetype"] }
 pmtiles = { version = "0.19.2", features = ["tilejson", "object-store"] }
 png = "0.18.0"
 postgis = "0.9"

--- a/justfile
+++ b/justfile
@@ -558,6 +558,15 @@ validate-tools:
         fi
     fi
 
+    # Check FreeBSD-specific tools
+    if [[ "$OSTYPE" == "freebsd"* ]]; then
+        # This should eventually go away if the upstream pbf_glyph_tools can vendor the source artifacts
+        # (no more need for protoc). Other platforms automatically install a vendored binary.
+        if ! command -v protoc >/dev/null 2>&1; then
+            missing_tools+=("protoc")
+        fi
+    fi
+
     # Report results
     if [[ ${#missing_tools[@]} -eq 0 ]]; then
         echo "✓ All required tools are installed"
@@ -565,6 +574,7 @@ validate-tools:
         echo "✗ Missing tools: ${missing_tools[*]}"
         echo "  Ubuntu/Debian: sudo apt install -y jq file curl grep sqlite3-tools gdal-bin"
         echo "  macOS: brew install jq file curl grep sqlite gdal gsed"
+        echo "  FreeBSD: pkg install jq curl sqlite3 gdal protobuf"
         echo ""
         exit 1
     fi


### PR DESCRIPTION
This upgrades the pbf_font_tools dependency to v3.1.0. It also adds a FreeBSD-specific check to `just validate-tools`. The latest version of the crate will fall back to the system protoc if a vendored binary is unavailable. This should be fine for FreeBSD, since ports there are generally much faster to update (more like a homebrew than a Debian).

Other notes:

* I considered adding a feature flag to enable protoc-from-src, but that seems unnecessary and would add more complexity short-term (martin does not currently have any feature flags and I'm assuming you'd like to keep it that way).
* I couldn't find where GNU sed is required but the macOS deps specifically list that. If you DO really depend on GNU sed features, we should probably add that under FreeBSD too (the package name is `gsed`), since both FreeBSD and macOS (everything but Linux) use BSD sed which has different flags.
* The justfile probably needs some more... improvements later if we want to have wider platform support. Requiring docker-compose is a non-starter on many platforms (including FreeBSD).

Fixes #2591 