### PR TITLE
ci: FreeBSD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,31 @@ jobs:
             target/test_logs/*
           retention-days: 5
 
+  test-freebsd:
+    name: Unit test on FreeBSD
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - lint-rust
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with: { persist-credentials: false }
+      - name: Test in FreeBSD
+        id: test
+        uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd # v1
+        with:
+          release: "14.2"
+          envs: "AWS_SKIP_CREDENTIALS AWS_REGION"
+          prepare: |
+            pkg install -y rust sqlite3 freetype2 cmake just
+          run: just env-info
+          run: just test
+        env:
+          AWS_SKIP_CREDENTIALS: 1
+          AWS_REGION: eu-central-1
+
   unit-test-svc-pg:
     name: Unit test postgis:${{ matrix.img_ver }} sslmode=${{ matrix.sslmode }}
     runs-on: ubuntu-latest
@@ -753,7 +778,7 @@ jobs:
       attestations: write
       # for writing release artifacts
       contents: write
-    needs: [ lint-unit-test-js, unit-test-rust, lint-rust, lint-rust-dependencies, test-multi-os, test-with-svc, test-aws-lambda, test-publish, build-aarch64-apple-darwin, build-x86_64-apple-darwin, build-aarch64-unknown-linux-gnu, build-aarch64-unknown-linux-musl ]
+    needs: [ lint-unit-test-js, unit-test-rust, lint-rust, lint-rust-dependencies, test-multi-os, test-with-svc, test-aws-lambda, test-freebsd, test-publish, build-aarch64-apple-darwin, build-x86_64-apple-darwin, build-aarch64-unknown-linux-gnu, build-aarch64-unknown-linux-musl ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,8 +593,9 @@ jobs:
           # - freetype2 for font rendering to SDF
           # - cmake for aws-lc-sys
           # - just for running standardized test suites
+          # - bash because the justfile has a lot of scripts that assume bash
           prepare: |
-            pkg install -y rust sqlite3 freetype2 cmake just
+            pkg install -y rust sqlite3 freetype2 cmake just bash
           run: |
             just env-info
             just test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,8 +586,13 @@ jobs:
         id: test
         uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd # v1
         with:
-          release: "14.2"
+          release: "15.0"
           envs: "AWS_SKIP_CREDENTIALS AWS_REGION"
+          # Dependencies (FreeBSD base systems come more bare):
+          # - sqlite3 for MBTiles support
+          # - freetype2 for font rendering to SDF
+          # - cmake for aws-lc-sys
+          # - just for running standardized test suites
           prepare: |
             pkg install -y rust sqlite3 freetype2 cmake just
           run: |
@@ -925,6 +930,7 @@ jobs:
       - lint-rust-dependencies
       - lint-unit-test-js
       - lint-rust
+      - test-freebsd
     if: always()
     permissions: {}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,8 +594,10 @@ jobs:
           # - cmake for aws-lc-sys
           # - just for running standardized test suites
           # - bash because the justfile has a lot of scripts that assume bash
+          # - node and npm are not currently used (we don't run the JS tests on FreeBSD),
+          #   but they are here in case we want them later.
           prepare: |
-            pkg install -y rust sqlite3 freetype2 cmake just bash
+            pkg install -y rust sqlite3 freetype2 cmake just bash node npm
           run: |
             just env-info
             just test-freebsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,7 +598,7 @@ jobs:
             pkg install -y rust sqlite3 freetype2 cmake just bash
           run: |
             just env-info
-            just test
+            just test-freebsd
         env:
           AWS_SKIP_CREDENTIALS: 1
           AWS_REGION: eu-central-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,8 +590,9 @@ jobs:
           envs: "AWS_SKIP_CREDENTIALS AWS_REGION"
           prepare: |
             pkg install -y rust sqlite3 freetype2 cmake just
-          run: just env-info
-          run: just test
+          run: |
+            just env-info
+            just test
         env:
           AWS_SKIP_CREDENTIALS: 1
           AWS_REGION: eu-central-1

--- a/justfile
+++ b/justfile
@@ -241,7 +241,7 @@ env-info:
     {{just}} --version
     rustc --version
     cargo --version
-    rustup --version
+    @if [ "$(uname)" != "FreeBSD" ]; then rustup --version; fi
     @echo "RUSTFLAGS='$RUSTFLAGS'"
     @echo "RUSTDOCFLAGS='$RUSTDOCFLAGS'"
     @echo "RUST_BACKTRACE='$RUST_BACKTRACE'"
@@ -491,6 +491,11 @@ test-lambda martin_bin='target/debug/martin':
 
     jq -ne 'input.statusCode == 200' <<<"$response"
 
+# Run tests that matter on FreeBSD.
+# Notably, we have to skip the postgres tests because the current structure relies on running docker
+# within the test. Additionally, some of the benches that run with --all-targets
+# are also docker-based integration tests.
+test-freebsd: (test-cargo "--lib --bins --tests --examples") test-doc
 
 # Run all tests using the oldest supported version of the database
 test-legacy: start-legacy (test-cargo "--all-targets") test-pg test-doc test-int


### PR DESCRIPTION
It looks like there are a few somewhat disjoint ways of executing tests, so I went with something that looked reasonable. This is a separate stage since it's quite a bit different from the other (e.g. multi-os) builds as it needs this qemu action to wrap the logic.

Closes #2680.

Notes:

- I added a test-freebsd just recipe to codify what we're testing.
- This does NOT exercise the integration test suite. This shouldn't be an issue as it is already run on many other platforms. The reason we can't run these is because they rely on Docker being available directly within the test environment. To make this more cross-platform, there might be a way to attach "services" to GitHub Actions (I don't know it that well but some other CI platforms do). Another option would be to switch to Podman which isn't so Linux-specific. But it looks like this is a _very_ deep rabbit hole between direct docker invocations in the justfile and the `testcontainers` package trying to spin up postgres directly in benchmark and integration tests.