### PR TITLE
docs: update outdated links and commands

### DIFF
--- a/docs/content/development/index.md
+++ b/docs/content/development/index.md
@@ -155,7 +155,7 @@ just run         # start Martin server
 just test        # run all tests
 just fmt         # format code
 just clippy      # lint code
-just book        # build documentation
+just docs        # serve documentation preview
 just stop        # stop test database
 ```
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -72,10 +72,10 @@ martin --help
 #### Debian Packages(x86_64) manually
 
 ```bash
-curl -O https://github.com/maplibre/martin/releases/latest/download/martin-Debian-x86_64.deb
-sudo dpkg -i ./martin-Debian-x86_64.deb
+curl -O https://github.com/maplibre/martin/releases/latest/download/debian-x86_64.deb
+sudo dpkg -i ./debian-x86_64.deb
 martin --help
-rm ./martin-Debian-x86_64.deb
+rm ./debian-x86_64.deb
 ```
 
 ### Building From source

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -33,7 +33,7 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 
 [rl-linux-x64-musl]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-musl.tar.gz
 
-[rl-linux-x64-deb]: https://github.com/maplibre/martin/releases/latest/download/martin-Debian-x86_64.deb
+[rl-linux-x64-deb]: https://github.com/maplibre/martin/releases/latest/download/debian-x86_64.deb
 
 [rl-linux-a64-gnu]: https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-unknown-linux-gnu.tar.gz
 

--- a/justfile
+++ b/justfile
@@ -278,7 +278,7 @@ help:
     @echo "  just run               # Start Martin server"
     @echo "  just test              # Run all tests"
     @echo "  just fmt               # Format code"
-    @echo "  just book              # Build documentation"
+    @echo "  just docs              # Serve documentation preview"
     @echo ""
     @echo "Full list: just --list"
 


### PR DESCRIPTION
Two minor documentation fixes I discovered while setting up my development env on ubuntu.

### Updates

- Fix Debian release link: the [old link](https://github.com/maplibre/martin/releases/latest/download/martin-Debian-x86_64.deb) returns 404. 
    - I think It would be better to name the debian package in upcoming release `martin-x86_64-debian.deb` so that it is consistent with other pkgs names. I can look into the packaging setup and work on it if that sounds fine.
- Replace the probably outdated `just book` command with the new `just docs` to run docs locally.
    - currently running `just book` returns this error `error: Justfile does not contain recipe book` 

