### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "actix-web",
  "approx",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.4"
-martin-core = { path = "./martin-core", version = "0.5.3", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.1" }
-mbtiles = { path = "./mbtiles", version = "0.17.3" }
+martin-core = { path = "./martin-core", version = "0.5.4", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.2" }
+mbtiles = { path = "./mbtiles", version = "0.17.4" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.9.1", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.8.2
+    image: ghcr.io/maplibre/martin:1.9.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -15,7 +15,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.8.2 \
+           ghcr.io/maplibre/martin:1.9.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -6,7 +6,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.8.2
+    image: ghcr.io/maplibre/martin:1.9.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -8,7 +8,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.8.2
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Exposing Local Files
@@ -19,7 +19,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.8.2 \
+  ghcr.io/maplibre/martin:1.9.0 \
   /files
 ```
 
@@ -35,7 +35,7 @@ with `-p` because the container is already using the host network.
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.8.2
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -46,7 +46,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.8.2
+  ghcr.io/maplibre/martin:1.9.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -57,5 +57,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.8.2
+  ghcr.io/maplibre/martin:1.9.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -11,13 +11,13 @@ Everything can be performed via AWS CloudShell, or you can install the AWS CLI a
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.8.2 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.9.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.8.2 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.9.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -317,7 +317,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.8.2 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.9.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/maplibre/martin/compare/martin-core-v0.5.3...martin-core-v0.5.4) - 2026-05-06
+
+### Added
+
+- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
+
+### Other
+
+- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
+- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
+
 ## [0.5.3](https://github.com/maplibre/martin/compare/martin-core-v0.5.2...martin-core-v0.5.3) - 2026-04-29
 
 ### Added

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.4](https://github.com/maplibre/martin/compare/martin-core-v0.5.3...martin-core-v0.5.4) - 2026-05-06
 
-### Added
+### Structured tracing fields
 
-- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
+The `fonts`, `sprites`, and `styles` resource modules now emit `tracing` events with structured fields (e.g. `font.name`, `font.glyph_count`, `sprite.path.kept`, `style.path.dropped`) instead of interpolated strings.
+Crates configuring a `tracing-subscriber` will pick the new fields up automatically — particularly useful with JSON formatters.
+The human-readable message text was shortened in the process, so any downstream log-scraper regex that matched the previous free-text messages needs to be updated. ([#2777](https://github.com/maplibre/martin/pull/2777))
 
 ### Other
 
-- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
-- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
+- *(deps)* Replace the dev-only `pixelmatch` dependency with `image-compare` for style-rendering tests; the public API is unchanged ([#2780](https://github.com/maplibre/martin/pull/2780)).
 
 ## [0.5.3](https://github.com/maplibre/martin/compare/martin-core-v0.5.2...martin-core-v0.5.3) - 2026-04-29
 

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.2...martin-v1.9.0) - 2026-05-06
+
+### Added
+
+- *(mlt)* MLT->MVT conversion ([#2775](https://github.com/maplibre/martin/pull/2775))
+- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
+- *(ui)* refactor the sprite viewing experience to display sdfs/.. ([#2774](https://github.com/maplibre/martin/pull/2774))
+- *(ui)* render font previews using SDF glyph data ([#2772](https://github.com/maplibre/martin/pull/2772))
+
+### Fixed
+
+- *(mbtiles)* don't drop folder source siblings when one file fails to init ([#2768](https://github.com/maplibre/martin/pull/2768))
+
+### Other
+
+- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
+- *(deps)* autoupdate pre-commit ([#2776](https://github.com/maplibre/martin/pull/2776))
+- add `AutoOption` for having something as auto, disabled or explicit ([#2773](https://github.com/maplibre/martin/pull/2773))
+- *(deps)* Bump the all-npm-version-updates group across 1 directory with 3 updates ([#2770](https://github.com/maplibre/martin/pull/2770))
+- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
+- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
+
 ## [1.8.2](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.8.2) - 2026-04-29
 
 ### Added

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,25 +9,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.2...martin-v1.9.0) - 2026-05-06
 
-### Added
+### MVT - MLT pre-processing encoding
 
-- *(mlt)* MLT->MVT conversion ([#2775](https://github.com/maplibre/martin/pull/2775))
-- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
-- *(ui)* refactor the sprite viewing experience to display sdfs/.. ([#2774](https://github.com/maplibre/martin/pull/2774))
-- *(ui)* render font previews using SDF glyph data ([#2772](https://github.com/maplibre/martin/pull/2772))
+Martin can now serve [MLT (MapLibre Tiles)](https://github.com/maplibre/maplibre-tile-spec) by transcoding MVT on the fly.
+MLT is a columnar successor to MVT - for our test fixture it is roughly 39% smaller on the wire and 12% faster to serve from cache due to this size difference.
+No tile re-generation or schema migration is required:
+the conversion runs at request time when the client sends `Accept: application/vnd.maplibre-tile`.
+We also can convert MLT tiles back to MVT if the client requests it.
+
+The `mlt` cargo feature is now part of the `default` feature set, so prebuilt binaries ship with MLT support.
+Builds without `mlt` will return an error if a client requests MLT.
+
+You can configure this behaviour with the new `convert-to-mlt` or `convert-to-mvt` config key.
+It accepts three states (`auto`, `disabled`, or an explicit encoder object) and can be set at three nesting levels (global, source-type, individual source).
+The most-specific level wins and the default is `auto`.
+
+```yaml
+convert-to-mlt: auto
+convert-to-mvt: auto
+
+postgres:
+  connection_string: postgresql://localhost/mydb
+
+pmtiles:
+  sources:
+    basemap:
+      path: /data/basemap.pmtiles
+      # inherits the global `auto`
+    legacy:
+      path: /data/legacy.pmtiles
+      # this one source always serves MLT and configures how to serve it
+      convert-to-mlt:
+        tessellate: true
+      convert-to-mvt: disabled
+```
+
+To override the encoder defaults (rarely needed; see the docs for the full field list), pass an explicit object:
+
+```yaml
+convert-to-mlt:
+  tessellate: false # Enable if your client supports pre-tessellated polygons and you benchmarked that this improves your usecase
+  try_spatial_morton_sort: true # Disable if your data is already spatially ordered
+  try_spatial_hilbert_sort: true # Disable if Morton sort doesn't compress well for your data
+  try_id_sort: false # Enable when features have sequential IDs and spatial sorting isn't beneficial
+  allow_fsst: true # Disable to reduce search space
+  allow_fpf: true # Disable to reduce search space
+  allow_shared_dict: true # Disable to reduce search space
+```
+
+[A full guide is avaliable here](https://github.com/maplibre/martin/blob/main/docs/content/using-guides/mlt.md).
+Implemented in [#2769](https://github.com/maplibre/martin/pull/2769) [#2773](https://github.com/maplibre/martin/pull/2773) and  [#2775](https://github.com/maplibre/martin/pull/2775) 
+
+### Improved sprite and font previews in the Web UI
+
+The Web UI now renders sprites and font previews directly using MapLibre GL and SDF glyph data.
+Sprite catalogs support live PNG/SDF rendering, icon scaling, SDF tint and halo previews, and quick sprite ID copying.
+Font cards now render real sample text from `/font/{name}/0-255` instead of placeholder previews, with graceful fallback handling when glyph loading fails.
+Existing sprite and font endpoints are unchanged. ([#2774](https://github.com/maplibre/martin/pull/2774), [#2772](https://github.com/maplibre/martin/pull/2772))
+
+### Structured logging for `martin-core` and `mbtiles`
+
+`martin-core` and `mbtiles` now emit structured `tracing` fields instead of interpolated log strings.
+Human-readable logs remain unchanged, but external log scrapers that rely on the old free-text format may need updates. ([#2777](https://github.com/maplibre/martin/pull/2777), [#2778](https://github.com/maplibre/martin/pull/2778))
 
 ### Fixed
 
-- *(mbtiles)* don't drop folder source siblings when one file fails to init ([#2768](https://github.com/maplibre/martin/pull/2768))
+- *(mbtiles)* Prevent folder sources from disappearing when a single MBTiles file fails to initialize.
+  Invalid files now emit a warning while the remaining sources continue loading normally. ([#2768](https://github.com/maplibre/martin/pull/2768))
 
 ### Other
 
-- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
-- *(deps)* autoupdate pre-commit ([#2776](https://github.com/maplibre/martin/pull/2776))
-- add `AutoOption` for having something as auto, disabled or explicit ([#2773](https://github.com/maplibre/martin/pull/2773))
-- *(deps)* Bump the all-npm-version-updates group across 1 directory with 3 updates ([#2770](https://github.com/maplibre/martin/pull/2770))
-- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
-- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
+- Various dependecy updates ([#2780](https://github.com/maplibre/martin/pull/2780), [#2770](https://github.com/maplibre/martin/pull/2770), [#2776](https://github.com/maplibre/martin/pull/2776))
 
 ## [1.8.2](https://github.com/maplibre/martin/compare/martin-v1.8.1...martin-v1.8.2) - 2026-04-29
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -58,7 +58,7 @@ convert-to-mlt:
 ```
 
 [A full guide is avaliable here](https://github.com/maplibre/martin/blob/main/docs/content/using-guides/mlt.md).
-Implemented in [#2769](https://github.com/maplibre/martin/pull/2769) [#2773](https://github.com/maplibre/martin/pull/2773) and  [#2775](https://github.com/maplibre/martin/pull/2775) 
+Implemented in [#2769](https://github.com/maplibre/martin/pull/2769) [#2773](https://github.com/maplibre/martin/pull/2773) and  [#2775](https://github.com/maplibre/martin/pull/2775)
 
 ### Improved sprite and font previews in the Web UI
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.8.2"
+version = "1.9.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -62,5 +62,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.8.2"
+  "version": "1.9.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.4](https://github.com/maplibre/martin/compare/mbtiles-v0.17.3...mbtiles-v0.17.4) - 2026-05-06
+
+### Added
+
+- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
+
+### Other
+
+- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
+
 ## [0.17.3](https://github.com/maplibre/martin/compare/mbtiles-v0.17.2...mbtiles-v0.17.3) - 2026-04-29
 
 ### Other

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -9,13 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.4](https://github.com/maplibre/martin/compare/mbtiles-v0.17.3...mbtiles-v0.17.4) - 2026-05-06
 
-### Added
+### Structured tracing fields
 
-- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
-
-### Other
-
-- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
+The `bindiff`, `metadata`, `transcoder`, `update`, and `validation` modules now emit `tracing` events with structured fields (`mbtiles.file`, `tile.coord`, `tile.id`, `metadata.name`, `metadata.compression`, `agg_tiles_hash`, `bindiff.inserted`, …) instead of interpolating values into the message text.
+The `mbtiles` CLI output stays readable in the default formatter, but log scrapers that matched the old free-text format need to be updated to consume the new fields. ([#2778](https://github.com/maplibre/martin/pull/2778))
 
 ## [0.17.3](https://github.com/maplibre/martin/compare/mbtiles-v0.17.2...mbtiles-v0.17.3) - 2026-04-29
 

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.3"
+version = "0.17.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -126,7 +126,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.8.2"
+    "version": "1.9.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `mbtiles`: 0.17.3 -> 0.17.4 (✓ API compatible changes)
* `martin-core`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `martin`: 1.8.2 -> 1.9.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.17.4](https://github.com/maplibre/martin/compare/mbtiles-v0.17.3...mbtiles-v0.17.4) - 2026-05-06

### Added

- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))

### Other

- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
</blockquote>

## `martin-core`

<blockquote>

## [0.5.4](https://github.com/maplibre/martin/compare/martin-core-v0.5.3...martin-core-v0.5.4) - 2026-05-06

### Added

- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))

### Other

- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
</blockquote>

## `martin`

<blockquote>

## [1.9.0](https://github.com/maplibre/martin/compare/martin-v1.8.2...martin-v1.9.0) - 2026-05-06

### Added

- *(mlt)* MLT->MVT conversion ([#2775](https://github.com/maplibre/martin/pull/2775))
- mvt->mlt pre-processing encoding ([#2769](https://github.com/maplibre/martin/pull/2769))
- *(ui)* refactor the sprite viewing experience to display sdfs/.. ([#2774](https://github.com/maplibre/martin/pull/2774))
- *(ui)* render font previews using SDF glyph data ([#2772](https://github.com/maplibre/martin/pull/2772))

### Fixed

- *(mbtiles)* don't drop folder source siblings when one file fails to init ([#2768](https://github.com/maplibre/martin/pull/2768))

### Other

- *(martin-core)* migrate more logs to be structured ([#2777](https://github.com/maplibre/martin/pull/2777))
- *(deps)* autoupdate pre-commit ([#2776](https://github.com/maplibre/martin/pull/2776))
- add `AutoOption` for having something as auto, disabled or explicit ([#2773](https://github.com/maplibre/martin/pull/2773))
- *(deps)* Bump the all-npm-version-updates group across 1 directory with 3 updates ([#2770](https://github.com/maplibre/martin/pull/2770))
- *(deps)* replace pixmatch with a more modern alternative ([#2780](https://github.com/maplibre/martin/pull/2780))
- *(mbtiles)* migrate the mbtiles crate to structured logs ([#2778](https://github.com/maplibre/martin/pull/2778))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).