### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "actix-web",
  "approx",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.4"
-martin-core = { path = "./martin-core", version = "0.5.2", default-features = false }
+martin-core = { path = "./martin-core", version = "0.5.3", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.1" }
-mbtiles = { path = "./mbtiles", version = "0.17.2" }
+mbtiles = { path = "./mbtiles", version = "0.17.3" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 moka = { version = "0.12", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.9.0
+    image: ghcr.io/maplibre/martin:1.8.2
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.8.1
+    image: ghcr.io/maplibre/martin:1.9.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.8.1 \
+           ghcr.io/maplibre/martin:1.9.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.9.0 \
+           ghcr.io/maplibre/martin:1.8.2 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.8.1
+    image: ghcr.io/maplibre/martin:1.9.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.9.0
+    image: ghcr.io/maplibre/martin:1.8.2
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.9.0
+  ghcr.io/maplibre/martin:1.8.2
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.9.0 \
+  ghcr.io/maplibre/martin:1.8.2 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.9.0
+  ghcr.io/maplibre/martin:1.8.2
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.9.0
+  ghcr.io/maplibre/martin:1.8.2
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.9.0
+  ghcr.io/maplibre/martin:1.8.2
 ```

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.8.1
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.8.1 \
+  ghcr.io/maplibre/martin:1.9.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.8.1
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.8.1
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.8.1
+  ghcr.io/maplibre/martin:1.9.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.9.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.8.2 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.9.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.8.2 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.8.1 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.9.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.8.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.9.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -315,7 +315,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.8.1 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.9.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/justfile
+++ b/justfile
@@ -315,7 +315,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.9.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.8.2 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -11,12 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))
-
-### Other
-
 - add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
 
 ## [0.5.2](https://github.com/maplibre/martin/compare/martin-core-v0.5.1...martin-core-v0.5.2) - 2026-04-29
 

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/maplibre/martin/compare/martin-core-v0.5.2...martin-core-v0.5.3) - 2026-04-29
+
+### Added
+
+- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))
+
+### Other
+
+- add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
+
 ## [0.5.2](https://github.com/maplibre/martin/compare/martin-core-v0.5.1...martin-core-v0.5.2) - 2026-04-29
 
 ### Other

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))
+### Added
+
+- We now publish an JSONSchema for our configuration and OpenAPI documentation for our HTTP API ([#2760](https://github.com/maplibre/martin/pull/2760))
+
+### Fixed
+
+- The last release had some aretefact not get attached, so this release fixes this
 
 ### Other
 
-- add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
+- add debug-only `#[tracing::instrument]` to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
 - *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
 - *(mbtiles)* migrate from log/env_logger to tracing ([#2755](https://github.com/maplibre/martin/pull/2755))
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.9.0) - 2026-04-29
+## [1.8.2](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.8.2) - 2026-04-29
 
 ### Added
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.9.0) - 2026-04-29
+
+### Added
+
+- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))
+
+### Other
+
+- add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
+- *(mbtiles)* migrate from log/env_logger to tracing ([#2755](https://github.com/maplibre/martin/pull/2755))
+
 ## [1.8.1](https://github.com/maplibre/martin/compare/martin-v1.8.0...martin-v1.8.1) - 2026-04-29
 
 ### Fixed

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.8.1"
+version = "1.9.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.9.0"
+version = "1.8.2"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.9.0"
+  "version": "1.8.2"
 }

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -61,5 +61,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.8.1"
+  "version": "1.9.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3](https://github.com/maplibre/martin/compare/mbtiles-v0.17.2...mbtiles-v0.17.3) - 2026-04-29
+
+### Other
+
+- *(mbtiles)* migrate from log/env_logger to tracing ([#2755](https://github.com/maplibre/martin/pull/2755))
+
 ## [0.17.2](https://github.com/maplibre/martin/compare/mbtiles-v0.17.1...mbtiles-v0.17.2) - 2026-04-29
 
 ### Other

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -126,7 +126,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.8.1"
+    "version": "1.9.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.17.2 -> 0.17.3 (✓ API compatible changes)
* `martin-core`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `martin`: 1.8.1 -> 1.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.17.3](https://github.com/maplibre/martin/compare/mbtiles-v0.17.2...mbtiles-v0.17.3) - 2026-04-29

### Other

- *(mbtiles)* migrate from log/env_logger to tracing ([#2755](https://github.com/maplibre/martin/pull/2755))
</blockquote>

## `martin-core`

<blockquote>

## [0.5.3](https://github.com/maplibre/martin/compare/martin-core-v0.5.2...martin-core-v0.5.3) - 2026-04-29

### Added

- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))

### Other

- add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
</blockquote>

## `martin`

<blockquote>

## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.9.0) - 2026-04-29

### Added

- derive JSON Schema (config) + OpenAPI (HTTP API) behind `unstable-schemas` ([#2760](https://github.com/maplibre/martin/pull/2760))

### Other

- add #[tracing::instrument] to hot-path entry points ([#2759](https://github.com/maplibre/martin/pull/2759))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 5 updates ([#2756](https://github.com/maplibre/martin/pull/2756))
- *(mbtiles)* migrate from log/env_logger to tracing ([#2755](https://github.com/maplibre/martin/pull/2755))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).