### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix-web",
  "approx",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.1"
-martin-core = { path = "./martin-core", version = "0.3.1", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.11" }
-mbtiles = { path = "./mbtiles", version = "0.15.3" }
+martin-core = { path = "./martin-core", version = "0.3.2", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.12" }
+mbtiles = { path = "./mbtiles", version = "0.15.4" }
 md5 = "0.8.0"
 moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.4.0
+    image: ghcr.io/maplibre/martin:1.5.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.4.0 \
+           ghcr.io/maplibre/martin:1.5.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.4.0
+    image: ghcr.io/maplibre/martin:1.5.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.4.0
+  ghcr.io/maplibre/martin:1.5.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.4.0 \
+  ghcr.io/maplibre/martin:1.5.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.4.0
+  ghcr.io/maplibre/martin:1.5.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.4.0
+  ghcr.io/maplibre/martin:1.5.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.4.0
+  ghcr.io/maplibre/martin:1.5.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.4.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.5.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.4.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.5.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -217,7 +217,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.4.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.5.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/maplibre/martin/compare/martin-core-v0.3.1...martin-core-v0.3.2) - 2026-04-02
+
+### Fixed
+
+- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
+
+### Other
+
+- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
+
 ## [0.3.1](https://github.com/maplibre/martin/compare/martin-core-v0.3.0...martin-core-v0.3.1) - 2026-03-14
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.6.11"
+version = "0.6.12"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/maplibre/martin/compare/martin-v1.4.0...martin-v1.5.0) - 2026-04-02
+
+### Added
+
+- migrate to workspaced justfiles using `mod` for demo and martin-ui ([#2623](https://github.com/maplibre/martin/pull/2623))
+
+### Fixed
+
+- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
+- *(postgres)* startup crash when ST_Extent returns LineString instead of Polygon ([#2600](https://github.com/maplibre/martin/pull/2600))
+
+### Other
+
+- *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2647](https://github.com/maplibre/martin/pull/2647))
+- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
+- *(deps-dev)* Bump flatted from 3.3.3 to 3.4.2 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2640](https://github.com/maplibre/martin/pull/2640))
+- *(perf)* don't test pg twice ([#2619](https://github.com/maplibre/martin/pull/2619))
+
 ## [1.4.0](https://github.com/maplibre/martin/compare/martin-v1.3.1...martin-v1.4.0) - 2026-03-14
 
 ### ZSTD support

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,17 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0](https://github.com/maplibre/martin/compare/martin-v1.4.0...martin-v1.5.0) - 2026-04-02
 
-### Added
-
-- migrate to workspaced justfiles using `mod` for demo and martin-ui ([#2623](https://github.com/maplibre/martin/pull/2623))
-
 ### Fixed
 
-- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
 - *(postgres)* startup crash when ST_Extent returns LineString instead of Polygon ([#2600](https://github.com/maplibre/martin/pull/2600))
 
 ### Other
 
+- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
+- migrate to workspaced justfiles using `mod` for demo and martin-ui ([#2623](https://github.com/maplibre/martin/pull/2623))
 - *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2647](https://github.com/maplibre/martin/pull/2647))
 - Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
 - *(deps-dev)* Bump flatted from 3.3.3 to 3.4.2 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2640](https://github.com/maplibre/martin/pull/2640))

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.4.0"
+version = "1.5.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -60,5 +60,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.4.0"
+  "version": "1.5.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.4](https://github.com/maplibre/martin/compare/mbtiles-v0.15.3...mbtiles-v0.15.4) - 2026-04-02
+
+### Fixed
+
+- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
+
+### Other
+
+- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
+
 ## [0.15.3](https://github.com/maplibre/martin/compare/mbtiles-v0.15.2...mbtiles-v0.15.3) - 2026-03-14
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.15.3"
+version = "0.15.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.6.11 -> 0.6.12 (✓ API compatible changes)
* `mbtiles`: 0.15.3 -> 0.15.4 (✓ API compatible changes)
* `martin-core`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `martin`: 1.4.0 -> 1.5.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.15.4](https://github.com/maplibre/martin/compare/mbtiles-v0.15.3...mbtiles-v0.15.4) - 2026-04-02

### Fixed

- typos ([#2651](https://github.com/maplibre/martin/pull/2651))

### Other

- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
</blockquote>

## `martin-core`

<blockquote>

## [0.3.2](https://github.com/maplibre/martin/compare/martin-core-v0.3.1...martin-core-v0.3.2) - 2026-04-02

### Fixed

- typos ([#2651](https://github.com/maplibre/martin/pull/2651))

### Other

- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
</blockquote>

## `martin`

<blockquote>

## [1.5.0](https://github.com/maplibre/martin/compare/martin-v1.4.0...martin-v1.5.0) - 2026-04-02

### Added

- migrate to workspaced justfiles using `mod` for demo and martin-ui ([#2623](https://github.com/maplibre/martin/pull/2623))

### Fixed

- typos ([#2651](https://github.com/maplibre/martin/pull/2651))
- *(postgres)* startup crash when ST_Extent returns LineString instead of Polygon ([#2600](https://github.com/maplibre/martin/pull/2600))

### Other

- *(deps)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2647](https://github.com/maplibre/martin/pull/2647))
- Enable `clippy::use_self` at workspace level and resolve all violations ([#2645](https://github.com/maplibre/martin/pull/2645))
- *(deps-dev)* Bump flatted from 3.3.3 to 3.4.2 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2640](https://github.com/maplibre/martin/pull/2640))
- *(perf)* don't test pg twice ([#2619](https://github.com/maplibre/martin/pull/2619))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).