### PR TITLE
feat: Expand relative URLs in style response

### DIFF
--- a/.github/files/homebrew.martin.rb.j2
+++ b/.github/files/homebrew.martin.rb.j2
@@ -14,10 +14,6 @@ class Martin < Formula
       sha256 "{{ macos_arm_sha256 }}"
       url "https://github.com/maplibre/martin/releases/download/martin-v#{current_version}/martin-aarch64-apple-darwin.tar.gz"
     end
-    on_intel do
-      sha256 "{{ macos_intel_sha256 }}"
-      url "https://github.com/maplibre/martin/releases/download/martin-v#{current_version}/martin-x86_64-apple-darwin.tar.gz"
-    end
   end
 
   on_linux do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,14 +401,6 @@ jobs:
       os: ubuntu-22.04
       release_mode: ${{ github.event_name != 'pull_request' }}
 
-  build-x86_64-apple-darwin:
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target: x86_64-apple-darwin
-      os: macos-15-intel # x64 CPU, available until August 2027, see https://github.com/actions/runner-images/issues/13045
-      use_cache: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
-      release_mode: ${{ github.event_name != 'pull_request' }}
-
   build-x86_64-pc-windows-msvc:
     uses: ./.github/workflows/build-binary.yml
     with:
@@ -467,9 +459,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # temporary disabled due to an issue with homebrew which is difficult to debug
-          # - target: x86_64-apple-darwin
-          #   os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: '.exe'
@@ -496,10 +485,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: nyurik/action-setup-postgis@e54fc643200ee809b4711c3f537c433dfbeba056 # v2.3
         id: pg
