### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix-web",
  "approx",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.2"
-martin-core = { path = "./martin-core", version = "0.4.0", default-features = false }
+martin-core = { path = "./martin-core", version = "0.4.1", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.0" }
-mbtiles = { path = "./mbtiles", version = "0.16.0" }
+mbtiles = { path = "./mbtiles", version = "0.17.0" }
 md5 = "0.8.0"
 moka = { version = "0.12", default-features = false }
 num_cpus = "1"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.6.0
+    image: ghcr.io/maplibre/martin:1.7.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.6.0 \
+           ghcr.io/maplibre/martin:1.7.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.6.0
+    image: ghcr.io/maplibre/martin:1.7.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.6.0
+  ghcr.io/maplibre/martin:1.7.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.6.0 \
+  ghcr.io/maplibre/martin:1.7.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.6.0
+  ghcr.io/maplibre/martin:1.7.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.6.0
+  ghcr.io/maplibre/martin:1.7.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.6.0
+  ghcr.io/maplibre/martin:1.7.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.6.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.7.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.6.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.7.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -225,7 +225,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.6.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.7.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/maplibre/martin/compare/martin-core-v0.4.0...martin-core-v0.4.1) - 2026-04-23
+
+### Other
+
+- Stabilize PMTiles directory cache TTL/TTI tests under scheduler jitter ([#2725](https://github.com/maplibre/martin/pull/2725))
+- add retries when starting PostGIS testcontainers ([#2724](https://github.com/maplibre/martin/pull/2724))
+- Stabilize flaky ttl_evicts_even_with_frequent_access test in tiles_test ([#2715](https://github.com/maplibre/martin/pull/2715))
+
 ## [0.4.0](https://github.com/maplibre/martin/compare/martin-core-v0.3.2...martin-core-v0.4.0) - 2026-04-18
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,9 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0](https://github.com/maplibre/martin/compare/martin-v1.6.0...martin-v1.7.0) - 2026-04-23
 
+### `martin_tile_cache_requests_total` and `martin_cache_requests_total` metrics
+
+We have added the following metrics, allowing for knowing what your cache hit rate.
+These are two metrics because for tiles we include the zoom while for fonts/sprites this does not make sense.
+
+```raw
+# HELP martin_cache_requests_total Martin cache lookups, labeled by cache type and hit/miss result
+# TYPE martin_cache_requests_total counter
+martin_cache_requests_total{cache="font",result="miss"} NUMBER
+martin_cache_requests_total{cache="sprite",result="miss"} NUMBER
+# HELP martin_tile_cache_requests_total Martin tile-coordinate cache lookups, labeled by cache type, hit/miss result, and zoom
+# TYPE martin_tile_cache_requests_total counter
+martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} NUMBER
+martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} NUMBER
+```
+
+> [!TIP]
+> If you have concrete needs for what metrics you would like to see, please open an issue.
+> The set of metrics we offer is quite early in its development livecycle.
+
+### Stabilised Server-side raster tile rendering backend
+
+We have stabilised our rendering backend, which means that you can now render images using MapLibre Native.
+We have some work planned to improve performance by prefetching and better paralelism, or to add capabilites like overlaying lines/text/shapes.. via query params.
+If you have needs/interests towards this area, we would also invite you to open a discussion/issue on the API that you would like to see.
+If you need configurability, we would also like to know what kind of configurability you need.
+
+To enable this feature, you need to add the following to your configuration file:
+
+```yaml
+styles:
+    rendering: true
+```
+
 ### Added
 
-- *(ui)* Add Tile URLs TileJSON and XYZ Tiles URLs ([#2731](https://github.com/maplibre/martin/pull/2731))
+- *(ui)* Add Tile URLs TileJSON and XYZ Tiles URLs to the inspect UI ([#2731](https://github.com/maplibre/martin/pull/2731))
 - *(mbtiles)* add --strict flag to use STRICT SQLite tables ([#2712](https://github.com/maplibre/martin/pull/2712))
 
 ### Fixed
@@ -20,10 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- add retries when starting PostGIS testcontainers ([#2724](https://github.com/maplibre/martin/pull/2724))
+- Some refactorings to increase CI reliability ([#2724](https://github.com/maplibre/martin/pull/2724), [#2715](https://github.com/maplibre/martin/pull/2715), [#2725](https://github.com/maplibre/martin/pull/2725))
 - *(deps)* autoupdate pre-commit ([#2720](https://github.com/maplibre/martin/pull/2720))
-- Stabilize PMTiles directory cache TTL/TTI tests under scheduler jitter ([#2725](https://github.com/maplibre/martin/pull/2725))
-- Stabilize flaky ttl_evicts_even_with_frequent_access test in tiles_test ([#2715](https://github.com/maplibre/martin/pull/2715))
 
 ## [1.6.0](https://github.com/maplibre/martin/compare/martin-v1.5.0...martin-v1.6.0) - 2026-04-18
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/maplibre/martin/compare/martin-v1.6.0...martin-v1.7.0) - 2026-04-23
+
+### Added
+
+- *(ui)* Add Tile URLs TileJSON and XYZ Tiles URLs ([#2731](https://github.com/maplibre/martin/pull/2731))
+- *(mbtiles)* add --strict flag to use STRICT SQLite tables ([#2712](https://github.com/maplibre/martin/pull/2712))
+
+### Fixed
+
+- Keep /health available with `--route-prefix foo` instead of just moving it to /foo/health to enable docker healthchecks ([#2723](https://github.com/maplibre/martin/pull/2723))
+
+### Other
+
+- add retries when starting PostGIS testcontainers ([#2724](https://github.com/maplibre/martin/pull/2724))
+- *(deps)* autoupdate pre-commit ([#2720](https://github.com/maplibre/martin/pull/2720))
+- Stabilize PMTiles directory cache TTL/TTI tests under scheduler jitter ([#2725](https://github.com/maplibre/martin/pull/2725))
+- Stabilize flaky ttl_evicts_even_with_frequent_access test in tiles_test ([#2715](https://github.com/maplibre/martin/pull/2715))
+
 ## [1.6.0](https://github.com/maplibre/martin/compare/martin-v1.5.0...martin-v1.6.0) - 2026-04-18
 
 ### Smarter, more configurable caching

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.6.0"
+version = "1.7.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/maplibre/martin/compare/mbtiles-v0.16.0...mbtiles-v0.17.0) - 2026-04-23
+
+### Added
+
+- *(mbtiles)* add --strict flag to use STRICT SQLite tables ([#2712](https://github.com/maplibre/martin/pull/2712))
+
 ## [0.16.0](https://github.com/maplibre/martin/compare/mbtiles-v0.15.4...mbtiles-v0.16.0) - 2026-04-18
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.16.0 -> 0.17.0 (⚠ API breaking changes)
* `martin-core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `martin`: 1.6.0 -> 1.7.0

### ⚠ `mbtiles` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MbtilesCopier.strict in /tmp/.tmphLVXVI/martin/mbtiles/src/copier.rs:83

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  mbtiles::create_normalized_tables now takes 2 parameters instead of 1, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:325
  mbtiles::create_flat_tables now takes 2 parameters instead of 1, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:206
  mbtiles::create_bsdiffraw_tables now takes 3 parameters instead of 2, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:260
  mbtiles::init_mbtiles_schema now takes 3 parameters instead of 2, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:398
  mbtiles::create_flat_with_hash_tables now takes 2 parameters instead of 1, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:225
  mbtiles::create_metadata_table now takes 2 parameters instead of 1, in /tmp/.tmphLVXVI/martin/mbtiles/src/queries.rs:190
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.17.0](https://github.com/maplibre/martin/compare/mbtiles-v0.16.0...mbtiles-v0.17.0) - 2026-04-23

### Added

- *(mbtiles)* add --strict flag to use STRICT SQLite tables ([#2712](https://github.com/maplibre/martin/pull/2712))
</blockquote>

## `martin-core`

<blockquote>

## [0.4.1](https://github.com/maplibre/martin/compare/martin-core-v0.4.0...martin-core-v0.4.1) - 2026-04-23

### Other

- Stabilize PMTiles directory cache TTL/TTI tests under scheduler jitter ([#2725](https://github.com/maplibre/martin/pull/2725))
- add retries when starting PostGIS testcontainers ([#2724](https://github.com/maplibre/martin/pull/2724))
- Stabilize flaky ttl_evicts_even_with_frequent_access test in tiles_test ([#2715](https://github.com/maplibre/martin/pull/2715))
</blockquote>

## `martin`

<blockquote>

## [1.7.0](https://github.com/maplibre/martin/compare/martin-v1.6.0...martin-v1.7.0) - 2026-04-23

### Added

- *(ui)* Add Tile URLs TileJSON and XYZ Tiles URLs ([#2731](https://github.com/maplibre/martin/pull/2731))
- *(mbtiles)* add --strict flag to use STRICT SQLite tables ([#2712](https://github.com/maplibre/martin/pull/2712))

### Fixed

- Keep /health available with `--route-prefix foo` instead of just moving it to /foo/health to enable docker healthchecks ([#2723](https://github.com/maplibre/martin/pull/2723))

### Other

- add retries when starting PostGIS testcontainers ([#2724](https://github.com/maplibre/martin/pull/2724))
- *(deps)* autoupdate pre-commit ([#2720](https://github.com/maplibre/martin/pull/2720))
- Stabilize PMTiles directory cache TTL/TTI tests under scheduler jitter ([#2725](https://github.com/maplibre/martin/pull/2725))
- Stabilize flaky ttl_evicts_even_with_frequent_access test in tiles_test ([#2715](https://github.com/maplibre/martin/pull/2715))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).