### PR TITLE
fix: Use HOTPATH_ALLOC_SELF for benchmarks

### DIFF
--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           HOTPATH_OUTPUT_FORMAT: json
           HOTPATH_OUTPUT_PATH: /tmp/metrics/head_timing.json
+          HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
         run: |
           set -euo pipefail
@@ -108,6 +109,7 @@ jobs:
         env:
           HOTPATH_OUTPUT_FORMAT: json
           HOTPATH_OUTPUT_PATH: /tmp/metrics/base_timing.json
+          HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Hi, https://github.com/pawurb/hotpath-rs author here.

I've noticed you're using CI integration. Default alloc tracking mode produces invalid results for recursive functions as you can see e.g. https://github.com/maplibre/martin/pull/2668 . 

This config should produce better results, I'm planning to make it default in next release.

BTW I'm actively working on the lib, so any feedback/bugs will be welcome.