### PR TITLE
ci: ignore RUSTSEC-2026-0049 / RUSTSEC-2026-0097 and GHSA-cq8v-f236-94qc

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,12 +35,14 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0049,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
           # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing side channels => not used exploitably
           # RUSTSEC-2024-0436 = paste - no longer maintained
           # RUSTSEC-2025-0134 = rustls-pemfile is unmaintained, but only used in development dependencies
           # RUSTSEC-2026-0002 = unsound stack borrow in lru
           # RUSTSEC-2026-0007 = integer overflow in bytes
+          # RUSTSEC-2026-0049 = rustls-webpki@0.101.7 CRL matching bug; stuck in aws-smithy-http-client's legacy rustls@0.21 chain, cannot be upgraded without an upstream aws-sdk-s3 release
+          # RUSTSEC-2026-0097 = rand unsoundness with custom logger + rand::rng(); pinned by probabilistic-collections 0.7.0 (rand 0.7) and sqlx 0.8 (rand 0.8), neither have updates available
           # RUSTSEC-2026-0098 = rustls-webpki name constraints for URI names; remaining finding is rustls-webpki@0.101.7 in aws-smithy-http-client's legacy rustls@0.21 chain
           # RUSTSEC-2026-0099 = rustls-webpki wildcard name constraints; remaining finding is rustls-webpki@0.101.7 in aws-smithy-http-client's legacy rustls@0.21 chain
           # RUSTSEC-2026-0104 = rustls-webpki CRL parsing panic; only remaining finding is rustls-webpki@0.101.7 in aws-smithy-http-client's legacy rustls@0.21 chain
@@ -59,6 +61,7 @@ jobs:
           license-check: false # incredibly high maintenance cost, also many false positives and not ability to ignore issues like "MIT/APACHE2" being used
           show-openssf-scorecard: true
           warn-on-openssf-scorecard-level: 5
+          allow-ghsas: GHSA-cq8v-f236-94qc # rand@0.7.3 unsoundness with custom logger; pinned by probabilistic-collections 0.7.0, cannot be upgraded
       # actions/dependency-review-action does not find all licenses -> we use cargo-deny for this in addition to dependency-review-action
       - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:


### PR DESCRIPTION
## Summary

Two new RustSec advisories are causing `cargo-audit` to fail, and neither can be remediated by upgrading our direct dependencies. This adds them (plus the matching `dependency-review-action` GHSA entry) to the existing ignore lists in `.github/workflows/security.yml`, with comments explaining why.

- **RUSTSEC-2026-0049** — `rustls-webpki` CRL matching bug. Reaches us through `aws-smithy-http-client`'s legacy `rustls@0.21` chain; can't be fixed without an upstream `aws-sdk-s3` release. Same root cause as the already-ignored RUSTSEC-2026-0098/0099/0104.
- **RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc** — `rand` unsoundness with a custom logger + `rand::rng()`. Pinned by `probabilistic-collections 0.7.0` (rand 0.7) and `sqlx 0.8` (rand 0.8); neither has an update available.

## Test plan

- [ ] `security` workflow passes on this branch (cargo-audit + dependency-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)