### PR TITLE
docs: add nginx location block for font name encoding

### DIFF
--- a/docs/content/run-with-nginx.md
+++ b/docs/content/run-with-nginx.md
@@ -23,6 +23,7 @@ location ~ /tiles/(?<fwd_path>.*) {
     proxy_pass        http://martin:3000/$fwd_path$is_args$args;
 }
 ```
+
 ## Serving Fonts
 
 If your font names contain spaces (e.g. `Open Sans Regular`), NGINX may

--- a/docs/content/run-with-nginx.md
+++ b/docs/content/run-with-nginx.md
@@ -23,6 +23,18 @@ location ~ /tiles/(?<fwd_path>.*) {
     proxy_pass        http://martin:3000/$fwd_path$is_args$args;
 }
 ```
+## Serving Fonts
+
+If your font names contain spaces (e.g. `Open Sans Regular`), NGINX may
+decode the `%20` in the URL into a literal space before forwarding it,
+causing Martin to return an HTTP 400 error. Add this location block to
+prevent that:
+
+```nginx
+location ~ /font/(?<fwd_path>.*) {
+    proxy_pass http://martin:3000/font/$fwd_path$is_args$args;
+}
+```
 
 ### Caching tiles
 


### PR DESCRIPTION
**Fixes** #2614 
Font names with spaces (e.g. Open Sans Regular) cause HTTP 400 errors when proxied through NGINX, because NGINX decodes %20 back to a literal space before forwarding to Martin. 
- [x] This adds a minimal location ~ /font/ block to handle font requests correctly.