### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "actix-web",
  "approx",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.4"
-martin-core = { path = "./martin-core", version = "0.5.1", default-features = false }
+martin-core = { path = "./martin-core", version = "0.5.2", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.1" }
-mbtiles = { path = "./mbtiles", version = "0.17.1" }
+mbtiles = { path = "./mbtiles", version = "0.17.2" }
 md5 = "0.8.0"
 moka = { version = "0.12", default-features = false }
 notify = "8.2.0"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.8.0
+    image: ghcr.io/maplibre/martin:1.8.1
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.8.0 \
+           ghcr.io/maplibre/martin:1.8.1 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.8.0
+    image: ghcr.io/maplibre/martin:1.8.1
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.8.0
+  ghcr.io/maplibre/martin:1.8.1
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.8.0 \
+  ghcr.io/maplibre/martin:1.8.1 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.8.0
+  ghcr.io/maplibre/martin:1.8.1
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.8.0
+  ghcr.io/maplibre/martin:1.8.1
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.8.0
+  ghcr.io/maplibre/martin:1.8.1
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.8.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.8.1 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.8.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.8.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -228,7 +228,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.8.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.8.1 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/maplibre/martin/compare/martin-core-v0.5.1...martin-core-v0.5.2) - 2026-04-29
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.1](https://github.com/maplibre/martin/compare/martin-core-v0.5.0...martin-core-v0.5.1) - 2026-04-28
 
 ### Other

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1](https://github.com/maplibre/martin/compare/martin-v1.8.0...martin-v1.8.1) - 2026-04-29
+
+### Fixed
+
+- *(styles)* default the optional `rendering` field so configs without it parse ([#2752](https://github.com/maplibre/martin/pull/2752))
+
+### Other
+
+- *(deps)* autoupdate pre-commit ([#2743](https://github.com/maplibre/martin/pull/2743))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 6 updates ([#2745](https://github.com/maplibre/martin/pull/2745))
+- update Cargo.toml dependencies
+
 ## [1.8.0](https://github.com/maplibre/martin/compare/martin-v1.7.0...martin-v1.8.0) - 2026-04-28
 
 ### Added

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.8.0"
+version = "1.8.1"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.8.0"
+  "version": "1.8.1"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/maplibre/martin/compare/mbtiles-v0.17.1...mbtiles-v0.17.2) - 2026-04-29
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.17.1](https://github.com/maplibre/martin/compare/mbtiles-v0.17.0...mbtiles-v0.17.1) - 2026-04-28
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.17.1 -> 0.17.2 (✓ API compatible changes)
* `martin-core`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `martin`: 1.8.0 -> 1.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.17.2](https://github.com/maplibre/martin/compare/mbtiles-v0.17.1...mbtiles-v0.17.2) - 2026-04-29

### Other

- update Cargo.toml dependencies
</blockquote>

## `martin-core`

<blockquote>

## [0.5.2](https://github.com/maplibre/martin/compare/martin-core-v0.5.1...martin-core-v0.5.2) - 2026-04-29

### Other

- update Cargo.toml dependencies
</blockquote>

## `martin`

<blockquote>

## [1.8.1](https://github.com/maplibre/martin/compare/martin-v1.8.0...martin-v1.8.1) - 2026-04-29

### Fixed

- *(styles)* default the optional `rendering` field so configs without it parse ([#2752](https://github.com/maplibre/martin/pull/2752))

### Other

- *(deps)* autoupdate pre-commit ([#2743](https://github.com/maplibre/martin/pull/2743))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 6 updates ([#2745](https://github.com/maplibre/martin/pull/2745))
- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).