### PR TITLE
feat(ui): Add Tile URLs TileJSON and XYZ Tiles URLs

### DIFF
--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -6,7 +6,6 @@ import { Layer, Map as MapLibreMap, Source } from '@vis.gl/react-maplibre';
 import type { VectorSourceSpecification } from 'maplibre-gl';
 import { Popup } from 'maplibre-gl';
 import { type ErrorInfo, useEffect, useId, useRef } from 'react';
-import { Toaster } from '@/components/ui/toaster';
 import { useAsyncOperation } from '@/hooks/use-async-operation';
 import { useToast } from '@/hooks/use-toast';
 import { buildMartinUrl } from '@/lib/api';
@@ -159,7 +158,6 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
           }}
         ></MapLibreMap>
       )}
-      <Toaster />
     </ErrorBoundary>
   );
 }

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -9,11 +9,11 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
-import { buildMartinUrl } from '@/lib/api';
 import { Database, Link } from 'lucide-react';
+import { CopyableUrl } from '@/components/ui/copyable-url';
+import { buildMartinUrl } from '@/lib/api';
 import { LoadingSpinner } from '../loading/loading-spinner';
 import { TileInspectDialogMap } from './tile-inspect-map';
-import { CopyableUrl } from '@/components/ui/copyable-url';
 
 interface TileInspectDialogProps {
   name: string;

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -44,6 +44,7 @@ function CopyableUrl({ label, url }: { label: string; url: string }) {
       <span className="flex items-center gap-2 mt-1">
         <code className="text-xs break-all flex-1">{url}</code>
         <button
+          type="button"
           onClick={handleCopy}
           className="shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
           title={`Copy ${label}`}

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -1,6 +1,5 @@
 'use client';
-
-import { Suspense } from 'react';
+import { Suspense, useState, useCallback } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +9,8 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
-import { Database } from 'lucide-react';
+import { buildMartinUrl } from '@/lib/api';
+import { Database, Link, Copy, Check } from 'lucide-react';
 import { LoadingSpinner } from '../loading/loading-spinner';
 import { TileInspectDialogMap } from './tile-inspect-map';
 
@@ -28,7 +28,37 @@ function TileMapLoading() {
   );
 }
 
+function CopyableUrl({ label, url }: { label: string; url: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [url]);
+
+  return (
+    <p>
+      <span className="font-medium">{label}:</span>
+      <br />
+      <span className="flex items-center gap-2 mt-1">
+        <code className="text-xs break-all flex-1">{url}</code>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
+          title={`Copy ${label}`}
+        >
+          {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+        </button>
+      </span>
+    </p>
+  );
+}
+
 export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDialogProps) {
+  const tileJsonUrl = buildMartinUrl(`/${name}`);
+  const xyzUrl = buildMartinUrl(`/${name}/{z}/{x}/{y}`);
+
   return (
     <Dialog onOpenChange={(v) => !v && onCloseAction()} open={true}>
       <DialogContent className="max-w-6xl w-full p-6 max-h-[90vh] overflow-auto">
@@ -96,6 +126,18 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
                   <span>{source.attribution}</span>
                 </p>
               )}
+            </div>
+          </section>
+
+          {/* Tile URLs */}
+          <section className="bg-muted/30 p-4 rounded-lg">
+            <div className="flex items-center gap-2 mb-2">
+              <Link className="w-5 h-5 text-muted-foreground" />
+              <h3 className="font-semibold">Tile URLs</h3>
+            </div>
+            <div className="flex flex-col gap-y-4 text-sm">
+              <CopyableUrl label="TileJSON" url={tileJsonUrl} />
+              <CopyableUrl label="XYZ Tiles" url={xyzUrl} />
             </div>
           </section>
         </div>

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
-import { Database, Link } from 'lucide-react';
+import { Database, ExternalLink  } from 'lucide-react';
 import { CopyableUrl } from '@/components/ui/copyable-url';
 import { buildMartinUrl } from '@/lib/api';
 import { LoadingSpinner } from '../loading/loading-spinner';
@@ -105,7 +105,7 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
           {/* Tile URLs */}
           <section className="bg-muted/30 p-4 rounded-lg">
             <div className="flex items-center gap-2 mb-2">
-              <Link className="w-5 h-5 text-muted-foreground" />
+              <ExternalLink  className="w-5 h-5 text-muted-foreground" />
               <h3 className="font-semibold">Tile URLs</h3>
             </div>
             <div className="flex flex-col gap-y-4 text-sm">

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
-import { Database, ExternalLink  } from 'lucide-react';
+import { Database, ExternalLink } from 'lucide-react';
 import { CopyableUrl } from '@/components/ui/copyable-url';
 import { buildMartinUrl } from '@/lib/api';
 import { LoadingSpinner } from '../loading/loading-spinner';
@@ -105,7 +105,7 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
           {/* Tile URLs */}
           <section className="bg-muted/30 p-4 rounded-lg">
             <div className="flex items-center gap-2 mb-2">
-              <ExternalLink  className="w-5 h-5 text-muted-foreground" />
+              <ExternalLink className="w-5 h-5 text-muted-foreground" />
               <h3 className="font-semibold">Tile URLs</h3>
             </div>
             <div className="flex flex-col gap-y-4 text-sm">

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Suspense, useState, useCallback } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -9,8 +9,8 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
+import { Check, Copy, Database, Link } from 'lucide-react';
 import { buildMartinUrl } from '@/lib/api';
