### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,7 @@ jobs:
       - name: Test in FreeBSD
         id: test
         uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd # v1
+        continue-on-error: true # fixme: remove
         with:
           release: "15.0"
           envs: "AWS_SKIP_CREDENTIALS AWS_REGION"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.2"
-martin-core = { path = "./martin-core", version = "0.3.2", default-features = false }
+martin-core = { path = "./martin-core", version = "0.4.0", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.6.12" }
-mbtiles = { path = "./mbtiles", version = "0.15.4" }
+mbtiles = { path = "./mbtiles", version = "0.16.0" }
 md5 = "0.8.0"
 moka = { version = "0.12", default-features = false }
 num_cpus = "1"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.5.0
+    image: ghcr.io/maplibre/martin:1.6.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.5.0 \
+           ghcr.io/maplibre/martin:1.6.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.5.0
+    image: ghcr.io/maplibre/martin:1.6.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.5.0
+  ghcr.io/maplibre/martin:1.6.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.5.0 \
+  ghcr.io/maplibre/martin:1.6.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.5.0
+  ghcr.io/maplibre/martin:1.6.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.5.0
+  ghcr.io/maplibre/martin:1.6.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.5.0
+  ghcr.io/maplibre/martin:1.6.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.5.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.6.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.5.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.6.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -225,7 +225,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.5.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.6.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/maplibre/martin/compare/martin-core-v0.3.2...martin-core-v0.4.0) - 2026-04-15
+
+### Added
+
+- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
+- make internal cache expiry configurable ([#2691](https://github.com/maplibre/martin/pull/2691))
+- support per-source cache zoom level ([#2673](https://github.com/maplibre/martin/pull/2673))
+
+### Other
+
+- Use moka entry API for deduplicating cache inserts + retrievals ([#2688](https://github.com/maplibre/martin/pull/2688))
+- add a formatting restriction when something should be an import vs path ([#2685](https://github.com/maplibre/martin/pull/2685))
+- introduce `TileSourceManager` and `ReloadAdvisory` ([#2661](https://github.com/maplibre/martin/pull/2661))
+- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
+- make sure our unit tests run under macos too ([#2648](https://github.com/maplibre/martin/pull/2648))
+- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
+
 ## [0.3.2](https://github.com/maplibre/martin/compare/martin-core-v0.3.1...martin-core-v0.3.2) - 2026-04-02
 
 ### Fixed

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/maplibre/martin/compare/martin-v1.5.0...martin-v1.6.0) - 2026-04-15
+
+### Added
+
+- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
+- make internal cache expiry configurable ([#2691](https://github.com/maplibre/martin/pull/2691))
+- support per-source cache zoom level ([#2673](https://github.com/maplibre/martin/pull/2673))
+- *(ui)* add React Compiler to martin-ui and demo/frontend ([#2686](https://github.com/maplibre/martin/pull/2686))
+- *(mbtiles)* Support planetilers' normalised schema ([#2681](https://github.com/maplibre/martin/pull/2681))
+- expose `on_invalid` as a CLI argument ([#2668](https://github.com/maplibre/martin/pull/2668))
+
+### Fixed
+
+- correct npm lockfile-only flag and handle missing lockfiles in sync-biome-version hook ([#2627](https://github.com/maplibre/martin/pull/2627))
+
+### Other
+
+- Use moka entry API for deduplicating cache inserts + retrievals ([#2688](https://github.com/maplibre/martin/pull/2688))
+- add a formatting restriction when something should be an import vs path ([#2685](https://github.com/maplibre/martin/pull/2685))
+- *(deps)* autoupdate pre-commit ([#2684](https://github.com/maplibre/martin/pull/2684))
+- introduce `TileSourceManager` and `ReloadAdvisory` ([#2661](https://github.com/maplibre/martin/pull/2661))
+- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
+- *(deps)* autoupdate pre-commit ([#2624](https://github.com/maplibre/martin/pull/2624))
+- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
+- *(deps-dev)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2662](https://github.com/maplibre/martin/pull/2662))
+- *(deps-dev)* Bump @biomejs/biome from 2.4.6 to 2.4.9 in /martin/martin-ui ([#2657](https://github.com/maplibre/martin/pull/2657))
+- make sure our unit tests run under macos too ([#2648](https://github.com/maplibre/martin/pull/2648))
+
 ## [1.5.0](https://github.com/maplibre/martin/compare/martin-v1.4.0...martin-v1.5.0) - 2026-04-02
 
 ### Fixed

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.5.0"
+version = "1.6.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/maplibre/martin/compare/mbtiles-v0.15.4...mbtiles-v0.16.0) - 2026-04-15
+
+### Added
+
+- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
+- *(mbtiles)* Support planetilers' normalised schema ([#2681](https://github.com/maplibre/martin/pull/2681))
+
+### Other
+
+- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
+- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
+
 ## [0.15.4](https://github.com/maplibre/martin/compare/mbtiles-v0.15.3...mbtiles-v0.15.4) - 2026-04-02
 
 ### Fixed

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.15.4"
+version = "0.16.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.15.4 -> 0.16.0 (⚠ API breaking changes)
* `martin-core`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)
* `martin`: 1.5.0 -> 1.6.0

### ⚠ `mbtiles` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field schema of variant MbtType::Normalized in /tmp/.tmpb1dHqg/martin/mbtiles/src/validation.rs:122

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  mbtiles::Mbtiles::insert_tiles takes 1 generic types instead of 0, in /tmp/.tmpb1dHqg/martin/mbtiles/src/mbtiles.rs:614
```

### ⚠ `martin-core` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  martin_core::tiles::mbtiles::MbtSource::new now takes 3 parameters instead of 2, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/mbtiles/source.rs:56
  martin_core::tiles::postgres::PostgresSource::new now takes 5 parameters instead of 4, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/postgres/source.rs:30
  martin_core::fonts::FontCache::new now takes 3 parameters instead of 1, in /tmp/.tmpb1dHqg/martin/martin-core/src/resources/fonts/cache.rs:22
  martin_core::tiles::pmtiles::PmtilesSource::new now takes 5 parameters instead of 4, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/pmtiles/source.rs:39
  martin_core::tiles::TileCache::new now takes 3 parameters instead of 1, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/cache.rs:17
  martin_core::tiles::pmtiles::PmtCache::new now takes 3 parameters instead of 1, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/pmtiles/cache.rs:21
  martin_core::tiles::cog::CogSource::new now takes 3 parameters instead of 2, in /tmp/.tmpb1dHqg/martin/martin-core/src/tiles/cog/source.rs:42
  martin_core::sprites::SpriteCache::new now takes 3 parameters instead of 1, in /tmp/.tmpb1dHqg/martin/martin-core/src/resources/sprites/cache.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.16.0](https://github.com/maplibre/martin/compare/mbtiles-v0.15.4...mbtiles-v0.16.0) - 2026-04-15

### Added

- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
- *(mbtiles)* Support planetilers' normalised schema ([#2681](https://github.com/maplibre/martin/pull/2681))

### Other

- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
</blockquote>

## `martin-core`

<blockquote>

## [0.4.0](https://github.com/maplibre/martin/compare/martin-core-v0.3.2...martin-core-v0.4.0) - 2026-04-15

### Added

- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
- make internal cache expiry configurable ([#2691](https://github.com/maplibre/martin/pull/2691))
- support per-source cache zoom level ([#2673](https://github.com/maplibre/martin/pull/2673))

### Other

- Use moka entry API for deduplicating cache inserts + retrievals ([#2688](https://github.com/maplibre/martin/pull/2688))
- add a formatting restriction when something should be an import vs path ([#2685](https://github.com/maplibre/martin/pull/2685))
- introduce `TileSourceManager` and `ReloadAdvisory` ([#2661](https://github.com/maplibre/martin/pull/2661))
- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
- make sure our unit tests run under macos too ([#2648](https://github.com/maplibre/martin/pull/2648))
- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
</blockquote>

## `martin`

<blockquote>

## [1.6.0](https://github.com/maplibre/martin/compare/martin-v1.5.0...martin-v1.6.0) - 2026-04-15

### Added

- *(mbtiles)* Add a transcoder API ([#2682](https://github.com/maplibre/martin/pull/2682))
- make internal cache expiry configurable ([#2691](https://github.com/maplibre/martin/pull/2691))
- support per-source cache zoom level ([#2673](https://github.com/maplibre/martin/pull/2673))
- *(ui)* add React Compiler to martin-ui and demo/frontend ([#2686](https://github.com/maplibre/martin/pull/2686))
- *(mbtiles)* Support planetilers' normalised schema ([#2681](https://github.com/maplibre/martin/pull/2681))
- expose `on_invalid` as a CLI argument ([#2668](https://github.com/maplibre/martin/pull/2668))

### Fixed

- correct npm lockfile-only flag and handle missing lockfiles in sync-biome-version hook ([#2627](https://github.com/maplibre/martin/pull/2627))

### Other

- Use moka entry API for deduplicating cache inserts + retrievals ([#2688](https://github.com/maplibre/martin/pull/2688))
- add a formatting restriction when something should be an import vs path ([#2685](https://github.com/maplibre/martin/pull/2685))
- *(deps)* autoupdate pre-commit ([#2684](https://github.com/maplibre/martin/pull/2684))
- introduce `TileSourceManager` and `ReloadAdvisory` ([#2661](https://github.com/maplibre/martin/pull/2661))
- Enable `clippy::unwrap_used` workspace lint ([#2670](https://github.com/maplibre/martin/pull/2670))
- *(deps)* autoupdate pre-commit ([#2624](https://github.com/maplibre/martin/pull/2624))
- hotpath based profiling integration ([#2663](https://github.com/maplibre/martin/pull/2663))
- *(deps-dev)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2662](https://github.com/maplibre/martin/pull/2662))
- *(deps-dev)* Bump @biomejs/biome from 2.4.6 to 2.4.9 in /martin/martin-ui ([#2657](https://github.com/maplibre/martin/pull/2657))
- make sure our unit tests run under macos too ([#2648](https://github.com/maplibre/martin/pull/2648))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).