### PR TITLE
fix: Do not use heavyweight compression with MLT

### DIFF
--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -263,8 +263,7 @@ impl TileInfo {
         if let Some(raster_format) = Self::detect_raster_formats(value) {
             Self::new(raster_format, Encoding::Internal)
         } else {
-            let inner_format = Self::detect_vectorish_format(value);
-            Self::new(inner_format, Encoding::Uncompressed)
+            Self::detect_vectorish_format(value).into()
         }
     }
 
@@ -542,6 +541,15 @@ mod tests {
 
         let result = TileInfo::detect(&compressed);
         assert_eq!(result, TileInfo::new(Format::Json, Encoding::Zlib));
+    }
+
+    #[test]
+    fn test_raw_mlt_encoding_internal() {
+        // MLT has internal compression, so raw MLT bytes should be Encoding::Internal
+        // to prevent the serve path from applying heavyweight gzip/brotli on top.
+        let mlt_data = &[0x02, 0x01];
+        let result = TileInfo::detect(mlt_data);
+        assert_eq!(result, TileInfo::new(Format::Mlt, Encoding::Internal));
     }
 
     #[test]

--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -161,7 +161,7 @@ mod tests {
         let result =
             apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
         assert_eq!(result.info.format, Format::Mlt);
-        assert_eq!(result.info.encoding, Encoding::Uncompressed);
+        assert_eq!(result.info.encoding, Encoding::Internal);
     }
 
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
@@ -199,7 +199,7 @@ mod tests {
         let result =
             apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
         assert_eq!(result.info.format, Format::Mlt);
-        assert_eq!(result.info.encoding, Encoding::Uncompressed);
+        assert_eq!(result.info.encoding, Encoding::Internal);
     }
 
     /// An MVT tile with one point feature - needed for meaningful round-trip tests

--- a/martin/src/srv/tiles/process/to_mlt.rs
+++ b/martin/src/srv/tiles/process/to_mlt.rs
@@ -28,6 +28,6 @@ pub fn convert_mvt_to_mlt(tile: Tile, cfg: EncoderConfig) -> Result<Tile, Proces
 
     Ok(Tile::new_hash_etag(
         mlt_bytes,
-        TileInfo::new(Format::Mlt, Encoding::Uncompressed),
+        TileInfo::new(Format::Mlt, Encoding::Internal),
     ))
 }

--- a/martin/src/srv/tiles/process/to_mvt.rs
+++ b/martin/src/srv/tiles/process/to_mvt.rs
@@ -81,10 +81,7 @@ mod tests {
 
     use super::*;
 
-    /// MLT->MVT round-trip: encode the test MVT to MLT, then back, and verify
-    /// layer/feature structure is preserved.
-    #[test]
-    fn round_trips_through_mlt() {
+    fn build_mlt_bytes() -> Vec<u8> {
         let mvt = mvt_with_feature_bytes();
         let layers = mvt_to_tile_layers(mvt).expect("decode MVT");
 
@@ -92,11 +89,16 @@ mod tests {
         for layer in layers {
             mlt_bytes.extend(layer.encode(EncoderConfig::default()).expect("encode MLT"));
         }
+        mlt_bytes
+    }
 
-        let tile = Tile::new_hash_etag(
-            mlt_bytes,
-            TileInfo::new(Format::Mlt, Encoding::Uncompressed),
-        );
+    /// MLT->MVT round-trip: encode the test MVT to MLT, then back, and verify
+    /// layer/feature structure is preserved.
+    #[test]
+    fn round_trips_through_mlt() {
+        let mlt_bytes = build_mlt_bytes();
+
+        let tile = Tile::new_hash_etag(mlt_bytes, TileInfo::new(Format::Mlt, Encoding::Internal));
         let result = convert_mlt_to_mvt(tile).expect("MLT->MVT");
         assert_eq!(result.info.format, Format::Mvt);
 
@@ -104,5 +106,19 @@ mod tests {
         assert_eq!(layers.len(), 1);
         assert_eq!(layers[0].name, "test");
         assert_eq!(layers[0].features.len(), 1);
+    }
+
+    /// Gzip-compressed MLT is not typically recommended, but it is valid and can be decoded.
+    #[test]
+    fn gzip_compressed_mlt_is_decodable() {
+        use martin_tile_utils::encode_gzip;
+        let mlt_bytes = build_mlt_bytes();
+        let gzipped = encode_gzip(&mlt_bytes).expect("gzip MLT");
+
+        let tile = Tile::new_hash_etag(gzipped, TileInfo::new(Format::Mlt, Encoding::Gzip));
+        let result = convert_mlt_to_mvt(tile).expect("MLT->MVT");
+        assert_eq!(result.info.format, Format::Mvt);
+        let layers = mvt_to_tile_layers(result.data).expect("decode MVT");
+        assert_eq!(layers.len(), 1);
     }
 }

--- a/mbtiles/src/metadata.rs
+++ b/mbtiles/src/metadata.rs
@@ -557,7 +557,7 @@ mod tests {
         let tile_info = mbt.detect_format(&meta.tilejson, &mut conn).await.unwrap();
         assert_eq!(
             tile_info,
-            Some(TileInfo::new(Format::Mlt, Encoding::Uncompressed))
+            Some(TileInfo::new(Format::Mlt, Encoding::Internal))
         );
     }
 

--- a/tests/expected/process/proc_mlt_table_source.mlt.headers
+++ b/tests/expected/process/proc_mlt_table_source.mlt.headers
@@ -1,5 +1,4 @@
-content-encoding: gzip
-content-length: 693
+content-length: 935
 content-type: application/vnd.maplibre-tile
 etag: "1SPbA7I_hVBzOtpy0gXHAQ"
 vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers


### PR DESCRIPTION
I'm still pretty new to MLT, so I might be off base. Let me know!

Currently, converting to MLT returns a tile compressed with a heavy weight compression like gzip.

My understanding is that MLT intentionally uses lightweight compression. By using a heavyweight compression on top of that, we most likely lose any benefit to these schemes.