### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "approx",
  "brotli 8.0.3",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.17.6"
+version = "0.18.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.8.1"
-martin-core = { path = "./martin-core", version = "0.7.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.3" }
-mbtiles = { path = "./mbtiles", version = "0.17.6" }
+martin-core = { path = "./martin-core", version = "0.8.0", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.4" }
+mbtiles = { path = "./mbtiles", version = "0.18.0" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.9.1", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.10.1
+    image: ghcr.io/maplibre/martin:1.11.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.10.1 \
+           ghcr.io/maplibre/martin:1.11.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.10.1
+    image: ghcr.io/maplibre/martin:1.11.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.10.1
+  ghcr.io/maplibre/martin:1.11.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.10.1 \
+  ghcr.io/maplibre/martin:1.11.0 \
   /files
 ```
 
@@ -42,7 +42,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.10.1
+  ghcr.io/maplibre/martin:1.11.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -53,7 +53,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.10.1
+  ghcr.io/maplibre/martin:1.11.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -64,5 +64,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.10.1
+  ghcr.io/maplibre/martin:1.11.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.10.1 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.11.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.10.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.11.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -387,7 +387,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.10.1 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.11.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
 - duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))
 - static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
+- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
 
 ### Fixed
 
@@ -23,11 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
 - update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
-- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
 - make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
-- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
 - cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
 
 ## [0.7.0](https://github.com/maplibre/martin/compare/martin-core-v0.6.0...martin-core-v0.7.0) - 2026-05-19

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/maplibre/martin/compare/martin-core-v0.7.0...martin-core-v0.8.0) - 2026-06-16
+
+### Added
+
+- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
+- duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))
+- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
+
+### Fixed
+
+- *(unstable-cog)* Allow for 0.1% (up to 3m of error at z0) in COGs from a matching zoom level in WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878))
+- *(martin)* reject invalid scale and inverted bbox in static rendering ([#2830](https://github.com/maplibre/martin/pull/2830))
+- ignore ignored directory for sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815))
+
+### Other
+
+- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
+- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
+- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
+- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
+- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
+- cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
+
 ## [0.7.0](https://github.com/maplibre/martin/compare/martin-core-v0.6.0...martin-core-v0.7.0) - 2026-05-19
 
 ### Other

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0](https://github.com/maplibre/martin/compare/martin-v1.10.1...martin-v1.11.0) - 2026-06-16
+
+### Added
+
+- *(pg)* enable Postgres reloading ([#2841](https://github.com/maplibre/martin/pull/2841))
+- teach ObjectStoreDiscovery to track source data versions ([#2864](https://github.com/maplibre/martin/pull/2864))
+- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
+- Add COGReloader and PMTilesReloader (Tile Reload Phase 2) ([#2750](https://github.com/maplibre/martin/pull/2750))
+- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
+- duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))
+
+### Fixed
+
+- *(martin)* reject invalid scale and inverted bbox in static rendering ([#2830](https://github.com/maplibre/martin/pull/2830))
+- Use ST_EstimatedExtent for quick bounds calc ([#1220](https://github.com/maplibre/martin/pull/1220))
+- ignore ignored directory for sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815))
+- *(unstable-cog)* Allow for 0.1% (up to 3m of error at z0) in COGs from a matching zoom level in WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878))
+
+### Other
+
+- *(deps)* autoupdate pre-commit ([#2896](https://github.com/maplibre/martin/pull/2896))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 19 updates ([#2889](https://github.com/maplibre/martin/pull/2889))
+- add tests for how EXACTLY our config system does parsing (config-4) ([#2872](https://github.com/maplibre/martin/pull/2872))
+- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
+- move pg fingerprinting to u128 ([#2886](https://github.com/maplibre/martin/pull/2886))
+- split Config types into config.rs, making main/mod.rs a pure mod (config-3) ([#2876](https://github.com/maplibre/martin/pull/2876))
+- move parsing to its own module (config-2) ([#2875](https://github.com/maplibre/martin/pull/2875))
+- extract impl Config to lifecycle module (confgi-1) ([#2874](https://github.com/maplibre/martin/pull/2874))
+- pg reloader test to reduce the pg-reloader diff ([#2867](https://github.com/maplibre/martin/pull/2867))
+- rename PmTilesReloader to PmtilesReloader ([#2861](https://github.com/maplibre/martin/pull/2861))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2856](https://github.com/maplibre/martin/pull/2856))
+- migrate Pmtiles to `ReloadDriver` and `Discovery` (pg-reload-7) ([#2840](https://github.com/maplibre/martin/pull/2840))
+- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
+- adopt `ReloadDriver`/`Discovery` for Mbtiles (pg-reload-5) ([#2852](https://github.com/maplibre/martin/pull/2852))
+- move reload-`Trigger`-ing to a separate trait ([#2845](https://github.com/maplibre/martin/pull/2845))
+- *(deps)* autoupdate pre-commit ([#2849](https://github.com/maplibre/martin/pull/2849))
+- extract `Sink` trait for the tile-source manager ([#2844](https://github.com/maplibre/martin/pull/2844))
+- *(pg)* Refactor discovery to enable fingerprinting (PGReloader 2) ([#2835](https://github.com/maplibre/martin/pull/2835))
+- *(pg)* split auto-discovery into discover + instantiate phases (PGReloader 1) ([#2836](https://github.com/maplibre/martin/pull/2836))
+- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
+- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
+- fix import ordering drift ([#2838](https://github.com/maplibre/martin/pull/2838))
+- lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
+- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
+- add a pre-commit to simplify UTF characters ([#2827](https://github.com/maplibre/martin/pull/2827))
+- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
+- cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
+- add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
+- *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
+
 ## [1.10.1](https://github.com/maplibre/martin/compare/martin-v1.10.0...martin-v1.10.1) - 2026-05-19
 
 ### Fixed

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,53 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0](https://github.com/maplibre/martin/compare/martin-v1.10.1...martin-v1.11.0) - 2026-06-16
 
-### Added
+### Live reloading for PostgreSQL, PMTiles and COG sources
 
-- *(pg)* enable Postgres reloading ([#2841](https://github.com/maplibre/martin/pull/2841))
-- teach ObjectStoreDiscovery to track source data versions ([#2864](https://github.com/maplibre/martin/pull/2864))
-- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
-- Add COGReloader and PMTilesReloader (Tile Reload Phase 2) ([#2750](https://github.com/maplibre/martin/pull/2750))
-- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
-- duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))
+Back in `1.8.0` we taught Martin to hot-reload MBTiles directories.
+This release finishes the job: PostgreSQL, PMTiles and COG sources now reload automatically too, so Martin keeps serving fresh data without a restart.
+
+Two reload mechanisms are used, depending on what the source can observe:
+
+- **File system events** - local **PMTiles** and **COG** files reload as soon as the underlying file changes on disk ([#2750](https://github.com/maplibre/martin/pull/2750), [#2858](https://github.com/maplibre/martin/pull/2858)).
+- **Fixed timer (polling)** - **PostgreSQL** and remote **PMTiles** (object stores) can't watch the file system, so Martin polls them on a timer (configurable, default 10m) and reloads when it detects a change. PostgreSQL picks up new and changed tables/functions as they appear, and remote object stores now track source data versions to know when to reload ([#2841](https://github.com/maplibre/martin/pull/2841), [#2864](https://github.com/maplibre/martin/pull/2864)).
+
+Under the hood, every source type now shares a common `ReloadDriver`/`Discovery` mechanism, which should make future source types easier to support. ([#2835](https://github.com/maplibre/martin/pull/2835), [#2836](https://github.com/maplibre/martin/pull/2836), [#2837](https://github.com/maplibre/martin/pull/2837), [#2886](https://github.com/maplibre/martin/pull/2886), [#2844](https://github.com/maplibre/martin/pull/2844), [#2845](https://github.com/maplibre/martin/pull/2845), [#2840](https://github.com/maplibre/martin/pull/2840), [#2852](https://github.com/maplibre/martin/pull/2852), [#2853](https://github.com/maplibre/martin/pull/2853), [#2861](https://github.com/maplibre/martin/pull/2861), [#2867](https://github.com/maplibre/martin/pull/2867)).
+
+### ☀️ GSoC spotlight: a new `duckdb` source (in `martin-core`)
+
+A warm welcome to [Manbhav Sugla (@manbhav234)](https://github.com/manbhav234), our Google Summer of Code student!
+This release lands his first PR, kicking off a brand-new DuckDB source for Martin and laying the groundwork for serving tiles from DuckDB.
+
+It is still early and not currently entierly plumbed through the system, but it is a good start.
+Done in [#2831](https://github.com/maplibre/martin/pull/2831).
+
+### Static rendering core
+
+We added the core machinery for static (single-image) rendering.
+
+This allows you to do static rendering such as for example this OG-image showing the :
+<img src="https://nav.tum.de/api/locations/mi/preview" alt="OG-image" width="500">
+
+Done in [#2804](https://github.com/maplibre/martin/pull/2804).
 
 ### Fixed
 
-- *(martin)* reject invalid scale and inverted bbox in static rendering ([#2830](https://github.com/maplibre/martin/pull/2830))
-- Use ST_EstimatedExtent for quick bounds calc ([#1220](https://github.com/maplibre/martin/pull/1220))
-- ignore ignored directory for sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815))
-- *(unstable-cog)* Allow for 0.1% (up to 3m of error at z0) in COGs from a matching zoom level in WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878))
+- *(martin)* Static rendering now rejects invalid scale values and inverted bounding boxes instead of producing broken output ([#2830](https://github.com/maplibre/martin/pull/2830)).
+- *(pg)* Use `ST_EstimatedExtent` for faster bounds calculation at startup ([#1220](https://github.com/maplibre/martin/pull/1220)).
+- *(sprites)* Ignored directories are now skipped during sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815)).
+- *(unstable-cog)* Allow up to 0.1% tolerance (up to 3m of error at z0) when matching a COG's zoom level to WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878)).
 
 ### Other
 
-- *(deps)* autoupdate pre-commit ([#2896](https://github.com/maplibre/martin/pull/2896))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 19 updates ([#2889](https://github.com/maplibre/martin/pull/2889))
-- add tests for how EXACTLY our config system does parsing (config-4) ([#2872](https://github.com/maplibre/martin/pull/2872))
-- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
-- move pg fingerprinting to u128 ([#2886](https://github.com/maplibre/martin/pull/2886))
-- split Config types into config.rs, making main/mod.rs a pure mod (config-3) ([#2876](https://github.com/maplibre/martin/pull/2876))
-- move parsing to its own module (config-2) ([#2875](https://github.com/maplibre/martin/pull/2875))
-- extract impl Config to lifecycle module (confgi-1) ([#2874](https://github.com/maplibre/martin/pull/2874))
-- pg reloader test to reduce the pg-reloader diff ([#2867](https://github.com/maplibre/martin/pull/2867))
-- rename PmTilesReloader to PmtilesReloader ([#2861](https://github.com/maplibre/martin/pull/2861))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2856](https://github.com/maplibre/martin/pull/2856))
-- migrate Pmtiles to `ReloadDriver` and `Discovery` (pg-reload-7) ([#2840](https://github.com/maplibre/martin/pull/2840))
-- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
-- adopt `ReloadDriver`/`Discovery` for Mbtiles (pg-reload-5) ([#2852](https://github.com/maplibre/martin/pull/2852))
-- move reload-`Trigger`-ing to a separate trait ([#2845](https://github.com/maplibre/martin/pull/2845))
-- *(deps)* autoupdate pre-commit ([#2849](https://github.com/maplibre/martin/pull/2849))
-- extract `Sink` trait for the tile-source manager ([#2844](https://github.com/maplibre/martin/pull/2844))
-- *(pg)* Refactor discovery to enable fingerprinting (PGReloader 2) ([#2835](https://github.com/maplibre/martin/pull/2835))
-- *(pg)* split auto-discovery into discover + instantiate phases (PGReloader 1) ([#2836](https://github.com/maplibre/martin/pull/2836))
-- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
-- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
-- fix import ordering drift ([#2838](https://github.com/maplibre/martin/pull/2838))
-- lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
-- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
-- add a pre-commit to simplify UTF characters ([#2827](https://github.com/maplibre/martin/pull/2827))
-- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
-- cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
-- add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
-- *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
+- The MapLibre Native renderer is now multi-threaded and was updated to `maplibre_native@8.1` ([#2826](https://github.com/maplibre/martin/pull/2826), [#2859](https://github.com/maplibre/martin/pull/2859)).
+- A large refactor split the config code into dedicated `config`, parsing and lifecycle modules, added tests for exactly how config parsing behaves, and moved test helpers to `test_support` ([#2874](https://github.com/maplibre/martin/pull/2874), [#2875](https://github.com/maplibre/martin/pull/2875), [#2876](https://github.com/maplibre/martin/pull/2876), [#2872](https://github.com/maplibre/martin/pull/2872), [#2885](https://github.com/maplibre/martin/pull/2885)).
+- `martin-tile-utils` now has `#![forbid(unsafe_code)]`, error types with multiple identical fields got names, import ordering drift was fixed, and a pre-commit hook simplifies UTF characters ([#2847](https://github.com/maplibre/martin/pull/2847), [#2832](https://github.com/maplibre/martin/pull/2832), [#2838](https://github.com/maplibre/martin/pull/2838), [#2827](https://github.com/maplibre/martin/pull/2827)).
+- Render fixtures are now cached in CI ([#2828](https://github.com/maplibre/martin/pull/2828)).
+- *(deps)* Updated `sqlx` to 0.9.0 (adapting MBTiles dynamic SQL to `SqlSafeStr`), refreshed the lockfile, autoupdated pre-commit, and bumped npm dependencies ([#2821](https://github.com/maplibre/martin/pull/2821), [#2822](https://github.com/maplibre/martin/pull/2822), [#2849](https://github.com/maplibre/martin/pull/2849), [#2896](https://github.com/maplibre/martin/pull/2896), [#2856](https://github.com/maplibre/martin/pull/2856), [#2889](https://github.com/maplibre/martin/pull/2889)).
 
 ## [1.10.1](https://github.com/maplibre/martin/compare/martin-v1.10.0...martin-v1.10.1) - 2026-05-19
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.10.1"
+version = "1.11.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.10.1"
+  "version": "1.11.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -9,17 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0](https://github.com/maplibre/martin/compare/mbtiles-v0.17.6...mbtiles-v0.18.0) - 2026-06-16
 
-### Added
-
-- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
-
 ### Other
 
-- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
 - make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
 - lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
 - *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
-- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
 - add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
 
 ## [0.17.6](https://github.com/maplibre/martin/compare/mbtiles-v0.17.5...mbtiles-v0.17.6) - 2026-05-19

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/maplibre/martin/compare/mbtiles-v0.17.6...mbtiles-v0.18.0) - 2026-06-16
+
+### Added
+
+- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
+
+### Other
+
+- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
+- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
+- lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
+- *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
+- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
+- add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
+
 ## [0.17.6](https://github.com/maplibre/martin/compare/mbtiles-v0.17.5...mbtiles-v0.17.6) - 2026-05-19
 
 ### Fixed

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.17.6"
+version = "0.18.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -218,7 +218,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.10.1"
+    "version": "1.11.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `mbtiles`: 0.17.6 -> 0.18.0 (⚠ API breaking changes)
* `martin-core`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `martin`: 1.10.1 -> 1.11.0

### ⚠ `mbtiles` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant MbtError::InconsistentMetadata in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:39
  variant MbtError::IncorrectTileHash in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:50
  variant MbtError::MissingTileReference in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:59
  variant MbtError::InvalidTileIndex in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:68
  variant MbtError::AggHashMismatch in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:78
  variant MbtError::MismatchedTargetType in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:115
  variant MbtError::AggHashMismatchWithDiff in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:152
  variant MbtError::AggHashMismatchAfterApply in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:162
  variant MbtError::BinDiffIncorrectTileHash in /tmp/.tmpCkABTN/martin/mbtiles/src/errors.rs:177
```

### ⚠ `martin-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type StyleSources is no longer UnwindSafe, in /tmp/.tmpCkABTN/martin/martin-core/src/resources/styles/mod.rs:93

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant FontError::InvalidFontRangeStartEnd in /tmp/.tmpCkABTN/martin/martin-core/src/resources/fonts/error.rs:19
  variant PmtilesError::UnknownTileType in /tmp/.tmpCkABTN/martin/martin-core/src/tiles/pmtiles/error.rs:23
  variant PostgresError::CannotUseClientKey in /tmp/.tmpCkABTN/martin/martin-core/src/tiles/postgres/errors.rs:40
  variant PostgresError::PostgisTooOld in /tmp/.tmpCkABTN/martin/martin-core/src/tiles/postgres/errors.rs:84
  variant PostgresError::PostgresqlTooOld in /tmp/.tmpCkABTN/martin/martin-core/src/tiles/postgres/errors.rs:93
  variant PostgresError::PrepareQueryError in /tmp/.tmpCkABTN/martin/martin-core/src/tiles/postgres/errors.rs:102

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant StyleError::SingleThreadedRenderPoolError, previously in file /tmp/.tmpFbd1fK/martin-core/src/resources/styles/error.rs:8
  variant PostgresError::InvalidTableExtent, previously in file /tmp/.tmpFbd1fK/martin-core/src/tiles/postgres/errors.rs:84

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  StyleSources::set_rendering_enabled, previously in file /tmp/.tmpFbd1fK/martin-core/src/resources/styles/mod.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.18.0](https://github.com/maplibre/martin/compare/mbtiles-v0.17.6...mbtiles-v0.18.0) - 2026-06-16

### Added

- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))

### Other

- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
- lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
- *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
- add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
</blockquote>

## `martin-core`

<blockquote>

## [0.8.0](https://github.com/maplibre/martin/compare/martin-core-v0.7.0...martin-core-v0.8.0) - 2026-06-16

### Added

- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
- duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))
- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))

