### PR TITLE
ci: add test-packages justfile recipe and use it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,23 +77,8 @@ jobs:
         if: runner.os == 'Linux'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Run cargo test
-        run: |
-          set -x
-          cargo test --package martin-tile-utils
-          cargo test --package mbtiles --no-default-features
-          cargo test --package mbtiles
-          cargo test --package martin-core
-          # style rendering requires upstream resources
-          # we use a cassete recording to not have random flakes
-          if [ "$RUNNER_OS" = Linux ]; then
-            just with-render-cache 'cargo test --package martin'
-          else
-            cargo test --package martin
-          fi
-        env:
-          AWS_SKIP_CREDENTIALS: 1
-          AWS_REGION: eu-central-1
-      - run: cargo test --doc
+        run: just test-packages
+      - run: just test-doc
   lint-rust:
     name: Lint the Rust code
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Run cargo test
-        run: just test-packages
+        run: just test-packages-ci
       - run: just test-doc
   lint-rust:
     name: Lint the Rust code

--- a/justfile
+++ b/justfile
@@ -594,6 +594,20 @@ test-minio:
 test-cargo *args:
     MLN_PRECOMPILE=1 cargo test {{args}}
 
+# Run unit tests for each package in dependency order (used by CI)
+test-packages:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo test --package martin-tile-utils
+    cargo test --package mbtiles --no-default-features
+    cargo test --package mbtiles
+    cargo test --package martin-core
+    if [ "$(uname)" = Linux ]; then
+        {{just}} with-render-cache 'cargo test --package martin'
+    else
+        cargo test --package martin
+    fi
+
 # Run Rust doc tests
 test-doc *args:
     MLN_PRECOMPILE=1 cargo test --doc {{args}}

--- a/justfile
+++ b/justfile
@@ -594,8 +594,8 @@ test-minio:
 test-cargo *args:
     MLN_PRECOMPILE=1 cargo test {{args}}
 
-# Run unit tests for each package in dependency order (used by CI)
-test-packages:
+# Run unit tests for each package in dependency order
+test-packages-ci:
     #!/usr/bin/env bash
     set -euo pipefail
     cargo test --package martin-tile-utils

--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
 
 // This code was partially adapted from https://github.com/maplibre/mbtileserver-rs
 // project originally written by Kaveh Karimi and licensed under MIT OR Apache-2.0


### PR DESCRIPTION
Closes #2492.

Consolidates the per-package `cargo test` block in `ci.yml` into a new `test-packages` justfile recipe, consistent with how `build-binary.yml` already delegates to `just build-release-musl` and `just move-artifacts`.

The `AWS_SKIP_CREDENTIALS` and `AWS_REGION` env vars are removed from the CI step as they are already exported by the justfile.

The `[linux]`-only `with-render-cache` call is preserved via a `uname` check inside the recipe's bash shebang block, matching the original `$RUNNER_OS` conditional in the workflow.