### PR TITLE
Revert "ci: automate release publishing - trigger on `created`, publi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [ created ]
+    types: [ published ]
   workflow_dispatch:
 
 defaults:
@@ -877,13 +877,13 @@ jobs:
             exit 1
           fi
           gh release upload "$RELEASE_TAG_NAME" target/files/* --clobber
-          gh release edit "$RELEASE_TAG_NAME" --verify-tag --draft=false --latest
+          gh release edit "$RELEASE_TAG_NAME" --verify-tag --latest
       - name: Publish without artifacts
         if: ${{ github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'martin-v') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release edit "$RELEASE_TAG_NAME" --verify-tag --draft=false --latest=false
+        run: gh release edit "$RELEASE_TAG_NAME" --verify-tag --latest=false
 
         # Create a personal access token
         #     Gen:  https://github.com/settings/personal-access-tokens/new

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,10 +2,10 @@
 dependencies_update = false # sounds good but only works if this were not to pull in incompatible versions
 changelog_update = true
 # Our process goes as follows:
-# - We first release as a non-latest draft
-# - the binaries are built (in GHA, attested) and
+# - We first release as a non-latest draft and publish it
+# - the binaries are build (in GHA, attested) and
 # - attached to the release
-# - the release is then automatically published (draft=false) and marked as latest for martin
+# - the release is marked as non-draft (and latest for martin).
 # => Our releases are fully attested and immutable
 git_release_latest = false
 git_release_draft = true


### PR DESCRIPTION
…sh draft automatically (#2748)"

This reverts commit 35d0c85d05d710173d240c09d19bef8610900598.