### PR TITLE
fix: center style previews according to center/zoom from style JSON

### DIFF
--- a/martin/martin-ui/src/components/catalogs/styles.tsx
+++ b/martin/martin-ui/src/components/catalogs/styles.tsx
@@ -10,31 +10,13 @@ import { TooltipCopyText } from '@/components/ui/tooltip-copy-text';
 import { buildMartinUrl } from '@/lib/api';
 import type { Style } from '@/lib/types';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import {
-  FullscreenControl,
-  Map as MapLibreMap,
-  type ViewStateChangeEvent,
-} from '@vis.gl/react-maplibre';
-import { useCallback, useState } from 'react';
+import { FullscreenControl, Map as MapLibreMap } from '@vis.gl/react-maplibre';
 
 function StylePreviewMap({ styleName }: { styleName: string }) {
-  const [viewState, setViewState] = useState<{
-    latitude: number;
-    longitude: number;
-    zoom: number;
-  } | null>(null);
-
-  const handleMove = useCallback((evt: ViewStateChangeEvent) => {
-    const { latitude, longitude, zoom } = evt.viewState;
-    setViewState({ latitude, longitude, zoom });
-  }, []);
-
   return (
     <MapLibreMap
-      reuseMaps
-      {...(viewState ?? {})}
       mapStyle={buildMartinUrl(`/style/${styleName}`)}
-      onMove={handleMove}
+      reuseMaps
       style={{
         aspectRatio: 16 / 9,
         backgroundColor: '#E5E7EB',

--- a/martin/martin-ui/src/components/catalogs/styles.tsx
+++ b/martin/martin-ui/src/components/catalogs/styles.tsx
@@ -10,8 +10,43 @@ import { TooltipCopyText } from '@/components/ui/tooltip-copy-text';
 import { buildMartinUrl } from '@/lib/api';
 import type { Style } from '@/lib/types';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { FullscreenControl, Map as MapLibreMap } from '@vis.gl/react-maplibre';
-import { useState } from 'react';
+import {
+  FullscreenControl,
+  Map as MapLibreMap,
+  type ViewStateChangeEvent,
+} from '@vis.gl/react-maplibre';
+import { useCallback, useState } from 'react';
+
+function StylePreviewMap({ styleName }: { styleName: string }) {
+  const [viewState, setViewState] = useState<{
+    latitude: number;
+    longitude: number;
+    zoom: number;
+  } | null>(null);
+
+  const handleMove = useCallback((evt: ViewStateChangeEvent) => {
+    const { latitude, longitude, zoom } = evt.viewState;
+    setViewState({ latitude, longitude, zoom });
+  }, []);
+
+  return (
+    <MapLibreMap
+      reuseMaps
+      {...(viewState ?? {})}
+      mapStyle={buildMartinUrl(`/style/${styleName}`)}
+      onMove={handleMove}
+      style={{
+        aspectRatio: 16 / 9,
+        backgroundColor: '#E5E7EB',
+        backgroundImage: 'linear-gradient(to bottom right, var(--tw-gradient-stops))',
+        borderRadius: 'var(--radius)',
+        width: '100%',
+      }}
+    >
+      <FullscreenControl />
+    </MapLibreMap>
+  );
+}
 
 interface StylesCatalogProps {
   styles?: { [name: string]: Style };
@@ -38,11 +73,6 @@ export function StylesCatalog({
   selectedStyleForGuide = undefined,
   onStyleGuide = () => {},
 }: StylesCatalogProps) {
-  const [viewState, setViewState] = useState({
-    latitude: 53,
-    longitude: 9,
-    zoom: 2,
-  });
   if (isLoading) {
     return (
       <CatalogSkeleton
@@ -110,21 +140,7 @@ export function StylesCatalog({
             </CardHeader>
             <CardContent>
               <div className="space-y-4">
-                <MapLibreMap
-                  reuseMaps
-                  {...viewState}
-                  mapStyle={buildMartinUrl(`/style/${name}`)}
-                  onMove={(evt) => setViewState(evt.viewState)}
-                  style={{
-                    aspectRatio: 16 / 9,
-                    backgroundColor: '#E5E7EB',
-                    backgroundImage: 'linear-gradient(to bottom right, var(--tw-gradient-stops))',
-                    borderRadius: 'var(--radius)',
-                    width: '100%',
-                  }}
-                >
-                  <FullscreenControl />
-                </MapLibreMap>
+                <StylePreviewMap styleName={name} />
                 <div className="space-y-2 text-sm text-muted-foreground">
                   {style.versionHash && (
                     <div className="flex justify-between">


### PR DESCRIPTION
## Summary

Style previews in the Styles Catalog now respect the `center` and `zoom`
properties from the style JSON, matching the behavior of the style editor
(Maputnik).

## Changes

**`martin/martin-ui/src/components/catalogs/styles.tsx`**

Extracted a `StylePreviewMap` component that manages its own view state
per card. On initial render, no explicit latitude/longitude/zoom is passed
to `MapLibreMap`, so react-maplibre uses whatever center/zoom the style
JSON specifies. After the user interacts with a map preview, the component
tracks that specific map's position independently.

Previously, all previews shared a single hardcoded `viewState`
(`latitude: 53, longitude: 9, zoom: 2`) which overrode the style JSON.

- Type checks pass (`tsc --noEmit`)
- Linting passes (`biome check`)

Fixes #2569

This contribution was developed with AI assistance (Claude Code).