### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.4"
-martin-core = { path = "./martin-core", version = "0.5.4", default-features = false }
+martin-core = { path = "./martin-core", version = "0.6.0", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.2" }
-mbtiles = { path = "./mbtiles", version = "0.17.4" }
+mbtiles = { path = "./mbtiles", version = "0.17.5" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.9.1", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.9.1
+    image: ghcr.io/maplibre/martin:1.10.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.9.1 \
+           ghcr.io/maplibre/martin:1.10.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.9.1
+    image: ghcr.io/maplibre/martin:1.10.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.9.1
+  ghcr.io/maplibre/martin:1.10.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.9.1 \
+  ghcr.io/maplibre/martin:1.10.0 \
   /files
 ```
 
@@ -42,7 +42,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.9.1
+  ghcr.io/maplibre/martin:1.10.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -53,7 +53,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.9.1
+  ghcr.io/maplibre/martin:1.10.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -64,5 +64,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.9.1
+  ghcr.io/maplibre/martin:1.10.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.9.1 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.10.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.9.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.10.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -323,7 +323,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.9.1 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.10.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/maplibre/martin/compare/martin-core-v0.5.4...martin-core-v0.6.0) - 2026-05-16
+
+### Added
+
+- add if rendering is active to the catalog ([#2795](https://github.com/maplibre/martin/pull/2795))
+- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))
+
+### Fixed
+
+- *(sprites)* warn early and explain `.svg`-only requirement ([#2793](https://github.com/maplibre/martin/pull/2793))
+
+### Other
+
+- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
+- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
+- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
+
 ## [0.5.4](https://github.com/maplibre/martin/compare/martin-core-v0.5.3...martin-core-v0.5.4) - 2026-05-06
 
 ### Structured tracing fields

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -13,16 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add if rendering is active to the catalog ([#2795](https://github.com/maplibre/martin/pull/2795))
 - Expand relative URLs in style response ([#2801](https://github.com/maplibre/martin/pull/2801))
-- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))
-
-### Fixed
-
-- tests fail when terminal is not exactly 80 columns ([#2803](https://github.com/maplibre/martin/pull/2803))
 - *(sprites)* warn early and explain `.svg`-only requirement ([#2793](https://github.com/maplibre/martin/pull/2793))
 
 ### Other
 
-- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
+- tests fail when terminal is not exactly 80 columns ([#2803](https://github.com/maplibre/martin/pull/2803))
+- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))
+- make sure that unused variables are handled for MLT configration ([#2808](https://github.com/maplibre/martin/pull/2808))
 - various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
 - fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
 - *(deps)* autoupdate pre-commit ([#2799](https://github.com/maplibre/martin/pull/2799))

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/maplibre/martin/compare/martin-v1.9.1...martin-v1.10.0) - 2026-05-16
+
+### Added
+
+- add if rendering is active to the catalog ([#2795](https://github.com/maplibre/martin/pull/2795))
+- Expand relative URLs in style response ([#2801](https://github.com/maplibre/martin/pull/2801))
+- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))
+
+### Fixed
+
+- tests fail when terminal is not exactly 80 columns ([#2803](https://github.com/maplibre/martin/pull/2803))
+- *(sprites)* warn early and explain `.svg`-only requirement ([#2793](https://github.com/maplibre/martin/pull/2793))
+
+### Other
+
+- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
+- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
+- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
+- *(deps)* autoupdate pre-commit ([#2799](https://github.com/maplibre/martin/pull/2799))
+
 ## [1.9.1](https://github.com/maplibre/martin/compare/martin-v1.9.0...martin-v1.9.1) - 2026-05-09
 
 ### Other

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.9.1"
+version = "1.10.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -70,5 +70,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.9.1"
+  "version": "1.10.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.5](https://github.com/maplibre/martin/compare/mbtiles-v0.17.4...mbtiles-v0.17.5) - 2026-05-16
+
+### Other
+
+- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
+- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
+- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
+
 ## [0.17.4](https://github.com/maplibre/martin/compare/mbtiles-v0.17.3...mbtiles-v0.17.4) - 2026-05-06
 
 ### Structured tracing fields

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.4"
+version = "0.17.5"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -211,7 +211,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.9.1"
+    "version": "1.10.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.17.4 -> 0.17.5 (✓ API compatible changes)
* `martin-core`: 0.5.4 -> 0.6.0 (⚠ API breaking changes)
* `martin`: 1.9.1 -> 1.10.0

### ⚠ `martin-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CatalogStyleEntry.kind in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/styles/mod.rs:65
  field CatalogStyleEntry.version_hash in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/styles/mod.rs:67
  field CatalogStyleEntry.layer_count in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/styles/mod.rs:69
  field CatalogStyleEntry.colors in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/styles/mod.rs:71
  field CatalogStyleEntry.last_modified_at in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/styles/mod.rs:73
  field CatalogSourceEntry.layer_count in /tmp/.tmpMZ6e3o/martin/martin-core/src/tiles/catalog.rs:55
  field CatalogSourceEntry.last_modified_at in /tmp/.tmpMZ6e3o/martin/martin-core/src/tiles/catalog.rs:57
  field CatalogFontEntry.format in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/fonts/mod.rs:136
  field CatalogFontEntry.last_modified_at in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/fonts/mod.rs:138
  field CatalogSpriteEntry.size_in_bytes in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/sprites/mod.rs:58
  field CatalogSpriteEntry.last_modified_at in /tmp/.tmpMZ6e3o/martin/martin-core/src/resources/sprites/mod.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.17.5](https://github.com/maplibre/martin/compare/mbtiles-v0.17.4...mbtiles-v0.17.5) - 2026-05-16

### Other

- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
</blockquote>

## `martin-core`

<blockquote>

## [0.6.0](https://github.com/maplibre/martin/compare/martin-core-v0.5.4...martin-core-v0.6.0) - 2026-05-16

### Added

- add if rendering is active to the catalog ([#2795](https://github.com/maplibre/martin/pull/2795))
- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))

### Fixed

- *(sprites)* warn early and explain `.svg`-only requirement ([#2793](https://github.com/maplibre/martin/pull/2793))

### Other

- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
</blockquote>

## `martin`

<blockquote>

## [1.10.0](https://github.com/maplibre/martin/compare/martin-v1.9.1...martin-v1.10.0) - 2026-05-16

### Added

- add if rendering is active to the catalog ([#2795](https://github.com/maplibre/martin/pull/2795))
- Expand relative URLs in style response ([#2801](https://github.com/maplibre/martin/pull/2801))
- *(ui)* generate `types.gen.ts` from OpenAPI and adopt openapi-fetch ([#2797](https://github.com/maplibre/martin/pull/2797))

### Fixed

- tests fail when terminal is not exactly 80 columns ([#2803](https://github.com/maplibre/martin/pull/2803))
- *(sprites)* warn early and explain `.svg`-only requirement ([#2793](https://github.com/maplibre/martin/pull/2793))

### Other

- apply more restrictions to our code and make sure that unused variables are handled for MLT ([#2808](https://github.com/maplibre/martin/pull/2808))
- various minor docs improvements ([#2807](https://github.com/maplibre/martin/pull/2807))
- fix all m-dashes to use regular dashes ([#2805](https://github.com/maplibre/martin/pull/2805))
- *(deps)* autoupdate pre-commit ([#2799](https://github.com/maplibre/martin/pull/2799))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).