-import { Database, Link, Copy, Check } from 'lucide-react';
 import { LoadingSpinner } from '../loading/loading-spinner';
 import { TileInspectDialogMap } from './tile-inspect-map';
 
@@ -44,11 +44,15 @@ function CopyableUrl({ label, url }: { label: string; url: string }) {
       <span className="flex items-center gap-2 mt-1">
         <code className="text-xs break-all flex-1">{url}</code>
         <button
-          onClick={handleCopy}
           className="shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
+          onClick={handleCopy}
           title={`Copy ${label}`}
         >
-          {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+          {copied ? (
+            <Check className="w-3.5 h-3.5 text-green-500" />
+          ) : (
+            <Copy className="w-3.5 h-3.5" />
+          )}
         </button>
       </span>
     </p>

--- a/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Suspense, useCallback, useState } from 'react';
+import { Suspense } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -9,10 +9,11 @@ import {
 } from '@/components/ui/dialog';
 import type { TileSource } from '@/lib/types';
 import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
-import { Check, Copy, Database, Link } from 'lucide-react';
 import { buildMartinUrl } from '@/lib/api';
+import { Database, Link } from 'lucide-react';
 import { LoadingSpinner } from '../loading/loading-spinner';
 import { TileInspectDialogMap } from './tile-inspect-map';
+import { CopyableUrl } from '@/components/ui/copyable-url';
 
 interface TileInspectDialogProps {
   name: string;
@@ -25,38 +26,6 @@ function TileMapLoading() {
     <div className="flex justify-center items-center text-white text-3xl w-full h-125">
       <LoadingSpinner />
     </div>
-  );
-}
-
-function CopyableUrl({ label, url }: { label: string; url: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [url]);
-
-  return (
-    <p>
-      <span className="font-medium">{label}:</span>
-      <br />
-      <span className="flex items-center gap-2 mt-1">
-        <code className="text-xs break-all flex-1">{url}</code>
-        <button
-          className="shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
-          onClick={handleCopy}
-          title={`Copy ${label}`}
-          type="button"
-        >
-          {copied ? (
-            <Check className="w-3.5 h-3.5 text-green-500" />
-          ) : (
-            <Copy className="w-3.5 h-3.5" />
-          )}
-        </button>
-      </span>
-    </p>
   );
 }
 
@@ -77,7 +46,6 @@ export function TileInspectDialog({ name, source, onCloseAction }: TileInspectDi
             Inspect the tile source to explore tile boundaries and properties.
           </DialogDescription>
         </DialogHeader>
-
         <div className="space-y-4">
           <section className="border rounded-lg overflow-hidden">
             <Suspense fallback={<TileMapLoading />}>

--- a/martin/martin-ui/src/components/ui/copyable-url.tsx
+++ b/martin/martin-ui/src/components/ui/copyable-url.tsx
@@ -12,7 +12,12 @@ export function CopyableUrl({ label, url }: CopyableUrlProps) {
       <br />
       <span className="flex items-center gap-2 mt-1">
         <code className="text-xs break-all flex-1">{url}</code>
-        <CopyLinkButton link={url} toastMessage={`${label} URL copied!`} size="sm" variant="ghost" />
+        <CopyLinkButton
+          link={url}
+          size="sm"
+          toastMessage={`${label} URL copied!`}
+          variant="ghost"
+        />
       </span>
     </p>
   );

--- a/martin/martin-ui/src/components/ui/copyable-url.tsx
+++ b/martin/martin-ui/src/components/ui/copyable-url.tsx
@@ -1,0 +1,19 @@
+import { CopyLinkButton } from './copy-link-button';
+
+interface CopyableUrlProps {
+  label: string;
+  url: string;
+}
+
+export function CopyableUrl({ label, url }: CopyableUrlProps) {
+  return (
+    <p>
+      <span className="font-medium">{label}:</span>
+      <br />
+      <span className="flex items-center gap-2 mt-1">
+        <code className="text-xs break-all flex-1">{url}</code>
+        <CopyLinkButton link={url} toastMessage={`${label} URL copied!`} size="sm" variant="ghost" />
+      </span>
+    </p>
+  );
+}

--- a/martin/martin-ui/vitest.setup.tsx
+++ b/martin/martin-ui/vitest.setup.tsx
@@ -241,6 +241,7 @@ vi.mock('lucide-react', () => ({
   Copy: () => <span role="img" />,
   Database: () => <span role="img" />,
   Download: () => <span role="img" />,
+  ExternalLink: () => <span role="img" />,
   Eye: () => <span role="img" />,
   Github: () => <span role="img" />,
   Image: () => <span role="img" />,


### PR DESCRIPTION
See micro discussion here https://github.com/maplibre/martin/issues/852#issuecomment-4296464995

Adding TileJSON and XYZ urls and copy buttons, quickly drafted with Claude Sonnet 4.6

<img width="2560" height="1303" alt="image" src="https://github.com/user-attachments/assets/6742b563-9d77-4b84-8d20-fc74c8718614" />
