### PR TITLE
fix(sprites): warn early and explain `.svg`-only requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "spreet",
+ "tempfile",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tiff",

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -115,6 +115,7 @@ image-compare.workspace = true
 insta = { workspace = true, features = ["json", "yaml"] }
 rstest.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 testcontainers-modules.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -26,7 +26,10 @@ pub enum SpriteError {
     InvalidSpriteFilePath(String, PathBuf),
 
     /// No SVG files found in directory.
-    #[error("No sprite SVG files found in {0}")]
+    #[error(
+        "No sprite SVG files found in {0}. Martin generates spritesheets from source `.svg` files; \
+         a directory containing only pre-generated `sprite.png` / `sprite.json` cannot be used."
+    )]
     NoSpriteFilesFound(PathBuf),
 
     /// Failed to read sprite file.

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -26,10 +26,7 @@ pub enum SpriteError {
     InvalidSpriteFilePath(String, PathBuf),
 
     /// No SVG files found in directory.
-    #[error(
-        "No sprite SVG files found in {0}. Martin generates spritesheets from source `.svg` files; \
-         a directory containing only pre-generated `sprite.png` / `sprite.json` cannot be used."
-    )]
+    #[error("No sprite SVG files found in {0} to generate spritesheets from")]
     NoSpriteFilesFound(PathBuf),
 
     /// Failed to read sprite file.

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -108,10 +108,8 @@ impl SpriteSources {
                         warn!(
                             source.id = %v.key(),
                             sprite.path = %disp_path,
-                            "Sprite source directory contains no `.svg` files. \
-                             Martin generates spritesheets from source SVG files; \
-                             pre-generated `sprite.png` / `sprite.json` files are not used. \
-                             Sprite requests for this source will fail."
+                            "No sprite SVG files found in directory to generate spritesheets from. \
+                             Sprite requests for this source will fail, until at least one svg is present."
                         );
                     }
                     v.insert(SpriteSource { path });
@@ -279,10 +277,7 @@ mod tests {
             panic!("expected NoSpriteFilesFound, got Ok");
         };
 
-        assert!(matches!(err, SpriteError::NoSpriteFilesFound(ref p) if p == tmp.path()));
-        let msg = err.to_string();
-        assert!(msg.contains(".svg"), "error message lacks `.svg`: {msg}");
-        assert!(msg.contains(&tmp.path().display().to_string()));
+        assert!(matches!(err, SpriteError::NoSpriteFilesFound(_)));
     }
 
     async fn test_src(

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -102,6 +102,18 @@ impl SpriteSources {
                         sprite.path = %disp_path,
                         "Configured sprite source"
                     );
+                    if let Ok(paths) = get_svg_input_paths(&path, true)
+                        && paths.is_empty()
+                    {
+                        warn!(
+                            source.id = %v.key(),
+                            sprite.path = %disp_path,
+                            "Sprite source directory contains no `.svg` files. \
+                             Martin generates spritesheets from source SVG files; \
+                             pre-generated `sprite.png` / `sprite.json` files are not used. \
+                             Sprite requests for this source will fail."
+                        );
+                    }
                     v.insert(SpriteSource { path });
                 }
             }
@@ -251,6 +263,26 @@ mod tests {
             test_src(src2_path.iter(), 1, "src2_1", generate_sdf).await;
             test_src(src2_path.iter(), 2, "src2_2", generate_sdf).await;
         }
+    }
+
+    #[tokio::test]
+    async fn directory_without_svgs_yields_helpful_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("sprite.json"), b"{}").unwrap();
+        std::fs::write(tmp.path().join("sprite.png"), b"\x89PNG\r\n").unwrap();
+
+        let mut sprites = SpriteSources::default();
+        sprites.add_source("bad".to_string(), tmp.path().to_path_buf());
+
+        let source = sprites.get("bad").expect("source registered");
+        let Err(err) = get_spritesheet([source].iter(), 1, false).await else {
+            panic!("expected NoSpriteFilesFound, got Ok");
+        };
+
+        assert!(matches!(err, SpriteError::NoSpriteFilesFound(ref p) if p == tmp.path()));
+        let msg = err.to_string();
+        assert!(msg.contains(".svg"), "error message lacks `.svg`: {msg}");
+        assert!(msg.contains(&tmp.path().display().to_string()));
     }
 
     async fn test_src(


### PR DESCRIPTION
## Summary

Issue #2136 asks for a clearer warning when a user points Martin at a sprite directory that has no `.svg` files. The original report (#1336, closed) involved a user pointing Martin at a pre-generated spritesheet (`sprite.png` + `sprite.json`). Martin returned `500 No sprite SVG files found in <path>` with no explanation of what files Martin does want.

This PR improves that signal *without* changing what Martin supports, actually consuming pre-generated sprites is tracked separately in #1364 and is out of scope here.

* emits a `WARN` from `SpriteSources::add_source` when the directory exists but contains no `.svg` files, so users see the problem at startup rather than at request time
* expands the `NoSpriteFilesFound` error to call out that Martin generates spritesheets from source `.svg` files
* adds a unit test covering both the variant and the wording

## Verification

Reproduced locally with a directory containing only `sprite.png` and `sprite.json`, saw the new warning at startup and the improved 500 body at request time.

- [x] `cargo test -p martin-core --features sprites` -> 40/40 passing
- [x] `cargo fmt --check`
- [x] `cargo clippy -p martin-core --features sprites --tests -- -D warnings`

Closes #2136.
