### PR TITLE
fix(mbtiles): don't drop folder source siblings when one file fails to init

### DIFF
--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1033,10 +1033,11 @@ mod folder_source_tests {
     async fn resolve_mixed_dir(good: usize, bad: usize) -> (Vec<String>, Vec<String>) {
         let dir = TempDir::new().expect("create tempdir");
         for i in 0..good {
-            std::fs::write(dir.path().join(format!("good_{i}.tiles")), b"").unwrap();
+            std::fs::write(dir.path().join(format!("good_{i}.tiles")), b"").expect("write good");
         }
         for i in 0..bad {
-            std::fs::write(dir.path().join(format!("{BAD_PREFIX}{i}.tiles")), b"").unwrap();
+            std::fs::write(dir.path().join(format!("{BAD_PREFIX}{i}.tiles")), b"")
+                .expect("write bad");
         }
 
         let mut config = FileConfigEnum::<FakeConfig>::Path(dir.path().to_path_buf());

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -936,13 +936,13 @@ mod mbtiles_tests {
 /// Folder-source path resolution: a single bad file in a directory must not
 /// drop its valid siblings. Regression for
 /// <https://github.com/maplibre/martin/discussions/2767>.
-#[cfg(test)]
+#[cfg(all(test, feature = "_tiles"))]
 mod folder_source_tests {
     use async_trait::async_trait;
+    use insta::assert_yaml_snapshot;
     use martin_core::CacheZoomRange;
     use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format, TileCoord, TileData, TileInfo};
-    use rstest::rstest;
     use tempfile::TempDir;
     use tilejson::{TileJSON, tilejson};
 
@@ -1027,15 +1027,10 @@ mod folder_source_tests {
         }
     }
 
-    /// Asserts a folder containing `good` good files and `bad` bad files
-    /// resolves to `good` sources and `bad` `PathError` warnings.
-    #[rstest]
-    #[case::one_good_one_bad(1, 1)]
-    #[case::two_good_two_bad(2, 2)]
-    #[case::all_bad(0, 2)]
-    #[case::all_good(2, 0)]
-    #[tokio::test]
-    async fn folder_source_with_mixed_files(#[case] good: usize, #[case] bad: usize) {
+    /// Resolves a freshly-created tempdir populated with `good` good files and
+    /// `bad` bad files, returning sorted source ids + warning strings with the
+    /// random tempdir prefix replaced by `<DIR>` for snapshot stability.
+    async fn resolve_mixed_dir(good: usize, bad: usize) -> (Vec<String>, Vec<String>) {
         let dir = TempDir::new().expect("create tempdir");
         for i in 0..good {
             std::fs::write(dir.path().join(format!("good_{i}.tiles")), b"").unwrap();
@@ -1051,13 +1046,55 @@ mod folder_source_tests {
                 .await
                 .expect("resolve_files always returns Ok; OnInvalid decides fatality");
 
-        assert_eq!(sources.len(), good);
-        assert_eq!(warnings.len(), bad);
-        assert!(
-            warnings
-                .iter()
-                .all(|w| matches!(w, TileSourceWarning::PathError { .. }))
-        );
+        let prefix = dir.path().to_string_lossy().to_string();
+        let mut ids: Vec<String> = sources.iter().map(|s| s.get_id().to_string()).collect();
+        ids.sort();
+        let mut msgs: Vec<String> = warnings
+            .iter()
+            .map(|w| w.to_string().replace(&prefix, "<DIR>"))
+            .collect();
+        msgs.sort();
+        (ids, msgs)
+    }
+
+    #[tokio::test]
+    async fn one_good_one_bad() {
+        let (sources, warnings) = resolve_mixed_dir(1, 1).await;
+        assert_yaml_snapshot!(sources, @"- good_0");
+        assert_yaml_snapshot!(warnings, @r#"- "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles""#);
+    }
+
+    #[tokio::test]
+    async fn two_good_two_bad() {
+        let (sources, warnings) = resolve_mixed_dir(2, 2).await;
+        assert_yaml_snapshot!(sources, @r"
+        - good_0
+        - good_1
+        ");
+        assert_yaml_snapshot!(warnings, @r#"
+        - "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles"
+        - "Path <DIR>/bad_1.tiles: Source path is not a file: <DIR>/bad_1.tiles"
+        "#);
+    }
+
+    #[tokio::test]
+    async fn all_bad() {
+        let (sources, warnings) = resolve_mixed_dir(0, 2).await;
+        assert_yaml_snapshot!(sources, @"[]");
+        assert_yaml_snapshot!(warnings, @r#"
+        - "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles"
+        - "Path <DIR>/bad_1.tiles: Source path is not a file: <DIR>/bad_1.tiles"
+        "#);
+    }
+
+    #[tokio::test]
+    async fn all_good() {
+        let (sources, warnings) = resolve_mixed_dir(2, 0).await;
+        assert_yaml_snapshot!(sources, @r"
+        - good_0
+        - good_1
+        ");
+        assert_yaml_snapshot!(warnings, @"[]");
     }
 }
 

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -347,7 +347,10 @@ async fn resolve_int<T: TileSourceConfiguration>(
         )
         .await
         {
-            Ok(sources) => results.extend(sources),
+            Ok((sources, path_warnings)) => {
+                results.extend(sources);
+                warnings.extend(path_warnings);
+            }
             Err(err) => {
                 warnings.push(TileSourceWarning::PathError {
                     path: path.display().to_string(),
@@ -415,8 +418,9 @@ async fn resolve_one_path_int<T: TileSourceConfiguration>(
     directories: &mut Vec<PathBuf>,
     configs: &mut BTreeMap<String, FileConfigSrc>,
     default_cache: CachePolicy,
-) -> MartinResult<Vec<BoxedSource>> {
+) -> MartinResult<(Vec<BoxedSource>, Vec<TileSourceWarning>)> {
     let mut results = Vec::new();
+    let mut warnings = Vec::new();
 
     if let Some(url) = parse_url(T::parse_urls(), &path)? {
         let target_ext = extension.iter().find(|&e| url.to_string().ends_with(e));
@@ -470,13 +474,29 @@ async fn resolve_one_path_int<T: TileSourceConfiguration>(
                 |s| s.to_string_lossy().to_string(),
             );
             let id = idr.resolve(&id, can.to_string_lossy().to_string());
-            info!("Configured source {id} from {}", can.display());
-            files.insert(can);
-            configs.insert(id.clone(), FileConfigSrc::Path(path.clone()));
-            results.push(custom.new_sources(id, path, default_cache).await?);
+            // Only commit `id`/`can` to bookkeeping after a successful init so a single
+            // bad file inside a directory does not poison the whole batch — without this,
+            // `on_invalid: warn` would still drop every sibling source.
+            match custom
+                .new_sources(id.clone(), path.clone(), default_cache)
+                .await
+            {
+                Ok(src) => {
+                    info!("Configured source {id} from {}", can.display());
+                    files.insert(can);
+                    configs.insert(id, FileConfigSrc::Path(path));
+                    results.push(src);
+                }
+                Err(err) => {
+                    warnings.push(TileSourceWarning::PathError {
+                        path: path.display().to_string(),
+                        error: err.to_string(),
+                    });
+                }
+            }
         }
     }
-    Ok(results)
+    Ok((results, warnings))
 }
 
 /// Returns a vector of file paths matching any `allowed_extension` within the given directory.
@@ -910,6 +930,134 @@ mod mbtiles_tests {
         let (sources, warnings) = result.unwrap();
         assert_eq!(sources.len(), 0);
         assert_eq!(warnings.len(), 2);
+    }
+}
+
+/// Folder-source path resolution: a single bad file in a directory must not
+/// drop its valid siblings. Regression for
+/// <https://github.com/maplibre/martin/discussions/2767>.
+#[cfg(test)]
+mod folder_source_tests {
+    use async_trait::async_trait;
+    use martin_core::CacheZoomRange;
+    use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
+    use martin_tile_utils::{Encoding, Format, TileCoord, TileData, TileInfo};
+    use rstest::rstest;
+    use tempfile::TempDir;
+    use tilejson::{TileJSON, tilejson};
+
+    use super::*;
+    use crate::MartinError;
+    use crate::config::primitives::IdResolver;
+
+    /// Files whose stem starts with this prefix are treated as invalid by [`FakeConfig`].
+    const BAD_PREFIX: &str = "bad_";
+
+    #[derive(Clone, Debug, Default, PartialEq)]
+    struct FakeConfig;
+
+    impl ConfigurationLivecycleHooks for FakeConfig {
+        fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+            UnrecognizedKeys::new()
+        }
+    }
+
+    impl TileSourceConfiguration for FakeConfig {
+        fn parse_urls() -> bool {
+            false
+        }
+        async fn new_sources(
+            &self,
+            id: String,
+            path: PathBuf,
+            _cache: CachePolicy,
+        ) -> MartinResult<BoxedSource> {
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            if stem.starts_with(BAD_PREFIX) {
+                Err(MartinError::from(ConfigFileError::InvalidFilePath(path)))
+            } else {
+                Ok(Box::new(FakeSource {
+                    id,
+                    tj: tilejson! { tiles: vec![] },
+                }))
+            }
+        }
+        async fn new_sources_url(
+            &self,
+            _id: String,
+            _url: Url,
+            _cache: CachePolicy,
+        ) -> MartinResult<BoxedSource> {
+            unreachable!()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakeSource {
+        id: String,
+        tj: TileJSON,
+    }
+
+    #[async_trait]
+    impl Source for FakeSource {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+        fn get_tilejson(&self) -> &TileJSON {
+            &self.tj
+        }
+        fn get_tile_info(&self) -> TileInfo {
+            TileInfo::new(Format::Mvt, Encoding::Uncompressed)
+        }
+        fn clone_source(&self) -> BoxedSource {
+            Box::new(self.clone())
+        }
+        fn cache_zoom(&self) -> CacheZoomRange {
+            CacheZoomRange::default()
+        }
+        async fn get_tile(
+            &self,
+            _xyz: TileCoord,
+            _url_query: Option<&UrlQuery>,
+        ) -> MartinCoreResult<TileData> {
+            Ok(vec![])
+        }
+    }
+
+    /// Asserts a folder containing `good` good files and `bad` bad files
+    /// resolves to `good` sources and `bad` `PathError` warnings.
+    #[rstest]
+    #[case::one_good_one_bad(1, 1)]
+    #[case::two_good_two_bad(2, 2)]
+    #[case::all_bad(0, 2)]
+    #[case::all_good(2, 0)]
+    #[tokio::test]
+    async fn folder_source_with_mixed_files(#[case] good: usize, #[case] bad: usize) {
+        let dir = TempDir::new().expect("create tempdir");
+        for i in 0..good {
+            std::fs::write(dir.path().join(format!("good_{i}.tiles")), b"").unwrap();
+        }
+        for i in 0..bad {
+            std::fs::write(dir.path().join(format!("{BAD_PREFIX}{i}.tiles")), b"").unwrap();
+        }
+
+        let mut config = FileConfigEnum::<FakeConfig>::Path(dir.path().to_path_buf());
+        let idr = IdResolver::new(&[]);
+        let (sources, warnings) =
+            resolve_files(&mut config, &idr, &["tiles"], CachePolicy::default())
+                .await
+                .expect("resolve_files always returns Ok; OnInvalid decides fatality");
+
+        assert_eq!(sources.len(), good);
+        assert_eq!(warnings.len(), bad);
+        assert!(
+            warnings
+                .iter()
+                .all(|w| matches!(w, TileSourceWarning::PathError { .. }))
+        );
     }
 }
 

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -283,4 +283,88 @@ mod tests {
         mgr.apply_changes(advisory).await.unwrap();
         assert_yaml_snapshot!(sorted_source_names(&mgr), @"- a");
     }
+
+    /// Regression test for <https://github.com/maplibre/martin/discussions/2767>:
+    /// a persistently-failing source must not block later additions or removals
+    /// from reaching the live catalog when `OnInvalid::Warn` is in effect.
+    ///
+    /// Simulates the directory-watcher loop:
+    /// 1. Watch a directory with one bad file → catalog empty.
+    /// 2. Add a valid file → catalog gains it.
+    /// 3. Delete the valid file → catalog drops it.
+    #[tokio::test]
+    async fn watcher_loop_around_persistent_bad_file() {
+        use std::collections::BTreeMap;
+        use std::path::{Path, PathBuf};
+
+        use tempfile::TempDir;
+
+        use crate::MartinError;
+        use crate::config::file::ConfigFileError;
+
+        const BAD_PREFIX: &str = "bad_";
+
+        fn scan(dir: &Path) -> BTreeMap<String, u64> {
+            let mut out = BTreeMap::new();
+            for entry in std::fs::read_dir(dir).expect("read tempdir").flatten() {
+                if !entry.file_type().is_ok_and(|t| t.is_file()) {
+                    continue;
+                }
+                let id = entry
+                    .path()
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_string)
+                    .expect("file stem is valid utf-8");
+                out.insert(id, 1);
+            }
+            out
+        }
+
+        #[expect(
+            clippy::unused_async,
+            reason = "must satisfy AsyncFn for ReloadAdvisory::from_maps"
+        )]
+        async fn build(id: String, dir: PathBuf) -> MartinResult<BoxedSource> {
+            if id.starts_with(BAD_PREFIX) {
+                return Err(MartinError::from(ConfigFileError::InvalidFilePath(
+                    dir.join(format!("{id}.tiles")),
+                )));
+            }
+            Ok(Box::new(TestSource {
+                id,
+                tj: tilejson! { tiles: vec![] },
+            }))
+        }
+
+        let dir = TempDir::new().expect("create tempdir");
+        let dir_path = dir.path().to_path_buf();
+        let mgr = TileSourceManager::new(None, OnInvalid::Warn);
+        let mut state: BTreeMap<String, u64> = BTreeMap::new();
+
+        // Reconciles the manager with the current on-disk state and advances `state`.
+        let tick = async |state: &mut BTreeMap<String, u64>| {
+            let next = scan(&dir_path);
+            let advisory = ReloadAdvisory::from_maps(state, &next, async |id| {
+                build(id, dir_path.clone()).await
+            })
+            .await;
+            mgr.apply_changes(advisory)
+                .await
+                .expect("warn policy must not abort on a bad file");
+            *state = next;
+        };
+
+        std::fs::write(dir.path().join("bad_a.tiles"), b"").unwrap();
+        tick(&mut state).await;
+        assert_yaml_snapshot!(sorted_source_names(&mgr), @"[]");
+
+        std::fs::write(dir.path().join("good_x.tiles"), b"").unwrap();
+        tick(&mut state).await;
+        assert_yaml_snapshot!(sorted_source_names(&mgr), @"- good_x");
+
+        std::fs::remove_file(dir.path().join("good_x.tiles")).unwrap();
+        tick(&mut state).await;
+        assert_yaml_snapshot!(sorted_source_names(&mgr), @"[]");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #2767. A single invalid mbtiles file inside a folder source caused the entire directory to vanish from `/catalog` under `on_invalid: warn` — the user's reproduction:

```yaml
mbtiles:
  paths:
    - /path/to/mbtiles/directory
on_invalid: warn
```

with one bad file in the directory produced an empty catalog instead of warning on the bad file and serving the rest.