### PR TITLE
refactor: extract `Sink` trait for the tile-source manager

### DIFF
--- a/martin/src/config/file/tiles/driver/mod.rs
+++ b/martin/src/config/file/tiles/driver/mod.rs
@@ -1,0 +1,5 @@
+//! The [`Sink`] trait that reload drivers apply advisories against.
+
+mod sink;
+
+pub use sink::Sink;

--- a/martin/src/config/file/tiles/driver/sink.rs
+++ b/martin/src/config/file/tiles/driver/sink.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+
+use crate::MartinResult;
+use crate::reload::ReloadAdvisory;
+
+/// Where a reload driver applies advisories.
+///
+/// The production implementation is [`TileSourceManager`](crate::TileSourceManager);
+/// tests use a recording spy.
+#[async_trait]
+pub trait Sink: Send + 'static {
+    /// Applies a [`ReloadAdvisory`] to the live source set.
+    async fn apply_changes(&self, advisory: ReloadAdvisory) -> MartinResult<()>;
+}

--- a/martin/src/config/file/tiles/driver/sink.rs
+++ b/martin/src/config/file/tiles/driver/sink.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-
 use crate::MartinResult;
 use crate::reload::ReloadAdvisory;
 
@@ -7,8 +5,10 @@ use crate::reload::ReloadAdvisory;
 ///
 /// The production implementation is [`TileSourceManager`](crate::TileSourceManager);
 /// tests use a recording spy.
-#[async_trait]
 pub trait Sink: Send + 'static {
     /// Applies a [`ReloadAdvisory`] to the live source set.
-    async fn apply_changes(&self, advisory: ReloadAdvisory) -> MartinResult<()>;
+    fn apply_changes(
+        &self,
+        advisory: ReloadAdvisory,
+    ) -> impl Future<Output = MartinResult<()>> + Send;
 }

--- a/martin/src/config/file/tiles/mod.rs
+++ b/martin/src/config/file/tiles/mod.rs
@@ -7,4 +7,5 @@ pub mod pmtiles;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 
+pub mod driver;
 pub mod reload;

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -8,6 +8,7 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, Watcher as _};
 use tokio::sync::mpsc;
 
 use crate::config::file::cog::CogConfig;
+use crate::config::file::driver::Sink as _;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::reload::{discover_sources_by_ext, path_modified_ms};
 use crate::config::file::{CachePolicy, FileConfigEnum};

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -7,6 +7,7 @@ use notify::event::{AccessKind, AccessMode};
 use notify::{Config, Event, EventKind, RecommendedWatcher, Watcher as _};
 use tokio::sync::mpsc;
 
+use crate::config::file::driver::Sink as _;
 use crate::config::file::mbtiles::MbtConfig;
 use crate::config::file::process::ProcessConfig;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc;
 use tokio::time::{Instant, MissedTickBehavior};
 use url::Url;
 
+use crate::config::file::driver::Sink as _;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use dashmap::DashMap;
 use martin_core::tiles::{BoxedSource, OptTileCache};
 use tracing::{info, warn};
@@ -70,7 +69,6 @@ impl TileSourceManager {
     }
 }
 
-#[async_trait]
 impl Sink for TileSourceManager {
     /// Applies a [`ReloadAdvisory`] to the live source set.
     ///

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use dashmap::DashMap;
 use martin_core::tiles::{BoxedSource, OptTileCache};
 use tracing::{info, warn};
 
 use crate::MartinResult;
+use crate::config::file::driver::Sink;
 use crate::config::file::{OnInvalid, ProcessConfig};
 use crate::reload::ReloadAdvisory;
 use crate::source::TileSources;
@@ -66,7 +68,10 @@ impl TileSourceManager {
     pub fn tile_cache(&self) -> &OptTileCache {
         &self.tile_cache
     }
+}
 
+#[async_trait]
+impl Sink for TileSourceManager {
     /// Applies a [`ReloadAdvisory`] to the live source set.
     ///
     /// When a source fails to initialize, the configured [`OnInvalid`] policy
@@ -78,7 +83,7 @@ impl TileSourceManager {
     /// 1. **Updates** - time-critical; invalidate cache then replace the source.
     /// 2. **Additions** - make new sources available.
     /// 3. **Removals** - garbage-collect stale sources and their cached tiles.
-    pub async fn apply_changes(&self, advisory: ReloadAdvisory) -> MartinResult<()> {
+    async fn apply_changes(&self, advisory: ReloadAdvisory) -> MartinResult<()> {
         if advisory.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
Pulls the `Sink` trait from
- #2840