### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "approx",
  "brotli 8.0.2",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.4.4"
-martin-core = { path = "./martin-core", version = "0.6.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.2" }
-mbtiles = { path = "./mbtiles", version = "0.17.5" }
+martin-core = { path = "./martin-core", version = "0.7.0", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.3" }
+mbtiles = { path = "./mbtiles", version = "0.17.6" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.9.1", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.10.0
+    image: ghcr.io/maplibre/martin:1.10.1
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.10.0 \
+           ghcr.io/maplibre/martin:1.10.1 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.10.0
+    image: ghcr.io/maplibre/martin:1.10.1
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.10.0
+  ghcr.io/maplibre/martin:1.10.1
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.10.0 \
+  ghcr.io/maplibre/martin:1.10.1 \
   /files
 ```
 
@@ -42,7 +42,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.10.0
+  ghcr.io/maplibre/martin:1.10.1
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -53,7 +53,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.10.0
+  ghcr.io/maplibre/martin:1.10.1
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -64,5 +64,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.10.0
+  ghcr.io/maplibre/martin:1.10.1
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.10.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.10.1 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.10.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.10.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -323,7 +323,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.10.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.10.1 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/maplibre/martin/compare/martin-core-v0.6.0...martin-core-v0.7.0) - 2026-05-19
+
+### Other
+
+- share code accross the resource caches ([#2810](https://github.com/maplibre/martin/pull/2810))
+
 ## [0.6.0](https://github.com/maplibre/martin/compare/martin-core-v0.5.4...martin-core-v0.6.0) - 2026-05-16
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1](https://github.com/maplibre/martin/compare/martin-v1.10.0...martin-v1.10.1) - 2026-05-19
+
+### Fixed
+
+- Do not use heavyweight compression with MLT ([#2813](https://github.com/maplibre/martin/pull/2813))
+
+### Other
+
+- share code accross the resource caches ([#2810](https://github.com/maplibre/martin/pull/2810))
+
 ## [1.10.0](https://github.com/maplibre/martin/compare/martin-v1.9.1...martin-v1.10.0) - 2026-05-16
 
 ### Added

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.10.0"
+version = "1.10.1"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -70,5 +70,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.10.0"
+  "version": "1.10.1"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.6](https://github.com/maplibre/martin/compare/mbtiles-v0.17.5...mbtiles-v0.17.6) - 2026-05-19
+
+### Fixed
+
+- Do not use heavyweight compression with MLT ([#2813](https://github.com/maplibre/martin/pull/2813))
+
 ## [0.17.5](https://github.com/maplibre/martin/compare/mbtiles-v0.17.4...mbtiles-v0.17.5) - 2026-05-16
 
 ### Other

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level MbTiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -211,7 +211,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.10.0"
+    "version": "1.10.1"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `mbtiles`: 0.17.5 -> 0.17.6 (✓ API compatible changes)
* `martin-core`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `martin`: 1.10.0 -> 1.10.1

### ⚠ `martin-core` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct martin_core::tiles::TileCache, previously in file /tmp/.tmpUJLmbU/martin-core/src/tiles/cache.rs:14
  struct martin_core::sprites::SpriteCache, previously in file /tmp/.tmpUJLmbU/martin-core/src/resources/sprites/cache.rs:13
  struct martin_core::fonts::FontCache, previously in file /tmp/.tmpUJLmbU/martin-core/src/resources/fonts/cache.rs:18
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.17.6](https://github.com/maplibre/martin/compare/mbtiles-v0.17.5...mbtiles-v0.17.6) - 2026-05-19

### Fixed

- Do not use heavyweight compression with MLT ([#2813](https://github.com/maplibre/martin/pull/2813))
</blockquote>

## `martin-core`

<blockquote>

## [0.7.0](https://github.com/maplibre/martin/compare/martin-core-v0.6.0...martin-core-v0.7.0) - 2026-05-19

### Other

- share code accross the resource caches ([#2810](https://github.com/maplibre/martin/pull/2810))
</blockquote>

## `martin`

<blockquote>

## [1.10.1](https://github.com/maplibre/martin/compare/martin-v1.10.0...martin-v1.10.1) - 2026-05-19

### Fixed

- Do not use heavyweight compression with MLT ([#2813](https://github.com/maplibre/martin/pull/2813))

### Other

- share code accross the resource caches ([#2810](https://github.com/maplibre/martin/pull/2810))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).