### PR TITLE
fix: ignore ignored directory for sprite resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,6 +4137,7 @@ dependencies = [
  "tracing",
  "url",
  "utoipa",
+ "walkdir",
  "xxhash-rust",
 ]
 

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -43,6 +43,7 @@ fonts = [
     "dep:regex",
     "dep:itertools",
     "dep:dashmap",
+    "dep:walkdir",
 ]
 sprites = [
     "dep:actix-web",
@@ -51,8 +52,9 @@ sprites = [
     "tokio/fs",
     "dep:futures",
     "dep:dashmap",
+    "dep:walkdir",
 ]
-styles = ["tokio/fs", "dep:dashmap"]
+styles = ["tokio/fs", "dep:dashmap", "dep:walkdir"]
 mbtiles = ["dep:backon", "dep:mbtiles", "dep:tokio", "_tiles"]
 pmtiles = ["dep:pmtiles", "dep:object_store", "_tiles"]
 _tiles = ["dep:base64"]
@@ -103,6 +105,7 @@ tokio = { workspace = true, optional = true }
 tokio-postgres-rustls = { workspace = true, optional = true }
 tracing.workspace = true
 utoipa = { workspace = true, optional = true }
+walkdir = { workspace = true, optional = true }
 xxhash-rust.workspace = true
 
 [dev-dependencies]

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -268,11 +268,11 @@ pub struct FontSource {
     catalog_entry: CatalogFontEntry,
 }
 
-/// Discovers fonts at `path` (a directory walked recursively, or a single
-/// font file) and registers them in `fonts`.
+/// Discovers fonts at `path` and registers them in `fonts`.
 ///
-/// Hidden files and directories are skipped — see [`crate::resources::walk_files`]
-/// for the rationale around Kubernetes `ConfigMap` symlink trees.
+/// If `path` is
+/// - a directory, we walked recursively, or
+/// - if it is a single font file we register this
 #[instrument(skip(lib, fonts), fields(path = ?path), err(Debug))]
 fn discover_fonts(
     lib: &Library,

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -32,6 +32,10 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, instrument, warn};
 
+use crate::walk_files;
+
+const FONT_EXTENSIONS: &[&str] = &["otf", "ttf", "ttc"];
+
 /// Maximum Unicode codepoint supported.
 ///
 /// Although U+FFFF covers the Basic Multilingual Plane, the Unicode standard
@@ -149,7 +153,7 @@ impl FontSources {
     /// Discovers and loads fonts from the specified directory by recursively scanning for `.ttf`, `.otf`, and `.ttc` files.
     pub fn recursively_add_directory(&mut self, path: PathBuf) -> Result<(), FontError> {
         let lib = Library::init()?;
-        recurse_dirs(&lib, path, &mut self.fonts, true)
+        discover_fonts(&lib, path, &mut self.fonts)
     }
 
     /// Returns a catalog of all loaded fonts
@@ -264,40 +268,37 @@ pub struct FontSource {
     catalog_entry: CatalogFontEntry,
 }
 
-/// Recursively discovers fonts in directories and individual files.
-/// Supports `.ttf`, `.otf`, and `.ttc` files.
-#[instrument(skip(lib, fonts), fields(path = ?path, is_top_level), err(Debug))]
-fn recurse_dirs(
+/// Discovers fonts at `path` (a directory walked recursively, or a single
+/// font file) and registers them in `fonts`.
+///
+/// Hidden files and directories are skipped — see [`crate::resources::walk_files`]
+/// for the rationale around Kubernetes `ConfigMap` symlink trees.
+#[instrument(skip(lib, fonts), fields(path = ?path), err(Debug))]
+fn discover_fonts(
     lib: &Library,
     path: PathBuf,
     fonts: &mut DashMap<String, FontSource>,
-    is_top_level: bool,
 ) -> Result<(), FontError> {
-    let start_count = fonts.len();
-    if path.is_dir() {
-        for dir_entry in path
-            .read_dir()
-            .map_err(|e| FontError::IoError(e, path.clone()))?
-            .flatten()
-        {
-            recurse_dirs(lib, dir_entry.path(), fonts, false)?;
-        }
-        if is_top_level && fonts.len() == start_count {
-            return Err(FontError::NoFontFilesFound(path));
-        }
-    } else {
-        if path
+    if path.is_file() {
+        if !path
             .extension()
             .and_then(OsStr::to_str)
-            .is_some_and(|e| ["otf", "ttf", "ttc"].contains(&e))
+            .is_some_and(|e| FONT_EXTENSIONS.contains(&e))
         {
-            parse_font(lib, fonts, path.clone())?;
-        }
-        if is_top_level && fonts.len() == start_count {
             return Err(FontError::InvalidFontFilePath(path));
         }
+        return parse_font(lib, fonts, path);
     }
 
+    let start_count = fonts.len();
+    let font_files = walk_files(&path, FONT_EXTENSIONS)
+        .map_err(|e| FontError::IoError(e.into(), path.clone()))?;
+    for font_path in font_files {
+        parse_font(lib, fonts, font_path)?;
+    }
+    if fonts.len() == start_count {
+        return Err(FontError::NoFontFilesFound(path));
+    }
     Ok(())
 }
 
@@ -399,6 +400,36 @@ fn parse_font(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression for <https://github.com/maplibre/martin/issues/1343>: same
+    /// k8s `ConfigMap` symlink layout that bit sprites would also have
+    /// triple-counted font files; the dedup on font name in `parse_font`
+    /// masked the symptom, but the wasted work and warning spam are real.
+    #[cfg(unix)]
+    #[test]
+    fn k8s_configmap_symlinks_do_not_warn_about_duplicates() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let real_dir = root.join("..2024_05_17_17_57_51.390489675");
+        std::fs::create_dir(&real_dir).unwrap();
+        let font_src =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/fixtures/fonts2/u+3320.ttf");
+        std::fs::copy(&font_src, real_dir.join("u3320.ttf")).unwrap();
+        symlink("..2024_05_17_17_57_51.390489675", root.join("..data")).unwrap();
+        symlink("..data/u3320.ttf", root.join("u3320.ttf")).unwrap();
+
+        let mut sources = FontSources::default();
+        sources
+            .recursively_add_directory(root.to_path_buf())
+            .unwrap();
+        assert_eq!(
+            sources.get_catalog().len(),
+            1,
+            "expected exactly one font, not duplicates from the ..data/..timestamped tree"
+        );
+    }
 
     #[test]
     fn test_get_available_codepoints() {

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -401,10 +401,6 @@ fn parse_font(
 mod tests {
     use super::*;
 
-    /// Regression for <https://github.com/maplibre/martin/issues/1343>: same
-    /// k8s `ConfigMap` symlink layout that bit sprites would also have
-    /// triple-counted font files; the dedup on font name in `parse_font`
-    /// masked the symptom, but the wasted work and warning spam are real.
     #[cfg(unix)]
     #[test]
     fn k8s_configmap_symlinks_do_not_warn_about_duplicates() {

--- a/martin-core/src/resources/mod.rs
+++ b/martin-core/src/resources/mod.rs
@@ -13,3 +13,8 @@ pub mod sprites;
 
 #[cfg(feature = "styles")]
 pub mod styles;
+
+#[cfg(any(feature = "fonts", feature = "sprites", feature = "styles"))]
+mod walk;
+#[cfg(any(feature = "fonts", feature = "sprites", feature = "styles"))]
+pub use walk::walk_files;

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -33,6 +33,13 @@ use tokio::io::AsyncReadExt as _;
 use tracing::{info, instrument, warn};
 
 use self::SpriteError::{IoError, SpriteInstError, SpriteParsingError, SpriteProcessingError};
+use crate::walk_files;
+
+const SVG_EXTENSIONS: &[&str] = &["svg"];
+
+fn discover_svgs(path: &Path) -> Result<Vec<PathBuf>, SpriteError> {
+    walk_files(path, SVG_EXTENSIONS).map_err(|e| IoError(e.into(), path.to_path_buf()))
+}
 
 mod error;
 pub use error::SpriteError;
@@ -73,7 +80,7 @@ impl SpriteSources {
         // TODO: all sprite generation should be pre-cached
         let mut entries = SpriteCatalog::new();
         for source in &self.0 {
-            let paths = collect_svg_paths(&source.path)?;
+            let paths = discover_svgs(&source.path)?;
             let mut images = Vec::with_capacity(paths.len());
             for path in paths {
                 images.push(
@@ -122,7 +129,7 @@ impl SpriteSources {
                         sprite.path = %disp_path,
                         "Configured sprite source"
                     );
-                    if let Ok(paths) = collect_svg_paths(&path)
+                    if let Ok(paths) = discover_svgs(&path)
                         && paths.is_empty()
                     {
                         warn!(
@@ -177,36 +184,6 @@ pub struct SpriteSource {
     path: PathBuf,
 }
 
-/// Recursively collects `.svg` files under `dir`, ignoring entries whose name
-/// starts with `.`.
-///
-/// Unlike [`spreet::get_svg_input_paths`], this also skips dotfile-prefixed
-/// **directories**, which matters for Kubernetes `ConfigMap` mounts: a mount
-/// exposes the real files inside a `..2024_…` directory plus a `..data`
-/// symlink, alongside per-file symlinks at the mount root. Recursing into the
-/// bookkeeping directories would surface each file three times with garbled
-/// names — see <https://github.com/maplibre/martin/issues/1343>.
-fn collect_svg_paths(dir: &Path) -> Result<Vec<PathBuf>, SpriteError> {
-    let mut out = Vec::new();
-    let mut stack = vec![dir.to_path_buf()];
-    while let Some(current) = stack.pop() {
-        let read = std::fs::read_dir(&current).map_err(|e| IoError(e, current.clone()))?;
-        for entry in read {
-            let entry = entry.map_err(|e| IoError(e, current.clone()))?;
-            if entry.file_name().to_string_lossy().starts_with('.') {
-                continue;
-            }
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-            } else if path.is_file() && path.extension().is_some_and(|e| e == "svg") {
-                out.push(path);
-            }
-        }
-    }
-    Ok(out)
-}
-
 /// Parses SVG file into sprite.
 async fn parse_sprite(
     name: String,
@@ -249,7 +226,7 @@ pub async fn get_spritesheet(
     // Asynchronously load all SVG files from the given sources
     let mut futures = Vec::new();
     for source in sources {
-        let paths = collect_svg_paths(&source.path)?;
+        let paths = discover_svgs(&source.path)?;
         // SpritesheetBuilder::generate will return None if the folder does not contain any SVGs
         if paths.is_empty() {
             return Err(SpriteError::NoSpriteFilesFound(source.path.clone()));

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -289,8 +289,6 @@ mod tests {
         }
     }
 
-    /// Regression for <https://github.com/maplibre/martin/issues/1343> — see
-    /// [`collect_svg_paths`] docs for the k8s `ConfigMap` symlink layout.
     #[cfg(unix)]
     #[test]
     fn k8s_configmap_symlinks_yield_clean_sprite_names() {

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use dashmap::{DashMap, Entry};
@@ -28,11 +28,11 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 pub use spreet::Spritesheet;
 use spreet::resvg::usvg::{Options, Tree};
-use spreet::{Sprite, SpritesheetBuilder, get_svg_input_paths, sprite_name};
+use spreet::{Sprite, SpritesheetBuilder, sprite_name};
 use tokio::io::AsyncReadExt as _;
 use tracing::{info, instrument, warn};
 
-use self::SpriteError::{SpriteInstError, SpriteParsingError, SpriteProcessingError};
+use self::SpriteError::{IoError, SpriteInstError, SpriteParsingError, SpriteProcessingError};
 
 mod error;
 pub use error::SpriteError;
@@ -73,8 +73,7 @@ impl SpriteSources {
         // TODO: all sprite generation should be pre-cached
         let mut entries = SpriteCatalog::new();
         for source in &self.0 {
-            let paths = get_svg_input_paths(&source.path, true)
-                .map_err(|e| SpriteProcessingError(e, source.path.clone()))?;
+            let paths = collect_svg_paths(&source.path)?;
             let mut images = Vec::with_capacity(paths.len());
             for path in paths {
                 images.push(
@@ -123,7 +122,7 @@ impl SpriteSources {
                         sprite.path = %disp_path,
                         "Configured sprite source"
                     );
-                    if let Ok(paths) = get_svg_input_paths(&path, true)
+                    if let Ok(paths) = collect_svg_paths(&path)
                         && paths.is_empty()
                     {
                         warn!(
@@ -178,6 +177,36 @@ pub struct SpriteSource {
     path: PathBuf,
 }
 
+/// Recursively collects `.svg` files under `dir`, ignoring entries whose name
+/// starts with `.`.
+///
+/// Unlike [`spreet::get_svg_input_paths`], this also skips dotfile-prefixed
+/// **directories**, which matters for Kubernetes `ConfigMap` mounts: a mount
+/// exposes the real files inside a `..2024_…` directory plus a `..data`
+/// symlink, alongside per-file symlinks at the mount root. Recursing into the
+/// bookkeeping directories would surface each file three times with garbled
+/// names — see <https://github.com/maplibre/martin/issues/1343>.
+fn collect_svg_paths(dir: &Path) -> Result<Vec<PathBuf>, SpriteError> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let read = std::fs::read_dir(&current).map_err(|e| IoError(e, current.clone()))?;
+        for entry in read {
+            let entry = entry.map_err(|e| IoError(e, current.clone()))?;
+            if entry.file_name().to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.is_file() && path.extension().is_some_and(|e| e == "svg") {
+                out.push(path);
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Parses SVG file into sprite.
 async fn parse_sprite(
     name: String,
@@ -185,7 +214,7 @@ async fn parse_sprite(
     pixel_ratio: u8,
     as_sdf: bool,
 ) -> Result<(String, Sprite), SpriteError> {
-    let on_err = |e| SpriteError::IoError(e, path.clone());
+    let on_err = |e| IoError(e, path.clone());
 
     let mut file = tokio::fs::File::open(&path).await.map_err(on_err)?;
 
@@ -220,8 +249,7 @@ pub async fn get_spritesheet(
     // Asynchronously load all SVG files from the given sources
     let mut futures = Vec::new();
     for source in sources {
-        let paths = get_svg_input_paths(&source.path, true)
-            .map_err(|e| SpriteProcessingError(e, source.path.clone()))?;
+        let paths = collect_svg_paths(&source.path)?;
         // SpritesheetBuilder::generate will return None if the folder does not contain any SVGs
         if paths.is_empty() {
             return Err(SpriteError::NoSpriteFilesFound(source.path.clone()));
@@ -282,6 +310,37 @@ mod tests {
             test_src(src2_path.iter(), 1, "src2_1", generate_sdf).await;
             test_src(src2_path.iter(), 2, "src2_2", generate_sdf).await;
         }
+    }
+
+    /// Regression for <https://github.com/maplibre/martin/issues/1343> — see
+    /// [`collect_svg_paths`] docs for the k8s `ConfigMap` symlink layout.
+    #[cfg(unix)]
+    #[test]
+    fn k8s_configmap_symlinks_yield_clean_sprite_names() {
+        use std::fs::{create_dir, write};
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let real_dir = root.join("..2024_05_17_17_57_51.390489675");
+        create_dir(&real_dir).unwrap();
+        let svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>";
+        write(real_dir.join("foo.svg"), svg).unwrap();
+        write(real_dir.join("bar.svg"), svg).unwrap();
+        symlink("..2024_05_17_17_57_51.390489675", root.join("..data")).unwrap();
+        symlink("..data/foo.svg", root.join("foo.svg")).unwrap();
+        symlink("..data/bar.svg", root.join("bar.svg")).unwrap();
+
+        let mut sprites = SpriteSources::default();
+        sprites.add_source("foobar".to_string(), root.to_path_buf());
+
+        let catalog = sprites.get_catalog().expect("catalog");
+        let entry = catalog.get("foobar").expect("foobar source registered");
+        assert_eq!(
+            entry.images,
+            vec!["bar".to_string(), "foo".to_string()],
+            "expected plain sprite names without dotfile directory prefixes"
+        );
     }
 
     #[tokio::test]

--- a/martin-core/src/resources/walk.rs
+++ b/martin-core/src/resources/walk.rs
@@ -5,16 +5,7 @@ use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
 /// Recursively collects files under `dir` whose extension matches one of
-/// `extensions` (case-sensitive, no leading dot), ignoring entries whose name
-/// starts with `.`.
-///
-/// Hidden **directories** are skipped — not just hidden files. This matters
-/// for Kubernetes `ConfigMap` and `Secret` volumes, which expose data through
-/// a layered symlink tree: the real files live in a `..2024_…` directory,
-/// `..data` is a symlink to that directory, and each entry at the mount root
-/// is a symlink to `..data/<file>`. Recursing into the bookkeeping
-/// directories would surface each file three times — see
-/// <https://github.com/maplibre/martin/issues/1343>.
+/// `extensions` (case-sensitive, no leading dot)
 ///
 /// Symlinks are followed so the per-file symlinks at the mount root resolve
 /// to their real targets.
@@ -22,6 +13,10 @@ pub fn walk_files(dir: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>, walkd
     WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
+    // k8s config maps use a layered symlink tree:
+    // real files live in a `.2024_...` directory, `.data` is a symlink to that directory,
+    // and each entry at the mount root is a symlink to `.data/<file>`.
+    // Recursing into the bookkeeping dir would surface each file 3x
         .filter_entry(|e| e.depth() == 0 || !is_hidden(e))
         .filter_map(|entry| match entry {
             Ok(e) if has_matching_extension(e.path(), extensions) && e.file_type().is_file() => {
@@ -50,9 +45,6 @@ fn has_matching_extension(path: &Path, extensions: &[&str]) -> bool {
 mod tests {
     use super::*;
 
-    /// Regression for <https://github.com/maplibre/martin/issues/1343>:
-    /// k8s `ConfigMap` volumes layer symlinks (`..data` → `..2024_…/`) over
-    /// the actual files; recursing into the dotfile dirs would triple-count.
     #[cfg(unix)]
     #[test]
     fn k8s_configmap_symlinks_yield_each_file_once() {

--- a/martin-core/src/resources/walk.rs
+++ b/martin-core/src/resources/walk.rs
@@ -1,0 +1,105 @@
+//! Recursively walk a directory tree for resource discovery.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::{DirEntry, WalkDir};
+
+/// Recursively collects files under `dir` whose extension matches one of
+/// `extensions` (case-sensitive, no leading dot), ignoring entries whose name
+/// starts with `.`.
+///
+/// Hidden **directories** are skipped — not just hidden files. This matters
+/// for Kubernetes `ConfigMap` and `Secret` volumes, which expose data through
+/// a layered symlink tree: the real files live in a `..2024_…` directory,
+/// `..data` is a symlink to that directory, and each entry at the mount root
+/// is a symlink to `..data/<file>`. Recursing into the bookkeeping
+/// directories would surface each file three times — see
+/// <https://github.com/maplibre/martin/issues/1343>.
+///
+/// Symlinks are followed so the per-file symlinks at the mount root resolve
+/// to their real targets.
+pub fn walk_files(dir: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>, walkdir::Error> {
+    WalkDir::new(dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_entry(|e| e.depth() == 0 || !is_hidden(e))
+        .filter_map(|entry| match entry {
+            Ok(e) if has_matching_extension(e.path(), extensions) && e.file_type().is_file() => {
+                Some(Ok(e.into_path()))
+            }
+            Ok(_) => None,
+            Err(e) => Some(Err(e)),
+        })
+        .collect()
+}
+
+fn is_hidden(entry: &DirEntry) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .is_some_and(|s| s.starts_with('.'))
+}
+
+fn has_matching_extension(path: &Path, extensions: &[&str]) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| extensions.contains(&e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for <https://github.com/maplibre/martin/issues/1343>:
+    /// k8s `ConfigMap` volumes layer symlinks (`..data` → `..2024_…/`) over
+    /// the actual files; recursing into the dotfile dirs would triple-count.
+    #[cfg(unix)]
+    #[test]
+    fn k8s_configmap_symlinks_yield_each_file_once() {
+        use std::fs::{create_dir, write};
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let real_dir = root.join("..2024_05_17_17_57_51.390489675");
+        create_dir(&real_dir).unwrap();
+        write(real_dir.join("foo.svg"), b"<svg/>").unwrap();
+        write(real_dir.join("bar.svg"), b"<svg/>").unwrap();
+        symlink("..2024_05_17_17_57_51.390489675", root.join("..data")).unwrap();
+        symlink("..data/foo.svg", root.join("foo.svg")).unwrap();
+        symlink("..data/bar.svg", root.join("bar.svg")).unwrap();
+
+        let mut files = walk_files(root, &["svg"]).expect("walk_files");
+        files.sort();
+        assert_eq!(
+            files,
+            vec![root.join("bar.svg"), root.join("foo.svg")],
+            "k8s ConfigMap symlinks must not produce duplicates or dotfile-prefixed paths"
+        );
+    }
+
+    #[test]
+    fn extension_filter_is_case_sensitive_and_exact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("a.svg"), b"").unwrap();
+        std::fs::write(root.join("b.SVG"), b"").unwrap();
+        std::fs::write(root.join("c.svgx"), b"").unwrap();
+        std::fs::write(root.join("d.txt"), b"").unwrap();
+
+        let files = walk_files(root, &["svg"]).unwrap();
+        assert_eq!(files, vec![root.join("a.svg")]);
+    }
+
+    #[test]
+    fn recurses_into_visible_subdirectories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let nested = root.join("icons").join("logos");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("foo.svg"), b"").unwrap();
+
+        let files = walk_files(root, &["svg"]).unwrap();
+        assert_eq!(files, vec![nested.join("foo.svg")]);
+    }
+}

--- a/martin-core/src/resources/walk.rs
+++ b/martin-core/src/resources/walk.rs
@@ -13,10 +13,10 @@ pub fn walk_files(dir: &Path, extensions: &[&str]) -> Result<Vec<PathBuf>, walkd
     WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
-    // k8s config maps use a layered symlink tree:
-    // real files live in a `.2024_...` directory, `.data` is a symlink to that directory,
-    // and each entry at the mount root is a symlink to `.data/<file>`.
-    // Recursing into the bookkeeping dir would surface each file 3x
+        // k8s config maps use a layered symlink tree:
+        // real files live in a `.2024_...` directory, `.data` is a symlink to that directory,
+        // and each entry at the mount root is a symlink to `.data/<file>`.
+        // Recursing into the bookkeeping dir would surface each file 3x
         .filter_entry(|e| e.depth() == 0 || !is_hidden(e))
         .filter_map(|entry| match entry {
             Ok(e) if has_matching_extension(e.path(), extensions) && e.file_type().is_file() => {

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 use martin_core::styles::StyleSources;
+use martin_core::walk_files;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -144,54 +145,33 @@ impl StyleConfig {
     }
 }
 
-/// Returns a vector of file paths in a given directory (or file)
+/// Returns matching file paths under `source_path`, rewritten relative to the
+/// current working directory so the catalog displays portable, configurable
+/// paths.
 ///
-/// It ignores hidden files (files whose names begin with `.`) but it does follow symlinks.
-/// Will also return file paths in sub-directories recursively.
+/// Walking semantics (recursion, hidden-file/dir skip, symlink following)
+/// come from [`walk_files`].
 ///
 /// # Errors
 ///
-/// This function will return an error if Rust's underlying [`read_dir`](std::fs::read_dir) returns an error.
+/// Returns an error if directory walking fails.
 fn list_contained_files(
     source_path: &Path,
     filter_extension: &str,
 ) -> Result<Vec<PathBuf>, ConfigFileError> {
+    let files = walk_files(source_path, &[filter_extension])
+        .map_err(|e| ConfigFileError::DirectoryWalking(e, source_path.to_path_buf()))?;
     let working_directory = env::current_dir().ok();
-    let mut contained_files = Vec::new();
-    let it = walkdir::WalkDir::new(source_path)
-        .follow_links(true)
+    Ok(files
         .into_iter()
-        .filter_entry(|e| e.depth() == 0 || !is_hidden(e));
-    for entry in it {
-        let entry =
-            entry.map_err(|e| ConfigFileError::DirectoryWalking(e, source_path.to_path_buf()))?;
-        if entry.path().is_file()
-            && entry
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == filter_extension)
-        {
-            // path should be relative to the working directory in the catalog
-            let relative_path = match working_directory {
-                Some(ref work_dir) => entry
-                    .path()
-                    .strip_prefix(work_dir.as_path())
-                    .unwrap_or_else(|_| entry.path())
-                    .to_owned(),
-                None => entry.into_path(),
-            };
-            contained_files.push(relative_path);
-        }
-    }
-    Ok(contained_files)
-}
-
-/// Returns `true` if `entry`'s file name starts with `.`, `false` otherwise.
-fn is_hidden(entry: &walkdir::DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .is_some_and(|s| s.starts_with('.'))
+        .map(|path| match &working_directory {
+            Some(work_dir) => path
+                .strip_prefix(work_dir)
+                .map(Path::to_path_buf)
+                .unwrap_or(path),
+            None => path,
+        })
+        .collect())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We need to skip dotfile-prefixed **directories**, because Kubernetes `ConfigMap` mounts:
- a mount exposes the real files inside a `..2024_..` dir plus
- a `..data` symlink, alongside per-file symlinks at the mount root.

Recursing into the bookkeeping directories would surface each file three times with garbled names

- Resolves https://github.com/maplibre/martin/issues/1343