### Fixed

- *(unstable-cog)* Allow for 0.1% (up to 3m of error at z0) in COGs from a matching zoom level in WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878))
- *(martin)* reject invalid scale and inverted bbox in static rendering ([#2830](https://github.com/maplibre/martin/pull/2830))
- ignore ignored directory for sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815))

### Other

- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
- cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
</blockquote>

## `martin`

<blockquote>

## [1.11.0](https://github.com/maplibre/martin/compare/martin-v1.10.1...martin-v1.11.0) - 2026-06-16

### Added

- *(pg)* enable Postgres reloading ([#2841](https://github.com/maplibre/martin/pull/2841))
- teach ObjectStoreDiscovery to track source data versions ([#2864](https://github.com/maplibre/martin/pull/2864))
- Auto-refresh pmtiles source on source data change ([#2858](https://github.com/maplibre/martin/pull/2858))
- Add COGReloader and PMTilesReloader (Tile Reload Phase 2) ([#2750](https://github.com/maplibre/martin/pull/2750))
- static rendering core ([#2804](https://github.com/maplibre/martin/pull/2804))
- duckdb-source implementation at martin-core ([#2831](https://github.com/maplibre/martin/pull/2831))

### Fixed

- *(martin)* reject invalid scale and inverted bbox in static rendering ([#2830](https://github.com/maplibre/martin/pull/2830))
- Use ST_EstimatedExtent for quick bounds calc ([#1220](https://github.com/maplibre/martin/pull/1220))
- ignore ignored directory for sprite resolution ([#2815](https://github.com/maplibre/martin/pull/2815))
- *(unstable-cog)* Allow for 0.1% (up to 3m of error at z0) in COGs from a matching zoom level in WebMercatorQuad ([#2878](https://github.com/maplibre/martin/pull/2878))

### Other

- *(deps)* autoupdate pre-commit ([#2896](https://github.com/maplibre/martin/pull/2896))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 19 updates ([#2889](https://github.com/maplibre/martin/pull/2889))
- add tests for how EXACTLY our config system does parsing (config-4) ([#2872](https://github.com/maplibre/martin/pull/2872))
- split out the test code to `test_support` ([#2885](https://github.com/maplibre/martin/pull/2885))
- move pg fingerprinting to u128 ([#2886](https://github.com/maplibre/martin/pull/2886))
- split Config types into config.rs, making main/mod.rs a pure mod (config-3) ([#2876](https://github.com/maplibre/martin/pull/2876))
- move parsing to its own module (config-2) ([#2875](https://github.com/maplibre/martin/pull/2875))
- extract impl Config to lifecycle module (confgi-1) ([#2874](https://github.com/maplibre/martin/pull/2874))
- pg reloader test to reduce the pg-reloader diff ([#2867](https://github.com/maplibre/martin/pull/2867))
- rename PmTilesReloader to PmtilesReloader ([#2861](https://github.com/maplibre/martin/pull/2861))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2856](https://github.com/maplibre/martin/pull/2856))
- migrate Pmtiles to `ReloadDriver` and `Discovery` (pg-reload-7) ([#2840](https://github.com/maplibre/martin/pull/2840))
- migrate `MBTilesReloader` to be based on `ReloadDriver` and `Discovery` (pg-reload-6) ([#2853](https://github.com/maplibre/martin/pull/2853))
- adopt `ReloadDriver`/`Discovery` for Mbtiles (pg-reload-5) ([#2852](https://github.com/maplibre/martin/pull/2852))
- move reload-`Trigger`-ing to a separate trait ([#2845](https://github.com/maplibre/martin/pull/2845))
- *(deps)* autoupdate pre-commit ([#2849](https://github.com/maplibre/martin/pull/2849))
- extract `Sink` trait for the tile-source manager ([#2844](https://github.com/maplibre/martin/pull/2844))
- *(pg)* Refactor discovery to enable fingerprinting (PGReloader 2) ([#2835](https://github.com/maplibre/martin/pull/2835))
- *(pg)* split auto-discovery into discover + instantiate phases (PGReloader 1) ([#2836](https://github.com/maplibre/martin/pull/2836))
- *(pg)* cleanup how extent is handled (PGReloader 0) ([#2837](https://github.com/maplibre/martin/pull/2837))
- make sure that error types with multiple identical types have names ([#2832](https://github.com/maplibre/martin/pull/2832))
- fix import ordering drift ([#2838](https://github.com/maplibre/martin/pull/2838))
- lockfile maintenance ([#2822](https://github.com/maplibre/martin/pull/2822))
- make the MLN renderer multi threaded ([#2826](https://github.com/maplibre/martin/pull/2826))
- add a pre-commit to simplify UTF characters ([#2827](https://github.com/maplibre/martin/pull/2827))
- update to maplibre_native@8.1 ([#2859](https://github.com/maplibre/martin/pull/2859))
- cache render fixtures ([#2828](https://github.com/maplibre/martin/pull/2828))
- add #![forbid(unsafe_code)] to martin-tile-utils ([#2847](https://github.com/maplibre/martin/pull/2847))
- *(deps)* Update `sqlx` to 0.9.0 and adapt MBTiles dynamic SQL to `SqlSafeStr` ([#2821](https://github.com/maplibre/martin/pull/2821))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).