### PR TITLE
ci(perf): don't test pg twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,33 +38,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    env:
-      PGDATABASE: test
-      PGHOST: localhost
-      PGUSER: postgres
-      PGPASSWORD: postgres
-    services:
-      postgres:
-        image: postgis/postgis:18-3.6
-        ports:
-          # will assign a random free host port
-          - 5432/tcp
-        # Sadly there is currently no way to pass arguments to the service image other than this hack
-        # See also https://stackoverflow.com/a/62720566/177275
-        options: >-
-          -e POSTGRES_DB=test
-          -e POSTGRES_USER=postgres
-          -e POSTGRES_PASSWORD=postgres
-          -e PGDATABASE=test
-          -e PGUSER=postgres
-          -e PGPASSWORD=postgres
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --entrypoint sh
-          postgis/postgis:18-3.6
-          -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
       - run: rustup update stable && rustup default stable
       - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
@@ -82,10 +55,6 @@ jobs:
         with: { persist-credentials: false }
       - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
-      - name: Init database
-        run: tests/fixtures/initdb.sh
-        env:
-          PGPORT: ${{ job.services.postgres.ports[5432] }}
       - name: Run cargo test
         run: |
           set -x
@@ -94,9 +63,7 @@ jobs:
           cargo test --package mbtiles
           cargo test --package martin
           cargo test --package martin-core
-          just test-pg
         env:
-          DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=require
           AWS_SKIP_CREDENTIALS: 1
           AWS_REGION: eu-central-1
       - run: cargo test --doc
@@ -712,13 +679,9 @@ jobs:
           echo "Same but as base64 to prevent GitHub obfuscation (this is not a secret):"
           echo "$DATABASE_URL" | base64
           set -x
-          cargo test --package martin
           just test-pg
-          cargo clean
         env:
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
-          AWS_SKIP_CREDENTIALS: 1
-          AWS_REGION: eu-central-1
       - name: Save test output (on error)
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ bless:
     set -euo pipefail
 
     echo "Blessing unit tests"
-    for target in restart clean-test bless-insta bless-frontend; do
+    for target in restart clean-test bless-insta bless-frontend bless-pg; do
       echo "::group::just $target"
       {{quote(just_executable())}} $target
       echo "::endgroup::"
@@ -91,6 +91,11 @@ bless-int:
     rm -rf tests/temp
     tests/test.sh
     rm -rf tests/expected && mv tests/output tests/expected
+
+bless-pg: start  (cargo-install 'cargo-insta')
+    cargo insta test --accept --features test-pg --no-default-features --test pg_function_source_test --test pg_server_test --test pg_table_source_test
+    cargo insta test --accept --features test-pg --no-default-features --package martin --lib
+    cargo insta test --accept --features test-pg --package martin-core --no-default-features --lib
 
 # Build release binaries for a target with debug info stripped
 build-release target:
@@ -386,9 +391,9 @@ test: start (test-cargo "--all-targets") test-pg test-doc test-frontend test-int
 
 # Run PostgreSQL-requiring tests only
 test-pg: start
-    cargo test --features test-pg --test pg_function_source_test --test pg_server_test --test pg_table_source_test
-    cargo test --features test-pg --package martin --lib
-    cargo test --features test-pg --package martin-core --lib
+    cargo test --features test-pg --no-default-features --test pg_function_source_test --test pg_server_test --test pg_table_source_test
+    cargo test --features test-pg --no-default-features --package martin --lib
+    cargo test --features test-pg --package martin-core --no-default-features --lib
 
 # Run Rust unit tests (cargo test)
 test-cargo *args:

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -50,9 +50,6 @@ postgres:
     let body = read_body(response).await;
     let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_yaml_snapshot!(body, @r#"
-    fonts: {}
-    sprites: {}
-    styles: {}
     tiles:
       "-function.withweired---_-characters":
         content_type: application/x-protobuf

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -1,4 +1,9 @@
-#![cfg(all(feature = "test-pg", not(feature = "fonts"), not(feature = "sprites"), not(feature = "styles")))]
+#![cfg(all(
+    feature = "test-pg",
+    not(feature = "fonts"),
+    not(feature = "sprites"),
+    not(feature = "styles")
+))]
 
 use actix_http::Request;
 use actix_web::http::StatusCode;

--- a/martin/tests/pg_server_test.rs
+++ b/martin/tests/pg_server_test.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-pg")]
+#![cfg(all(feature = "test-pg", not(feature = "fonts"), not(feature = "sprites"), not(feature = "styles")))]
 
 use actix_http::Request;
 use actix_web::http::StatusCode;


### PR DESCRIPTION
Legacy, was not removed when we should have.
Clogs up the pipeline a bit making it slower than it needs to