-        with: { username: 'postgres', password: 'postgres', database: 'test', postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
-      - name: Install and run Postgis (Macos)
-        if: matrix.os == 'macos-13'
-        uses: nyurik/action-setup-postgis@e54fc643200ee809b4711c3f537c433dfbeba056 # v2.3
         with: { username: 'postgres', password: 'postgres', database: 'test', postgres-version: 16, port: 34837, postgis_version: 3.5.2 }
       - name: Install and run Postgis (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -797,7 +782,7 @@ jobs:
       attestations: write
       # for writing release artifacts
       contents: write
-    needs: [ lint-unit-test-js, unit-test-rust, lint-rust, lint-rust-dependencies, validate-schemas, test-multi-os, test-with-svc, test-aws-lambda, test-publish, build-aarch64-apple-darwin, build-x86_64-apple-darwin, build-aarch64-unknown-linux-gnu, build-aarch64-unknown-linux-musl ]
+    needs: [ lint-unit-test-js, unit-test-rust, lint-rust, lint-rust-dependencies, validate-schemas, test-multi-os, test-with-svc, test-aws-lambda, test-publish, build-aarch64-apple-darwin, build-aarch64-unknown-linux-gnu, build-aarch64-unknown-linux-musl ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -807,9 +792,6 @@ jobs:
       - name: Download build artifact build-aarch64-apple-darwin
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-apple-darwin', path: 'target/aarch64-apple-darwin' }
-      - name: Download build artifact build-x86_64-apple-darwin
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with: { name: 'build-x86_64-apple-darwin', path: 'target/x86_64-apple-darwin' }
       - name: Download build artifact build-aarch64-unknown-linux-gnu
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-aarch64-unknown-linux-gnu', path: 'target/aarch64-unknown-linux-gnu' }
@@ -833,7 +815,7 @@ jobs:
         run: |
           set -x
 
-          for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu aarch64-unknown-linux-musl x86_64-unknown-linux-musl x86_64-pc-windows-msvc debian-x86_64;
+          for target in aarch64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu aarch64-unknown-linux-musl x86_64-unknown-linux-musl x86_64-pc-windows-msvc debian-x86_64;
           do
             just package-assets "$target"
           done
@@ -852,7 +834,6 @@ jobs:
           cat << EOF > homebrew_config.yaml
           version: "$MARTIN_VERSION"
           macos_arm_sha256: "$(shasum -a 256 files/martin-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)"
-          macos_intel_sha256: "$(shasum -a 256 files/martin-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)"
           linux_arm_sha256: "$(shasum -a 256 files/martin-aarch64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           linux_intel_sha256: "$(shasum -a 256 files/martin-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)"
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,7 +572,7 @@ jobs:
             echo "** If this is expected, run 'just bless' to update expected output"
             echo ""
             echo "::group::Resulting diff (max 100 lines)"
-            diff --recursive --new-file --exclude='*.pbf' tests/output tests/expected | head -n 100 | cat --show-nonprinting
+            diff --recursive --new-file --exclude='*.pbf' tests/output tests/expected | head -n 100 | cat -v
             echo "::endgroup::"
             exit 1
           else

--- a/deny.toml
+++ b/deny.toml
@@ -87,6 +87,5 @@ targets = [
   "x86_64-unknown-linux-gnu",
   "aarch64-unknown-linux-gnu",
   "aarch64-apple-darwin",
-  "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
 ]

--- a/docs/content/quick-start-macos.md
+++ b/docs/content/quick-start-macos.md
@@ -5,8 +5,8 @@
 2. Download the latest version of Martin from
    the [release page](https://github.com/maplibre/martin/releases/latest).
    Use [about this Mac](https://support.apple.com/en-us/116943) to find your processors type.
-    * Use [martin-x86_64-apple-darwin.tar.gz](https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-apple-darwin.tar.gz) for Intel
-    * Use [martin-aarch64-apple-darwin.tar.gz](https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-apple-darwin.tar.gz) for M1
+    * **for M1**: Use [martin-aarch64-apple-darwin.tar.gz](https://github.com/maplibre/martin/releases/latest/download/martin-aarch64-apple-darwin.tar.gz)
+    * **for x86**, you likely can compile us source, but we don't complie this for you due to runner avaliability.
 
 3. Extract content of both files and place them in a same directory.
 

--- a/justfile
+++ b/justfile
@@ -533,22 +533,17 @@ test-int: clean-test install-sqlx start-pmtiles-server
     #!/usr/bin/env bash
     set -euo pipefail
     tests/test.sh
-    if [ "{{os()}}" != "linux" ]; then
-        echo "** Integration tests are only supported on Linux"
-        echo "** Skipping diffing with the expected output"
+    echo "** Comparing actual output with expected output..."
+    if ! diff --brief --recursive --new-file --exclude='*.pbf' tests/output tests/expected; then
+        echo "** Expected output does not match actual output"
+        echo "** If this is expected, run 'just bless' to update expected output"
+        echo ""
+        echo "::group::Resulting diff (max 100 lines)"
+        diff --recursive --new-file --exclude='*.pbf' tests/output tests/expected | head -n 100 | cat -v
+        echo "::endgroup::"
+        exit 1
     else
-        echo "** Comparing actual output with expected output..."
-        if ! diff --brief --recursive --new-file --exclude='*.pbf' tests/output tests/expected; then
-            echo "** Expected output does not match actual output"
-            echo "** If this is expected, run 'just bless' to update expected output"
-            echo ""
-            echo "::group::Resulting diff (max 100 lines)"
-            diff --recursive --new-file --exclude='*.pbf' tests/output tests/expected | head -n 100 | cat --show-nonprinting
-            echo "::endgroup::"
-            exit 1
-        else
-            echo "** Expected output matches actual output"
-        fi
+        echo "** Expected output matches actual output"
     fi
 
 # Run AWS Lambda smoke test against SAM local

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -83,6 +83,20 @@ pub struct SrvConfig {
     pub tilejson_url_version_param: Option<String>,
 }
 
+impl SrvConfig {
+    /// The URL path prefix under which Martin is publicly served, derived from
+    /// the explicit config (not request headers).
+    ///
+    /// Returns `base_path` if set, otherwise `route_prefix`, otherwise `None`.
+    /// The two have different deployment semantics (see field docs) but both
+    /// describe the public-facing prefix and so are interchangeable for the
+    /// purpose of building absolute URLs in responses.
+    #[must_use]
+    pub fn public_path_prefix(&self) -> Option<&str> {
+        self.base_path.as_deref().or(self.route_prefix.as_deref())
+    }
+}
+
 impl ConfigurationLivecycleHooks for SrvConfig {
     fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
         let mut unrecognized = UnrecognizedKeys::new();

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -22,6 +22,9 @@ pub use tile_source_manager::TileSourceManager;
 mod error;
 pub use error::{MartinError, MartinResult};
 
+#[cfg(feature = "styles")]
+pub mod maplibre_style;
+
 pub mod srv;
 
 #[cfg(feature = "unstable-schemas")]

--- a/martin/src/maplibre_style.rs
+++ b/martin/src/maplibre_style.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use url::Url;
 
 /// A partially-typed `MapLibre` style document.
 #[serde_with::skip_serializing_none]
@@ -116,8 +117,8 @@ fn expand_if_relative_url(url: &mut String, base_url: &str) {
     if url.starts_with("//") {
         return;
     }
-    // Has a scheme (https:, data:, mailto:, mapbox:, mbtiles:, ...) → leave alone.
-    if has_uri_scheme(url) {
+    // Already a valid absolute URL → leave alone.
+    if Url::parse(url).is_ok() {
         return;
     }
     // Ensure exactly one '/' between the base and the path, so a relative path
@@ -127,28 +128,6 @@ fn expand_if_relative_url(url: &mut String, base_url: &str) {
         url.insert(0, '/');
     }
     url.insert_str(0, base_url);
-}
-
-/// True if `url` begins with an RFC 3986 `scheme:` prefix.
-///
-/// `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by `:`.
-fn has_uri_scheme(url: &str) -> bool {
-    let mut chars = url.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !first.is_ascii_alphabetic() {
-        return false;
-    }
-    for c in chars {
-        if c == ':' {
-            return true;
-        }
-        if !(c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
-            return false;
-        }
-    }
-    false
 }
 
 #[cfg(test)]

--- a/martin/src/maplibre_style.rs
+++ b/martin/src/maplibre_style.rs
@@ -1,0 +1,387 @@
+//! Partial [`MapLibre` style spec][spec] types.
+//!
+//! Only the fields needed for URL rewriting are modeled; everything else
+//! round-trips through `serde_json::Value` via `#[serde(flatten)]`.
+//!
+//! This module is intentionally self-contained and depends only on
+//! `serde` / `serde_json`, so it could be lifted into a standalone crate later.
+//!
+//! [spec]: https://maplibre.org/maplibre-style-spec/
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A partially-typed `MapLibre` style document.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Style {
+    pub glyphs: Option<String>,
+
+    pub sprite: Option<Sprite>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sources: BTreeMap<String, Source>,
+
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Value>,
+}
+
+/// The `sprite` field is either a single URL or a list of `{id, url}` entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Sprite {
+    Single(String),
+    Multi(Vec<SpriteEntry>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpriteEntry {
+    pub id: String,
+    pub url: String,
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Value>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Source {
+    pub url: Option<String>,
+
+    pub tiles: Option<Vec<String>>,
+
+    /// May be a URL string (for remote `GeoJSON`) or inline `GeoJSON`.
+    pub data: Option<Value>,
+
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Value>,
+}
+
+impl Style {
+    /// Rewrite any URL field that lacks a scheme (does not contain `://`)
+    /// by prepending `base_url`.
+    ///
+    /// Lets a style.json on disk use protocol-less URLs like
+    /// `"/font/{fontstack}/{range}"`, which the `MapLibre` style spec doesn't
+    /// allow, while still serving spec-compliant absolute URLs to clients.
+    ///
+    /// Fields rewritten: top-level `glyphs`, `sprite` (both string and
+    /// `[{id, url}]` forms), and per-source `url`, `tiles[]`, and `data`
+    /// (only when `data` is a string).
+    pub fn expand_relative_urls(&mut self, base_url: &str) {
+        if let Some(glyphs) = &mut self.glyphs {
+            expand_if_relative_url(glyphs, base_url);
+        }
+        if let Some(sprite) = &mut self.sprite {
+            sprite.expand_relative_urls(base_url);
+        }
+        for source in self.sources.values_mut() {
+            source.expand_relative_urls(base_url);
+        }
+    }
+}
+
+impl Sprite {
+    fn expand_relative_urls(&mut self, base_url: &str) {
+        match self {
+            Self::Single(url) => expand_if_relative_url(url, base_url),
+            Self::Multi(entries) => {
+                for entry in entries {
+                    expand_if_relative_url(&mut entry.url, base_url);
+                }
+            }
+        }
+    }
+}
+
+impl Source {
+    fn expand_relative_urls(&mut self, base_url: &str) {
+        if let Some(url) = &mut self.url {
+            expand_if_relative_url(url, base_url);
+        }
+        if let Some(tiles) = &mut self.tiles {
+            for t in tiles {
+                expand_if_relative_url(t, base_url);
+            }
+        }
+        if let Some(Value::String(url)) = &mut self.data {
+            expand_if_relative_url(url, base_url);
+        }
+    }
+}
+
+fn expand_if_relative_url(url: &mut String, base_url: &str) {
+    // Protocol-relative URL like `//cdn.example/x` → leave alone.
+    if url.starts_with("//") {
+        return;
+    }
+    // Has a scheme (https:, data:, mailto:, mapbox:, mbtiles:, ...) → leave alone.
+    if has_uri_scheme(url) {
+        return;
+    }
+    // Ensure exactly one '/' between the base and the path, so a relative path
+    // without a leading slash (e.g. `fonts/{fontstack}`) doesn't get glued onto
+    // the prefix to produce `https://host/prefixfonts/...`.
+    if !url.starts_with('/') {
+        url.insert(0, '/');
+    }
+    url.insert_str(0, base_url);
+}
+
+/// True if `url` begins with an RFC 3986 `scheme:` prefix.
+///
+/// `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by `:`.
+fn has_uri_scheme(url: &str) -> bool {
+    let mut chars = url.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    for c in chars {
+        if c == ':' {
+            return true;
+        }
+        if !(c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+            return false;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse(v: Value) -> Style {
+        serde_json::from_value(v).unwrap()
+    }
+
+    fn dump(s: &Style) -> Value {
+        serde_json::to_value(s).unwrap()
+    }
+
+    #[test]
+    fn leaves_absolute_urls_alone() {
+        let original = json!({
+            "version": 8,
+            "glyphs": "https://example.com/font/{fontstack}/{range}.pbf",
+            "sprite": "https://example.com/sprite",
+            "sources": {
+                "v": {
+                    "type": "vector",
+                    "url": "https://example.com/tiles.json",
+                    "tiles": ["https://example.com/{z}/{x}/{y}.pbf"]
+                },
+                "g": {
+                    "type": "geojson",
+                    "data": "https://example.com/things.geojson"
+                }
+            }
+        });
+        let mut style = parse(original.clone());
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(dump(&style), original);
+    }
+
+    #[test]
+    fn rewrites_relative_urls() {
+        let mut style = parse(json!({
+            "version": 8,
+            "glyphs": "/font/{fontstack}/{range}.pbf",
+            "sprite": "/sprite/my_sprite",
+            "sources": {
+                "v": {
+                    "type": "vector",
+                    "url": "/my_source",
+                    "tiles": ["/my_source/{z}/{x}/{y}"]
+                },
+                "g": {
+                    "type": "geojson",
+                    "data": "/things.geojson"
+                }
+            }
+        }));
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(
+            dump(&style),
+            json!({
+                "version": 8,
+                "glyphs": "https://martin.example/font/{fontstack}/{range}.pbf",
+                "sprite": "https://martin.example/sprite/my_sprite",
+                "sources": {
+                    "v": {
+                        "type": "vector",
+                        "url": "https://martin.example/my_source",
+                        "tiles": ["https://martin.example/my_source/{z}/{x}/{y}"]
+                    },
+                    "g": {
+                        "type": "geojson",
+                        "data": "https://martin.example/things.geojson"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn rewrites_sprite_array_form() {
+        let mut style = parse(json!({
+            "sprite": [
+                {"id": "default", "url": "/sprite/main"},
+                {"id": "other", "url": "https://cdn.example/sprite/other"}
+            ]
+        }));
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(
+            dump(&style),
+            json!({
+                "sprite": [
+                    {"id": "default", "url": "https://martin.example/sprite/main"},
+                    {"id": "other", "url": "https://cdn.example/sprite/other"}
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn leaves_inline_geojson_data_alone() {
+        let original = json!({
+            "sources": {
+                "g": {
+                    "type": "geojson",
+                    "data": {"type": "FeatureCollection", "features": []}
+                }
+            }
+        });
+        let mut style = parse(original.clone());
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(dump(&style), original);
+    }
+
+    #[test]
+    fn leaves_non_http_schemes_alone() {
+        let original = json!({
+            "sources": {
+                "m": {"type": "vector", "url": "mbtiles://my.mbtiles"},
+                "p": {"type": "vector", "url": "pmtiles://my.pmtiles"}
+            }
+        });
+        let mut style = parse(original.clone());
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(dump(&style), original);
+    }
+
+    #[test]
+    fn only_updates_specified_fields() {
+        let mut style = parse(json!({
+            "sprite": "/sprite/touch_this",
+            "not_sprite": "/sprite/dont_touch_this",
+        }));
+        style.expand_relative_urls("https://martin.example");
+        assert_eq!(
+            dump(&style),
+            json!({
+                "sprite": "https://martin.example/sprite/touch_this",
+                "not_sprite": "/sprite/dont_touch_this",
+            })
+        );
+    }
+
+    fn expanded(url: &str, base: &str) -> String {
+        let mut s = url.to_string();
+        expand_if_relative_url(&mut s, base);
+        s
+    }
+
+    #[test]
+    fn expand_leaves_http_schemes_alone() {
+        assert_eq!(
+            expanded("https://example.com/x", "https://martin.example"),
+            "https://example.com/x"
+        );
+        assert_eq!(
+            expanded("http://example.com/x", "https://martin.example"),
+            "http://example.com/x"
+        );
+    }
+
+    #[test]
+    fn expand_leaves_custom_schemes_alone() {
+        assert_eq!(
+            expanded("mapbox://styles/foo", "https://martin.example"),
+            "mapbox://styles/foo"
+        );
+        assert_eq!(
+            expanded("mbtiles://my.mbtiles", "https://martin.example"),
+            "mbtiles://my.mbtiles"
+        );
+    }
+
+    #[test]
+    fn expand_leaves_data_and_mailto_uris_alone() {
+        assert_eq!(
+            expanded("data:font/ttf;base64,AAAA", "https://martin.example"),
+            "data:font/ttf;base64,AAAA"
+        );
+        assert_eq!(
+            expanded("mailto:nobody@example.com", "https://martin.example"),
+            "mailto:nobody@example.com"
+        );
+    }
+
+    #[test]
+    fn expand_leaves_protocol_relative_urls_alone() {
+        assert_eq!(
+            expanded("//cdn.example/sprite", "https://martin.example"),
+            "//cdn.example/sprite"
+        );
+    }
+
+    #[test]
+    fn expand_prepends_base_to_path_absolute_url() {
+        assert_eq!(
+            expanded("/font/{fontstack}", "https://martin.example/prefix"),
+            "https://martin.example/prefix/font/{fontstack}"
+        );
+    }
+
+    #[test]
+    fn expand_joins_relative_path_with_single_slash() {
+        assert_eq!(
+            expanded("fonts/{fontstack}", "https://martin.example/prefix"),
+            "https://martin.example/prefix/fonts/{fontstack}"
+        );
+        assert_eq!(
+            expanded("fonts/{fontstack}", "https://martin.example"),
+            "https://martin.example/fonts/{fontstack}"
+        );
+    }
+
+    #[test]
+    fn expand_does_not_treat_colon_in_path_segment_as_scheme() {
+        // A path segment containing ':' after a non-alpha first char isn't a scheme.
+        assert_eq!(
+            expanded("1bad:scheme/foo", "https://martin.example"),
+            "https://martin.example/1bad:scheme/foo"
+        );
+    }
+
+    #[test]
+    fn preserves_unknown_fields() {
+        let original = json!({
+            "version": 8,
+            "name": "demo",
+            "metadata": {"author": "me"},
+            "layers": [{"id": "background", "type": "background"}],
+            "center": [0.0, 0.0],
+            "zoom": 3
+        });
+        let style = parse(original.clone());
+        assert_eq!(dump(&style), original);
+    }
+}

--- a/martin/src/srv/styles.rs
+++ b/martin/src/srv/styles.rs
@@ -1,12 +1,15 @@
 use actix_middleware_etag::Etag;
+use actix_web::http::Uri;
 use actix_web::http::header::{ContentType, LOCATION};
 use actix_web::middleware::Compress;
 use actix_web::web::{Data, Path};
-use actix_web::{HttpResponse, route};
+use actix_web::{HttpRequest, HttpResponse, route};
 use martin_core::styles::StyleSources;
 use serde::Deserialize;
 use tracing::{error, instrument, warn};
 
+use crate::config::file::srv::SrvConfig;
+use crate::maplibre_style::Style;
 use crate::srv::server::DebouncedWarning;
 
 #[derive(Deserialize, Debug)]
@@ -37,7 +40,12 @@ struct StyleRequest {
 )]
 #[hotpath::measure]
 #[instrument(level = "debug", skip_all, fields(style.id = %path.style_id))]
-pub async fn get_style_json(path: Path<StyleRequest>, styles: Data<StyleSources>) -> HttpResponse {
+pub async fn get_style_json(
+    req: HttpRequest,
+    path: Path<StyleRequest>,
+    styles: Data<StyleSources>,
+    srv_config: Data<SrvConfig>,
+) -> HttpResponse {
     let style_id = &path.style_id;
     let Some(path) = styles.style_json_path(style_id) else {
         return HttpResponse::NotFound()
@@ -51,8 +59,23 @@ pub async fn get_style_json(path: Path<StyleRequest>, styles: Data<StyleSources>
             .content_type(ContentType::plaintext())
             .body("No such style exists");
     };
-    match serde_json::from_str::<serde_json::Value>(&style_content) {
-        Ok(value) => HttpResponse::Ok().json(value),
+    match serde_json::from_str::<Style>(&style_content) {
+        Ok(mut style) => {
+            // maplibre clients don't fully support relative URLs
+            // At the time of writing:
+            //   - maplibre-gl-js supports relative URLs for tilesets and sprites (but not glyphs)
+            //   - maplibre-native doesn't seem to support relative URLs at all
+            //
+            // Build an absolute base URL using the request's scheme/host and the
+            // configured path prefix, mirroring the precedence used for TileJSON
+            // URLs in `srv/tiles/metadata.rs`:
+            //   base_path > route_prefix > X-Forwarded-Prefix > ""
+            let prefix = path_prefix(&req, &srv_config);
+            let info = req.connection_info();
+            let base_url = format!("{}://{}{prefix}", info.scheme(), info.host());
+            style.expand_relative_urls(&base_url);
+            HttpResponse::Ok().json(style)
+        }
         Err(e) => {
             error!(
                 "Failed to parse style JSON {e:?} for style {style_id} at {:?}",
@@ -65,6 +88,28 @@ pub async fn get_style_json(path: Path<StyleRequest>, styles: Data<StyleSources>
                     "The requested style {style_id} is malformed: {e:?}"
                 ))
         }
+    }
+}
+
+/// Resolve the URL path prefix under which Martin is publicly served.
+///
+/// Returns an empty string when no prefix applies, otherwise a leading-slash
+/// path with no trailing slash (e.g. `/tiles`).
+///
+/// Note: `X-Rewrite-URL` is intentionally not honored here. Unlike the
+/// `TileJSON` case where the header's full path can be used directly, for
+/// styles the header would contain the full style request path
+/// (e.g. `/tiles/style/foo/style.json`), which isn't a usable prefix.
+fn path_prefix(req: &HttpRequest, srv_config: &SrvConfig) -> String {
+    if let Some(prefix) = srv_config.public_path_prefix() {
+        prefix.to_string()
+    } else {
+        req.headers()
+            .get("X-Forwarded-Prefix")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<Uri>().ok())
+            .map(|v| v.path().trim_end_matches('/').to_string())
+            .unwrap_or_default()
     }
 }
 
@@ -85,4 +130,63 @@ pub(crate) async fn redirect_styles(path: Path<StyleRequest>) -> HttpResponse {
     HttpResponse::MovedPermanently()
         .insert_header((LOCATION, format!("/style/{style_id}")))
         .finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::test::TestRequest;
+
+    use super::*;
+
+    fn cfg(base_path: Option<&str>, route_prefix: Option<&str>) -> SrvConfig {
+        SrvConfig {
+            base_path: base_path.map(ToString::to_string),
+            route_prefix: route_prefix.map(ToString::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn path_prefix_empty_when_nothing_configured() {
+        let req = TestRequest::default().to_http_request();
+        assert_eq!(path_prefix(&req, &cfg(None, None)), "");
+    }
+
+    #[test]
+    fn path_prefix_uses_base_path_first() {
+        let req = TestRequest::default()
+            .insert_header(("X-Forwarded-Prefix", "/header"))
+            .to_http_request();
+        assert_eq!(
+            path_prefix(&req, &cfg(Some("/from_base"), Some("/from_route"))),
+            "/from_base"
+        );
+    }
+
+    #[test]
+    fn path_prefix_falls_back_to_route_prefix() {
+        let req = TestRequest::default()
+            .insert_header(("X-Forwarded-Prefix", "/header"))
+            .to_http_request();
+        assert_eq!(
+            path_prefix(&req, &cfg(None, Some("/from_route"))),
+            "/from_route"
+        );
+    }
+
+    #[test]
+    fn path_prefix_falls_back_to_forwarded_prefix_header() {
+        let req = TestRequest::default()
+            .insert_header(("X-Forwarded-Prefix", "/from_header"))
+            .to_http_request();
+        assert_eq!(path_prefix(&req, &cfg(None, None)), "/from_header");
+    }
+
+    #[test]
+    fn path_prefix_strips_trailing_slash_from_header() {
+        let req = TestRequest::default()
+            .insert_header(("X-Forwarded-Prefix", "/from_header/"))
+            .to_http_request();
+        assert_eq!(path_prefix(&req, &cfg(None, None)), "/from_header");
+    }
 }

--- a/martin/src/srv/tiles/metadata.rs
+++ b/martin/src/srv/tiles/metadata.rs
@@ -52,12 +52,8 @@ pub async fn get_source_info(
 
     // Determine the path prefix for tile URLs in TileJSON responses
     // Priority: base_path (explicit override) > route_prefix (where Martin is mounted) > X-Rewrite-URL header > request path
-    let tiles_path = if let Some(base_path) = &srv_config.base_path {
-        // If base_path is explicitly set, use it directly
-        format!("{base_path}/{}", path.source_ids)
-    } else if let Some(route_prefix) = &srv_config.route_prefix {
-        // If route_prefix is set, use it (Martin is mounted under a subpath)
-        format!("{route_prefix}/{}", path.source_ids)
+    let tiles_path = if let Some(prefix) = srv_config.public_path_prefix() {
+        format!("{prefix}/{}", path.source_ids)
     } else {
         // Fall back to X-Rewrite-URL header if present, otherwise use request path
         req.headers()

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -33,6 +33,9 @@
     },
     "osm-liberty-lite": {
       "path": "tests/fixtures/styles/src2/osm-liberty-lite.json"
+    },
+    "relative_urls": {
+      "path": "tests/fixtures/styles/relative_urls.json"
     }
   },
   "tiles": {

--- a/tests/expected/auto/relative_style_urls.json
+++ b/tests/expected/auto/relative_style_urls.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "http://localhost:3111/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "http://localhost:3111/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "http://localhost:3111/table_source"
+    }
+  },
+  "sprite": "http://localhost:3111/sprite/src1",
+  "version": 8
+}

--- a/tests/expected/auto/relative_style_urls.json.headers
+++ b/tests/expected/auto/relative_style_urls.json.headers
@@ -1,0 +1,5 @@
+content-encoding: br
+content-type: application/json
+etag: W/"190-wEV9WFhcm2JeHwlgPklUYw=="
+transfer-encoding: chunked
+vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/auto/relative_style_urls_ignores_forwarded_for.json
+++ b/tests/expected/auto/relative_style_urls_ignores_forwarded_for.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "http://localhost:3111/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "http://localhost:3111/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "http://localhost:3111/table_source"
+    }
+  },
+  "sprite": "http://localhost:3111/sprite/src1",
+  "version": 8
+}

--- a/tests/expected/auto/relative_style_urls_ignores_forwarded_for.json.headers
+++ b/tests/expected/auto/relative_style_urls_ignores_forwarded_for.json.headers
@@ -1,0 +1,5 @@
+content-encoding: br
+content-type: application/json
+etag: W/"190-wEV9WFhcm2JeHwlgPklUYw=="
+transfer-encoding: chunked
+vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/auto/relative_style_urls_with_forwarded_host.json
+++ b/tests/expected/auto/relative_style_urls_with_forwarded_host.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "http://tiles.example.com/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "http://tiles.example.com/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "http://tiles.example.com/table_source"
+    }
+  },
+  "sprite": "http://tiles.example.com/sprite/src1",
+  "version": 8
+}

--- a/tests/expected/auto/relative_style_urls_with_forwarded_host.json.headers
+++ b/tests/expected/auto/relative_style_urls_with_forwarded_host.json.headers
@@ -1,0 +1,5 @@
+content-encoding: br
+content-type: application/json
+etag: W/"19c-JA6Og5erx_CZRjYh4wfHOw=="
+transfer-encoding: chunked
+vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/auto/relative_style_urls_with_host.json
+++ b/tests/expected/auto/relative_style_urls_with_host.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "http://example.com/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "http://example.com/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "http://example.com/table_source"
+    }
+  },
+  "sprite": "http://example.com/sprite/src1",
+  "version": 8
+}

--- a/tests/expected/auto/relative_style_urls_with_host.json.headers
+++ b/tests/expected/auto/relative_style_urls_with_host.json.headers
@@ -1,0 +1,5 @@
+content-encoding: br
+content-type: application/json
+etag: W/"184-fxvyUIqxlbkOCBazBXcuqg=="
+transfer-encoding: chunked
+vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/auto/relative_style_urls_with_prefix.json
+++ b/tests/expected/auto/relative_style_urls_with_prefix.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "http://localhost:3111/tiles/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "http://localhost:3111/tiles/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "http://localhost:3111/tiles/table_source"
+    }
+  },
+  "sprite": "http://localhost:3111/tiles/sprite/src1",
+  "version": 8
+}

--- a/tests/expected/auto/relative_style_urls_with_prefix.json.headers
+++ b/tests/expected/auto/relative_style_urls_with_prefix.json.headers
@@ -1,0 +1,5 @@
+content-encoding: br
+content-type: application/json
+etag: W/"1a8-D6ANng4CzhgoOPXNK4sLtw=="
+transfer-encoding: chunked
+vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/auto/save_config.yaml
+++ b/tests/expected/auto/save_config.yaml
@@ -420,6 +420,7 @@ mbtiles:
 sprites: tests/fixtures/sprites/src1
 styles:
 - tests/fixtures/styles/maplibre_demo.json
+- tests/fixtures/styles/relative_urls.json
 - tests/fixtures/styles/src2
 fonts:
 - tests/fixtures/fonts/overpass-mono-regular.ttf

--- a/tests/expected/configured/style_maplibre_demo.1.json.headers
+++ b/tests/expected/configured/style_maplibre_demo.1.json.headers
@@ -1,5 +1,5 @@
 content-encoding: br
 content-type: application/json
-etag: W/"1041-04dbk6bU1HSm97IrgbFR9g=="
+etag: W/"1041-WziwVsCt8kPEqnH09WGynw=="
 transfer-encoding: chunked
 vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/configured/style_maplibre_demo.json.headers
+++ b/tests/expected/configured/style_maplibre_demo.json.headers
@@ -1,5 +1,5 @@
 content-encoding: br
 content-type: application/json
-etag: W/"1041-04dbk6bU1HSm97IrgbFR9g=="
+etag: W/"1041-WziwVsCt8kPEqnH09WGynw=="
 transfer-encoding: chunked
 vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/configured/style_src2_maptiler_basic.1.json.headers
+++ b/tests/expected/configured/style_src2_maptiler_basic.1.json.headers
@@ -1,5 +1,5 @@
 content-encoding: br
 content-type: application/json
-etag: W/"3f38-7n4CiTZ0CYZTQGW7zSwhmQ=="
+etag: W/"3f38-maP1dgPKTXABNATzxY5Djg=="
 transfer-encoding: chunked
 vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/expected/configured/style_src2_maptiler_basic.json.headers
+++ b/tests/expected/configured/style_src2_maptiler_basic.json.headers
@@ -1,5 +1,5 @@
 content-encoding: br
 content-type: application/json
-etag: W/"3f38-7n4CiTZ0CYZTQGW7zSwhmQ=="
+etag: W/"3f38-maP1dgPKTXABNATzxY5Djg=="
 transfer-encoding: chunked
 vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers

--- a/tests/fixtures/styles/relative_urls.json
+++ b/tests/fixtures/styles/relative_urls.json
@@ -1,0 +1,27 @@
+{
+  "glyphs": "/font/{fontstack}/{range}",
+  "layers": [
+    {
+      "id": "background",
+      "paint": {
+        "background-color": "#000"
+      },
+      "type": "background"
+    }
+  ],
+  "name": "Relative URLs Test",
+  "sources": {
+    "from_tiles": {
+      "tiles": [
+        "/points1/{z}/{x}/{y}"
+      ],
+      "type": "vector"
+    },
+    "from_url": {
+      "type": "vector",
+      "url": "/table_source"
+    }
+  },
+  "sprite": "/sprite/src1",
+  "version": 8
+}

--- a/tests/fixtures/styles/relative_urls.json
+++ b/tests/fixtures/styles/relative_urls.json
@@ -12,9 +12,7 @@
   "name": "Relative URLs Test",
   "sources": {
     "from_tiles": {
-      "tiles": [
-        "/points1/{z}/{x}/{y}"
-      ],
+      "tiles": ["/points1/{z}/{x}/{y}"],
       "type": "vector"
     },
     "from_url": {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,9 +6,6 @@ unset DATABASE_URL
 
 export RUST_LOG_FORMAT=bare
 
-# TODO: use  --fail-with-body  to get the response body on failure
-CURL=${CURL:-curl --silent --show-error --fail --compressed}
-
 MARTIN_BUILD_ALL="${MARTIN_BUILD_ALL:-cargo build}"
 
 STATICS_URL="${STATICS_URL:-http://localhost:5412}"
@@ -47,6 +44,24 @@ else
   echo 'GNU sed is required for testing'
   exit 1
 fi
+
+# curl must support Brotli so the server's preferred encoding (br) is used,
+# keeping test output consistent across platforms.
+# On macOS the system curl lacks Brotli; prefer the Homebrew-installed one.
+if [[ -z "${CURL_BIN:-}" ]]; then
+  for candidate in curl /opt/homebrew/opt/curl/bin/curl /usr/local/opt/curl/bin/curl; do
+    if command -v "$candidate" > /dev/null 2>&1 && "$candidate" --version 2>/dev/null | grep -q brotli; then
+      CURL_BIN="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "${CURL_BIN:-}" ]]; then
+  echo 'curl with Brotli support is required for testing.'
+  echo 'On macOS, install it with: brew install curl'
+  exit 1
+fi
+CURL="${CURL:-$CURL_BIN --silent --show-error --fail --compressed}"
 
 function wait_for {
     # Seems the --retry-all-errors option is not available on older curl versions, but maybe in the future we can just use this:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -441,7 +441,7 @@ TEST_OUT_DIR="${TEST_OUT_BASE_DIR}/${TEST_NAME}"
 mkdir -p "$TEST_OUT_DIR"
 
 
-ARG=(--default-srid 900913 --auto-bounds calc --save-config "${TEST_OUT_DIR}/save_config.yaml" tests/fixtures/mbtiles tests/fixtures/pmtiles tests/fixtures/cog "$STATICS_URL/webp2.pmtiles" s3://pmtilestest/cb_2018_us_zcta510_500k.pmtiles --sprite tests/fixtures/sprites/src1 --font tests/fixtures/fonts/overpass-mono-regular.ttf --font tests/fixtures/fonts --style tests/fixtures/styles/maplibre_demo.json --style tests/fixtures/styles/src2 --tilejson-url-version-param version )
+ARG=(--default-srid 900913 --auto-bounds calc --save-config "${TEST_OUT_DIR}/save_config.yaml" tests/fixtures/mbtiles tests/fixtures/pmtiles tests/fixtures/cog "$STATICS_URL/webp2.pmtiles" s3://pmtilestest/cb_2018_us_zcta510_500k.pmtiles --sprite tests/fixtures/sprites/src1 --font tests/fixtures/fonts/overpass-mono-regular.ttf --font tests/fixtures/fonts --style tests/fixtures/styles/maplibre_demo.json --style tests/fixtures/styles/src2 --style tests/fixtures/styles/relative_urls.json --tilejson-url-version-param version )
 export DATABASE_URL="$MARTIN_DATABASE_URL"
 
 set -x
@@ -492,6 +492,15 @@ test_json_with_header tilejson_with_forwarded_proto_and_host function_zxy_query 
 test_json_with_header tilejson_with_x_forwarded_prefix function_zxy_query "X-Forwarded-Prefix: /tiles/function_zxy_query"
 test_json_with_header tilejson_with_x_rewrite_url function_zxy_query "X-Rewrite-URL: /footiles/function_zxy_query"
 
+>&2 echo "***** Test relative URL expansion in style.json *****"
+# Style fixture uses protocol-less URLs (glyphs, sprite, sources.url, sources.tiles);
+# the server rewrites them to absolute URLs in the response using the request's
+# scheme/host and the resolved path prefix.
+test_jsn              relative_style_urls                        style/relative_urls
+test_json_with_header relative_style_urls_with_host              style/relative_urls "Host: example.com"
+test_json_with_header relative_style_urls_with_prefix            style/relative_urls "X-Forwarded-Prefix: /tiles"
+test_json_with_header relative_style_urls_ignores_forwarded_for  style/relative_urls "X-Forwarded-For: forwarded-for.example.com"
+test_json_with_header relative_style_urls_with_forwarded_host    style/relative_urls "X-Forwarded-Host: tiles.example.com"
 
 >&2 echo "***** Test server response for function source *****"
 test_jsn fnc                      function_zxy_query

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -926,12 +926,12 @@ fi
 
 # If we don't do this, rounding differences on CI and local machines are a problem
 echo "::group::redact unnecessary precision in *_config.yaml and *.json"
-for file in $(find ./tests/ -name "*_config.yaml" -type f); do
+for file in $(find ./tests/output/ ./tests/expected/ -name "*_config.yaml" -type f); do
     echo "truncating floats in $file"
     "$SED" --regexp-extended --in-place 's/(-?[0-9]+\.[0-9]{10})[0-9]+$/\1 # truncated to 10 digits/g' "$file"
     "$SED" --regexp-extended --in-place 's/0+ # truncated/ # truncated/g' "$file"
 done
-for file in $(find ./tests/ -name "*.json" -type f); do
+for file in $(find ./tests/output/ ./tests/expected/ -name "*.json" -type f); do
     echo "truncating floats in $file"
     cat "$file" | cleanup_json_floats 10000000000 > "$file.tmp"
 


### PR DESCRIPTION
Addresses https://github.com/maplibre/martin/discussions/1870

This is working great for my use case: blue/green deployments, promoting with DNS.

Note, I don't personally use the base_path or route_prefix options. So please apply extra scrutiny to that code. I'm not entirely sure I understand the difference.