### PR TITLE
feat: sprite SDF preview

### DIFF
--- a/martin/martin-ui/src/components/dialogs/sprite-preview.tsx
+++ b/martin/martin-ui/src/components/dialogs/sprite-preview.tsx
@@ -1,6 +1,7 @@
 import { Download } from 'lucide-react';
-import { Suspense } from 'react';
+import { Suspense, useId, useState } from 'react';
 import { LoadingSpinner } from '@/components/loading/loading-spinner';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -9,7 +10,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
 import type { SpriteCollection } from '@/lib/types';
+import { cn } from '@/lib/utils';
 import { SpritePreview } from '../sprite/SpritePreview';
 
 interface SpritePreviewDialogProps {
@@ -19,18 +22,43 @@ interface SpritePreviewDialogProps {
   onDownloadAction: (sprite: SpriteCollection) => void;
 }
 
+const SIZE_MIN = 16;
+const SIZE_MAX = 128;
+const SIZE_DEFAULT = 80;
+
+const SDF_SCALE_MIN = 0.5;
+const SDF_SCALE_MAX = 5;
+const SDF_SCALE_DEFAULT = 2;
+
+const HALO_DEFAULT = 0;
+const HALO_MAX = 10;
+const HALO_BLUR_DEFAULT = 0;
+const HALO_BLUR_MAX = 10;
+
 export function SpritePreviewDialog({
   name,
   sprite,
   onDownloadAction,
   onCloseAction,
 }: SpritePreviewDialogProps) {
+  const uid = useId();
+  const iconColorId = `${uid}-icon-color`;
+  const haloColorId = `${uid}-halo-color`;
+
+  const [sdfMode, setSdfMode] = useState(false);
+  const [displaySize, setDisplaySize] = useState(SIZE_DEFAULT);
+  const [sdfScale, setSdfScale] = useState(SDF_SCALE_DEFAULT);
+  const [iconColor, setIconColor] = useState('#1a1a2e');
+  const [haloColor, setHaloColor] = useState('#ffffff');
+  const [haloWidth, setHaloWidth] = useState(HALO_DEFAULT);
+  const [haloBlur, setHaloBlur] = useState(HALO_BLUR_DEFAULT);
+
   return (
     <Dialog onOpenChange={(v) => !v && onCloseAction()} open={true}>
       <DialogContent className="max-w-4xl w-full p-6 max-h-[80vh] overflow-auto">
         {sprite && (
           <>
-            <DialogHeader className="mb-6 truncate">
+            <DialogHeader className="mb-4 truncate">
               <DialogTitle className="text-2xl flex gap-4">{name}</DialogTitle>
               <DialogDescription>
                 <span>Preview the selected sprite.</span>
@@ -41,7 +69,161 @@ export function SpritePreviewDialog({
                 </Button>
               </DialogDescription>
             </DialogHeader>
-            <div className="pace-y-4 bg-gray-50 rounded-lg text-gray-900">
+
+            {/* Toolbar */}
+            <div className="flex flex-nowrap items-center gap-4 mb-4 p-3 rounded-lg border bg-muted/40 overflow-x-auto">
+              <div className="flex shrink-0 items-center gap-2">
+                {!sdfMode ? (
+                  <Badge
+                    className="border-transparent bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200"
+                    variant="secondary"
+                  >
+                    PNG
+                  </Badge>
+                ) : (
+                  <span className="text-sm font-medium text-muted-foreground select-none px-2 py-0.5">
+                    PNG
+                  </span>
+                )}
+                <Switch
+                  aria-label="Toggle SDF mode"
+                  checked={sdfMode}
+                  onCheckedChange={setSdfMode}
+                />
+                {sdfMode ? (
+                  <Badge
+                    className="border-transparent bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200"
+                    variant="secondary"
+                  >
+                    SDF
+                  </Badge>
+                ) : (
+                  <span className="text-sm font-medium text-muted-foreground select-none px-2 py-0.5">
+                    SDF
+                  </span>
+                )}
+              </div>
+
+              <div className="h-5 w-px bg-border shrink-0" />
+
+              <div className="flex shrink-0 items-center gap-2 min-w-[160px]">
+                {sdfMode ? (
+                  <>
+                    <span className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap">
+                      Scale: {sdfScale.toFixed(1)}×
+                    </span>
+                    <input
+                      aria-label="SDF icon scale"
+                      className="w-24 accent-purple-600 cursor-pointer"
+                      max={SDF_SCALE_MAX}
+                      min={SDF_SCALE_MIN}
+                      onChange={(e) => setSdfScale(Number(e.target.value))}
+                      step={0.1}
+                      type="range"
+                      value={sdfScale}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <span className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap">
+                      Size: {displaySize}px
+                    </span>
+                    <input
+                      aria-label="Sprite display size"
+                      className="w-24 accent-purple-600 cursor-pointer"
+                      max={SIZE_MAX}
+                      min={SIZE_MIN}
+                      onChange={(e) => setDisplaySize(Number(e.target.value))}
+                      step={4}
+                      type="range"
+                      value={displaySize}
+                    />
+                  </>
+                )}
+              </div>
+
+              <div
+                aria-hidden={!sdfMode}
+                className={cn(
+                  'flex shrink-0 items-center gap-4',
+                  !sdfMode && 'invisible pointer-events-none select-none',
+                )}
+              >
+                <div className="h-5 w-px bg-border shrink-0" />
+
+                <div className="flex items-center gap-2">
+                  <label
+                    className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap"
+                    htmlFor={iconColorId}
+                  >
+                    Icon
+                  </label>
+                  <input
+                    className="w-8 h-8 rounded cursor-pointer border border-border p-0.5 bg-transparent"
+                    disabled={!sdfMode}
+                    id={iconColorId}
+                    onChange={(e) => setIconColor(e.target.value)}
+                    title="Icon color"
+                    type="color"
+                    value={iconColor}
+                  />
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <label
+                    className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap"
+                    htmlFor={haloColorId}
+                  >
+                    Halo
+                  </label>
+                  <input
+                    className="w-8 h-8 rounded cursor-pointer border border-border p-0.5 bg-transparent"
+                    disabled={!sdfMode}
+                    id={haloColorId}
+                    onChange={(e) => setHaloColor(e.target.value)}
+                    title="Halo color"
+                    type="color"
+                    value={haloColor}
+                  />
+                </div>
+
+                <div className="flex items-center gap-2 min-w-[150px]">
+                  <span className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap">
+                    Halo: {haloWidth}px
+                  </span>
+                  <input
+                    aria-label="Halo width"
+                    className="w-24 accent-purple-600 cursor-pointer"
+                    disabled={!sdfMode}
+                    max={HALO_MAX}
+                    min={0}
+                    onChange={(e) => setHaloWidth(Number(e.target.value))}
+                    step={0.5}
+                    type="range"
+                    value={haloWidth}
+                  />
+                </div>
+
+                <div className="flex items-center gap-2 min-w-[150px]">
+                  <span className="text-sm font-medium text-muted-foreground select-none whitespace-nowrap">
+                    Blur: {haloBlur}px
+                  </span>
+                  <input
+                    aria-label="Halo blur"
+                    className="w-24 accent-purple-600 cursor-pointer"
+                    disabled={!sdfMode}
+                    max={HALO_BLUR_MAX}
+                    min={0}
+                    onChange={(e) => setHaloBlur(Number(e.target.value))}
+                    step={0.5}
+                    type="range"
+                    value={haloBlur}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-gray-50 rounded-lg text-gray-900 px-4 pb-5 pt-5 mt-1">
               <Suspense
                 fallback={
                   <div className="flex justify-center py-12">
@@ -51,6 +233,13 @@ export function SpritePreviewDialog({
               >
                 <SpritePreview
                   className="w-full grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-4"
+                  displaySize={displaySize}
+                  haloBlur={haloBlur}
+                  haloColor={haloColor}
+                  haloWidth={haloWidth}
+                  iconColor={iconColor}
+                  iconSize={sdfScale}
+                  sdfMode={sdfMode}
                   spriteIds={sprite.images}
                   spriteUrl={`/sprite/${name}`}
                 />

--- a/martin/martin-ui/src/components/sprite/SdfMapPreview.tsx
+++ b/martin/martin-ui/src/components/sprite/SdfMapPreview.tsx
@@ -117,10 +117,8 @@ export function SdfMapPreview({
     const map = new maplibregl.Map({
       center: [0, 0],
       container: containerRef.current,
-      // pixelRatio: 2,
       interactive: false,
       style: {
-        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
         layers: [
           {
             id: 'background',
@@ -137,7 +135,7 @@ export function SdfMapPreview({
               'text-allow-overlap': true,
               'text-anchor': 'top',
               'text-field': ['get', 'label'],
-              'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
+              'text-font': ['Arial Regular', 'Helvetica Regular'],
               'text-ignore-placement': true,
               'text-max-width': 8,
               'text-offset': [0, TEXT_OFFSET_Y],
@@ -149,6 +147,8 @@ export function SdfMapPreview({
               'icon-halo-color': styleRef.current.haloColor,
               'icon-halo-width': styleRef.current.haloWidth,
               'text-color': '#6b7280',
+              'text-halo-color': '#f9fafb',
+              'text-halo-width': 1,
             },
             source: SOURCE_ID,
             type: 'symbol',

--- a/martin/martin-ui/src/components/sprite/SdfMapPreview.tsx
+++ b/martin/martin-ui/src/components/sprite/SdfMapPreview.tsx
@@ -1,0 +1,215 @@
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { useCallback, useEffect, useRef } from 'react';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
+import { buildMartinUrl } from '@/lib/api';
+
+type SdfMapPreviewProps = {
+  spriteUrl: string;
+  spriteIds: readonly string[];
+  iconColor: string;
+  haloColor: string;
+  haloWidth: number;
+  haloBlur: number;
+  iconSize: number;
+};
+
+const LAYER_ID = 'sdf-icons';
+const SOURCE_ID = 'sdf-grid';
+const MAX_COLS = 6;
+const INITIAL_ZOOM = 15;
+const TEXT_OFFSET_Y = 1.5;
+const BASE_CELL_H = 130;
+
+const EMPTY_FC: GeoJSON.FeatureCollection = {
+  features: [],
+  type: 'FeatureCollection',
+};
+
+function cellHeight(iconSize: number): number {
+  const iconPx = 22 * iconSize;
+  const textPx = 16;
+  const offsetPx = TEXT_OFFSET_Y * textPx;
+  return Math.max(BASE_CELL_H, iconPx + offsetPx + textPx * 2 + 20);
+}
+
+function buildGridFeatures(
+  map: maplibregl.Map,
+  spriteIds: readonly string[],
+  cols: number,
+  cellH: number,
+): GeoJSON.Feature<GeoJSON.Point>[] {
+  const canvasW = map.getCanvas().clientWidth;
+  const cellW = canvasW / cols;
+
+  return spriteIds.map((id, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const px = col * cellW + cellW / 2;
+    const py = row * cellH + cellH / 2;
+    const lngLat = map.unproject([px, py]);
+    return {
+      geometry: {
+        coordinates: [lngLat.lng, lngLat.lat],
+        type: 'Point',
+      },
+      properties: { icon: id, label: id },
+      type: 'Feature',
+    };
+  });
+}
+
+function queryIconAtPoint(map: maplibregl.Map, point: [number, number]): string | undefined {
+  const features = map.queryRenderedFeatures(point, { layers: [LAYER_ID] });
+  return features[0]?.properties?.icon as string | undefined;
+}
+
+export function SdfMapPreview({
+  spriteUrl,
+  spriteIds,
+  iconColor,
+  haloColor,
+  haloWidth,
+  haloBlur,
+  iconSize,
+}: SdfMapPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const { copy } = useCopyToClipboard({
+    successMessage: 'Sprite ID copied to clipboard',
+  });
+  const copyRef = useRef(copy);
+  copyRef.current = copy;
+
+  const cols = Math.min(spriteIds.length, MAX_COLS);
+  const rows = Math.ceil(spriteIds.length / Math.max(cols, 1));
+  const cellH = cellHeight(iconSize);
+
+  const styleRef = useRef({ haloBlur, haloColor, haloWidth, iconColor, iconSize });
+  styleRef.current = { haloBlur, haloColor, haloWidth, iconColor, iconSize };
+
+  const handleClick = useCallback((e: MouseEvent) => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+
+    const rect = map.getCanvas().getBoundingClientRect();
+    const point: [number, number] = [e.clientX - rect.left, e.clientY - rect.top];
+    const name = queryIconAtPoint(map, point);
+    if (name) copyRef.current(name);
+  }, []);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    const map = mapRef.current;
+    const container = containerRef.current;
+    if (!map || !map.isStyleLoaded() || !container) return;
+
+    const rect = map.getCanvas().getBoundingClientRect();
+    const point: [number, number] = [e.clientX - rect.left, e.clientY - rect.top];
+    const name = queryIconAtPoint(map, point);
+    container.style.cursor = name ? 'pointer' : '';
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current || spriteIds.length === 0) return;
+
+    const sdfSpriteUrl = buildMartinUrl(spriteUrl.replace('/sprite/', '/sdf_sprite/'));
+
+    const map = new maplibregl.Map({
+      center: [0, 0],
+      container: containerRef.current,
+      // pixelRatio: 2,
+      interactive: false,
+      style: {
+        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+        layers: [
+          {
+            id: 'background',
+            paint: { 'background-color': '#f9fafb' },
+            type: 'background',
+          },
+          {
+            id: LAYER_ID,
+            layout: {
+              'icon-allow-overlap': true,
+              'icon-ignore-placement': true,
+              'icon-image': ['get', 'icon'],
+              'icon-size': styleRef.current.iconSize,
+              'text-allow-overlap': true,
+              'text-anchor': 'top',
+              'text-field': ['get', 'label'],
+              'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
+              'text-ignore-placement': true,
+              'text-max-width': 8,
+              'text-offset': [0, TEXT_OFFSET_Y],
+              'text-size': 13,
+            },
+            paint: {
+              'icon-color': styleRef.current.iconColor,
+              'icon-halo-blur': styleRef.current.haloBlur,
+              'icon-halo-color': styleRef.current.haloColor,
+              'icon-halo-width': styleRef.current.haloWidth,
+              'text-color': '#6b7280',
+            },
+            source: SOURCE_ID,
+            type: 'symbol',
+          },
+        ],
+        sources: {
+          [SOURCE_ID]: { data: EMPTY_FC, type: 'geojson' },
+        },
+        sprite: sdfSpriteUrl,
+        version: 8,
+      },
+      zoom: INITIAL_ZOOM,
+    });
+
+    map.once('load', () => {
+      const features = buildGridFeatures(map, spriteIds, cols, cellH);
+      const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource;
+      source.setData({ features, type: 'FeatureCollection' });
+    });
+
+    const canvas = map.getCanvas();
+    canvas.addEventListener('click', handleClick);
+    canvas.addEventListener('mousemove', handleMouseMove);
+
+    mapRef.current = map;
+
+    return () => {
+      canvas.removeEventListener('click', handleClick);
+      canvas.removeEventListener('mousemove', handleMouseMove);
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [spriteUrl, spriteIds, cols, cellH, handleClick, handleMouseMove]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const update = () => {
+      if (!map.getLayer(LAYER_ID)) return;
+      map.setLayoutProperty(LAYER_ID, 'icon-size', iconSize);
+      map.setPaintProperty(LAYER_ID, 'icon-color', iconColor);
+      map.setPaintProperty(LAYER_ID, 'icon-halo-color', haloColor);
+      map.setPaintProperty(LAYER_ID, 'icon-halo-width', haloWidth);
+      map.setPaintProperty(LAYER_ID, 'icon-halo-blur', haloBlur);
+    };
+
+    if (map.isStyleLoaded()) {
+      update();
+    } else {
+      map.once('style.load', update);
+    }
+
+    return () => {
+      map.off('style.load', update);
+    };
+  }, [iconColor, iconSize, haloColor, haloWidth, haloBlur]);
+
+  const totalHeight = rows * cellH;
+
+  return (
+    <div className="w-full rounded-lg border" ref={containerRef} style={{ height: totalHeight }} />
+  );
+}

--- a/martin/martin-ui/src/components/sprite/SpriteCanvas.tsx
+++ b/martin/martin-ui/src/components/sprite/SpriteCanvas.tsx
@@ -9,16 +9,28 @@ type SpriteCanvasProps = {
   image?: HTMLImageElement;
   label: string;
   previewMode?: boolean;
+  displaySize?: number;
 };
 
-const SpriteCanvas = ({ meta, image, label, previewMode = false }: SpriteCanvasProps) => {
+const SpriteCanvas = ({
+  meta,
+  image,
+  label,
+  previewMode = false,
+  displaySize,
+}: SpriteCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  // not using copied since on-click the tooltip closes
   const { copy } = useCopyToClipboard({
     successMessage: `Sprite ID "${label}" copied to clipboard`,
   });
 
   const handleClick = () => copy(label);
+
+  const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+
+  // Resolve the CSS display size
+  const cssSize = displaySize ?? (previewMode ? 28 : 80);
+  const sizeStyle = { height: cssSize, width: cssSize };
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -26,27 +38,44 @@ const SpriteCanvas = ({ meta, image, label, previewMode = false }: SpriteCanvasP
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-    // Clear
-    ctx.clearRect(0, 0, meta.width, meta.height);
-    // Draw the sprite sub-image
-    ctx.drawImage(image, meta.x, meta.y, meta.width, meta.height, 0, 0, meta.width, meta.height);
-  }, [meta, image]);
 
-  if (previewMode)
+    const backingW = Math.round(cssSize * dpr);
+    const backingH = Math.round(cssSize * dpr);
+    canvas.width = backingW;
+    canvas.height = backingH;
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssSize, cssSize);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+
+    const srcW = meta.width;
+    const srcH = meta.height;
+    const scale = Math.min(cssSize / srcW, cssSize / srcH);
+    const drawW = srcW * scale;
+    const drawH = srcH * scale;
+    const offsetX = (cssSize - drawW) / 2;
+    const offsetY = (cssSize - drawH) / 2;
+    ctx.drawImage(image, meta.x, meta.y, srcW, srcH, offsetX, offsetY, drawW, drawH);
+  }, [meta, image, dpr, cssSize]);
+
+  if (previewMode) {
     return (
-      <div className="flex flex-col items-center justify-center m-1.5 h-7 w-7">
+      <div className="flex flex-col items-center justify-center m-1.5" style={sizeStyle}>
         {!meta || !image ? (
-          <div className="w-7 h-7 animate-pulse bg-purple-200 rounded-sm flex items-center justify-center"></div>
+          <div
+            className="animate-pulse bg-purple-200 rounded-sm flex items-center justify-center"
+            style={sizeStyle}
+          />
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
               <canvas
                 aria-label={`Icon for ${label}`}
-                className="h-7 w-7 object-contain block cursor-pointer hover:opacity-75 transition-opacity"
-                height={meta.height}
+                className="object-contain block cursor-pointer hover:opacity-75 transition-opacity"
                 onClick={handleClick}
                 ref={canvasRef}
-                width={meta.width}
+                style={sizeStyle}
               />
             </TooltipTrigger>
             <TooltipContent>
@@ -65,27 +94,31 @@ const SpriteCanvas = ({ meta, image, label, previewMode = false }: SpriteCanvasP
         )}
       </div>
     );
+  }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
-          className="flex flex-col items-center justify-center m-4 h-32 w-24"
+          className="flex flex-col items-center justify-center m-4"
           onClick={handleClick}
+          style={{ minHeight: cssSize + 40, width: cssSize + 16 }}
           type="button"
         >
           <div className="flex flex-1 items-center justify-center w-full">
             {!meta || !image ? (
-              <div className="w-24 h-24 animate-pulse bg-purple-200 rounded-sm flex items-center justify-center cursor-pointer hover:bg-purple-300 transition-colors"></div>
+              <div
+                className="animate-pulse bg-purple-200 rounded-sm flex items-center justify-center cursor-pointer hover:bg-purple-300 transition-colors"
+                style={sizeStyle}
+              />
             ) : (
-              <div className="flex items-center justify-center h-20 w-20">
+              <div className="flex items-center justify-center" style={sizeStyle}>
                 <canvas
                   aria-label={`Icon for ${label}`}
-                  className="h-20 w-20 object-contain block cursor-pointer hover:opacity-75 transition-opacity"
-                  height={meta.height}
+                  className="object-contain block cursor-pointer hover:opacity-75 transition-opacity"
                   onClick={handleClick}
                   ref={canvasRef}
-                  width={meta.width}
+                  style={sizeStyle}
                 />
               </div>
             )}

--- a/martin/martin-ui/src/components/sprite/SpritePreview.tsx
+++ b/martin/martin-ui/src/components/sprite/SpritePreview.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useEffect, useState } from 'react';
 import { buildMartinUrl } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { SdfMapPreview } from './SdfMapPreview';
 import { fetchSpriteImage, fetchSpriteIndex, type SpriteMeta } from './SpriteCache';
 import SpriteCanvas from './SpriteCanvas';
 
@@ -23,6 +24,24 @@ type SpritePreviewProps = {
    * Optional className for the container.
    */
   className?: string;
+  /**
+   * When true, render using MapLibre GL with the SDF sprite endpoint for dynamic icon/halo coloring.
+   */
+  sdfMode?: boolean;
+  /**
+   * Display size in px for each sprite icon. Falls back to previewMode/full-size defaults.
+   */
+  displaySize?: number;
+  /** Icon fill color for SDF mode */
+  iconColor?: string;
+  /** Halo color for SDF mode */
+  haloColor?: string;
+  /** Halo width in pixels for SDF mode */
+  haloWidth?: number;
+  /** Halo blur in pixels for SDF mode */
+  haloBlur?: number;
+  /** Icon scale factor for SDF mode (1.0 = native size) */
+  iconSize?: number;
 };
 
 type SpriteState =
@@ -39,6 +58,13 @@ export const SpritePreview: React.FC<SpritePreviewProps> = ({
   spriteIds,
   previewMode,
   className,
+  sdfMode = false,
+  displaySize,
+  iconColor,
+  haloColor,
+  haloWidth,
+  haloBlur,
+  iconSize,
 }) => {
   const PREVIEW_LIMIT = 18;
   const [state, setState] = useState<SpriteState>({ status: 'loading' });
@@ -85,6 +111,21 @@ export const SpritePreview: React.FC<SpritePreviewProps> = ({
     ids = ids.slice(0, PREVIEW_LIMIT - 1);
   }
 
+  // --- SDF mode: render via MapLibre GL ---
+  if (sdfMode) {
+    return (
+      <SdfMapPreview
+        haloBlur={haloBlur ?? 0}
+        haloColor={haloColor ?? '#ffffff'}
+        haloWidth={haloWidth ?? 0}
+        iconColor={iconColor ?? '#1a1a2e'}
+        iconSize={iconSize ?? 1}
+        spriteIds={ids}
+        spriteUrl={spriteUrl}
+      />
+    );
+  }
+
   // --- Main grid of sprites ---
   if (state.status === 'error') {
     return (
@@ -110,6 +151,7 @@ export const SpritePreview: React.FC<SpritePreviewProps> = ({
     <div className={cn(`flex flex-wrap gap-3 justify-start items-start min-h-[120px]`, className)}>
       {ids.map((id) => (
         <SpriteCanvas
+          displaySize={displaySize}
           image={state.status === 'ready' ? state.image : undefined}
           key={id}
           label={id}


### PR DESCRIPTION
Fixes: #1984 

**Summary**

Add an SDF preview mode to the sprite dialog that renders icons via MapLibre GL, allowing users to visualize SDF sprites with dynamic icon color, halo color/width/blur, and scale matching real map renderer behavior.
Introduce a toolbar with a PNG/SDF toggle, size/scale sliders, and color pickers so users can interactively inspect sprites without leaving the Martin UI.

Parameters added for SDF preview: 
- [x] Icon color
- [x] Icon size
- [x] Halo color
- [x] Halo width
- [x] Halo blur

**ScreenShot** 

https://github.com/user-attachments/assets/c0a21084-75c9-4efe-b230-9f64d0781e79