### PR TITLE
test: make sure our unit tests run under macos too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,20 @@ jobs:
       - run: just ui::test
       - run: just ui::type-check
   unit-test-rust:
-    name: Unit test the server
+    name: Unit test the server (${{ matrix.os }})
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # 1. Linux-only for PRs (faster feedback)
+        # 2. Run on all three OS platforms when merging to main 
+        os: ${{ fromJSON('["ubuntu-latest", "macos-latest"]') || (github.ref == 'refs/heads/main' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]')) }}
     steps:
       - run: rustup update stable && rustup default stable
       - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
+        if: runner.os == 'Linux'
         with:
           tool-cache: false
           mandb:   true
@@ -55,6 +62,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+        with:
+          key: ${{ matrix.os }}
       - uses: taiki-e/install-action@a57ddfbcd928cf9406a78dcc300dacc5d367a547 # v2.68.31
         with: { tool: 'just' }
       - name: Run cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
+    needs:
+      - lint-rust # not because it is needed, but because we want less concurrent jobs competing
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # 1. Linux-only for PRs (faster feedback)
-        # 2. Run on all three OS platforms when merging to main 
+        # 2. Run on all three OS platforms when merging to main
         os: ${{ fromJSON('["ubuntu-latest", "macos-latest"]') || (github.ref == 'refs/heads/main' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]')) }}
     steps:
       - run: rustup update stable && rustup default stable

--- a/martin-core/src/tiles/cog/source.rs
+++ b/martin-core/src/tiles/cog/source.rs
@@ -546,6 +546,7 @@ fn get_extent(
 mod tests {
     use std::path::Path;
 
+    use approx::assert_abs_diff_eq;
     use rstest::rstest;
     use tilejson::{Bounds, Center};
 
@@ -620,10 +621,11 @@ mod tests {
             source.tilejson.center.unwrap().to_string(),
             center.to_string()
         );
-        assert_eq!(
-            source.tilejson.bounds.unwrap().to_string(),
-            bounds.to_string()
-        );
+        let actual_bounds = source.tilejson.bounds.unwrap();
+        assert_abs_diff_eq!(actual_bounds.left, bounds.left, epsilon = 1e-12);
+        assert_abs_diff_eq!(actual_bounds.bottom, bounds.bottom, epsilon = 1e-12);
+        assert_abs_diff_eq!(actual_bounds.right, bounds.right, epsilon = 1e-12);
+        assert_abs_diff_eq!(actual_bounds.top, bounds.top, epsilon = 1e-12);
         assert_eq!(source.tilejson.other.get("tileSize").unwrap(), tile_size);
         assert_eq!(
             source.tilejson.other.get("format").unwrap().as_str(),


### PR DESCRIPTION
Use libm for `sinh` and `atan` in `webmercator_to_wgs84` conversion, since transcendental functions can produce slightly different results across platforms. 