### PR TITLE
chore: add #![forbid(unsafe_code)] to martin-tile-utils

### DIFF
--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
 
 // This code was partially adapted from https://github.com/maplibre/mbtileserver-rs
 // project originally written by Kaveh Karimi and licensed under MIT OR Apache-2.0


### PR DESCRIPTION
`martin-tile-utils` has no `unsafe` blocks and no FFI requirements, but lacks the `#![forbid(unsafe_code)]` annotation already present in the `martin` and `martin-core` crates. This one-line change enforces the absence of unsafe code at compile time, making the guarantee explicit and catching any future accidental introduction.

Verified via `grep -r unsafe martin-tile-utils/` — no matches.

Note: I do not have a local Rust toolchain to run `just lint`, but the annotation adds no new constraints on a crate that already contains no unsafe code. CI should confirm this cleanly.