### PR TITLE
feat: Auto-refresh pmtiles source on source data change

### DIFF
--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -56,7 +56,7 @@ sprites = [
 ]
 styles = ["tokio/fs", "dep:dashmap", "dep:walkdir"]
 mbtiles = ["dep:backon", "dep:mbtiles", "dep:tokio", "_tiles"]
-pmtiles = ["dep:pmtiles", "dep:object_store", "_tiles"]
+pmtiles = ["dep:pmtiles", "dep:object_store", "dep:tokio", "tokio/sync", "_tiles"]
 _tiles = ["dep:base64"]
 test-pg = ["postgres"]
 unstable-schemas = ["dep:schemars", "dep:utoipa"]

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -182,8 +182,7 @@ impl Source for PmtilesSource {
         xyz: TileCoord,
         _url_query: Option<&UrlQuery>,
     ) -> MartinCoreResult<TileData> {
-        let coord =
-            pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
+        let coord = pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
 
         let result = {
             let reader = self.pmtiles.read().await;

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -6,9 +6,10 @@ use async_trait::async_trait;
 use derive_debug::Dbg;
 use martin_tile_utils::{Encoding, Format, TileCoord, TileData, TileInfo};
 use object_store::ObjectStore;
-use pmtiles::{AsyncPmTilesReader, Compression, ObjectStoreBackend, TileType};
+use pmtiles::{AsyncPmTilesReader, Compression, ObjectStoreBackend, PmtError, TileType};
 use tilejson::TileJSON;
-use tracing::{trace, warn};
+use tokio::sync::{Notify, RwLock};
+use tracing::{info, trace, warn};
 
 use crate::CacheZoomRange;
 use crate::tiles::pmtiles::PmtCacheInstance;
@@ -20,7 +21,15 @@ use crate::tiles::{BoxedSource, MartinCoreResult, Source, UrlQuery};
 pub struct PmtilesSource {
     id: String,
     #[dbg(skip)]
-    pmtiles: Arc<AsyncPmTilesReader<ObjectStoreBackend, PmtCacheInstance>>,
+    pmtiles: Arc<RwLock<AsyncPmTilesReader<ObjectStoreBackend, PmtCacheInstance>>>,
+    #[dbg(skip)]
+    store: Arc<dyn ObjectStore>,
+    #[dbg(skip)]
+    path: object_store::path::Path,
+    #[dbg(skip)]
+    dir_cache: PmtCacheInstance,
+    #[dbg(skip)]
+    reload_signal: Arc<Notify>,
     #[dbg(skip)]
     tilejson: TileJSON,
     #[dbg(skip)]
@@ -39,9 +48,13 @@ impl PmtilesSource {
         cache_zoom: CacheZoomRange,
     ) -> Result<Self, PmtilesError> {
         let path = path.into();
+        let store: Arc<dyn ObjectStore> = Arc::from(store);
         let store_to_string = store.to_string();
-        let backend = ObjectStoreBackend::new(store, path.clone());
-        let reader = AsyncPmTilesReader::try_from_cached_source(backend, cache)
+        let backend = ObjectStoreBackend::new(
+            Box::new(Arc::clone(&store)) as Box<dyn ObjectStore>,
+            path.clone(),
+        );
+        let reader = AsyncPmTilesReader::try_from_cached_source(backend, cache.clone())
             .await
             .map_err(|e| PmtilesError::PmtErrorWithCtx(e, store_to_string.clone()))?;
 
@@ -98,13 +111,42 @@ impl PmtilesSource {
 
         Ok(Self {
             id,
-            pmtiles: Arc::new(reader),
+            pmtiles: Arc::new(RwLock::new(reader)),
+            store,
+            path,
+            dir_cache: cache,
+            reload_signal: Arc::new(Notify::new()),
             tilejson,
             tile_info: format,
             cache_zoom,
         })
     }
+
+    /// Returns a signal that fires once after each successful self-reload.
+    ///
+    /// Callers (e.g. `PmtilesReloader`) can `await` this to learn when the
+    /// tile-cache entries for this source should be invalidated.
+    pub fn reload_signal(&self) -> Arc<Notify> {
+        Arc::clone(&self.reload_signal)
+    }
+
+    /// Rebuilds the internal reader from the same store and path.
+    async fn reload(&self) -> Result<(), PmtilesError> {
+        let store_to_string = self.store.to_string();
+        let backend = ObjectStoreBackend::new(
+            Box::new(Arc::clone(&self.store)) as Box<dyn ObjectStore>,
+            self.path.clone(),
+        );
+        let new_reader =
+            AsyncPmTilesReader::try_from_cached_source(backend, self.dir_cache.clone())
+                .await
+                .map_err(|e| PmtilesError::PmtErrorWithCtx(e, store_to_string))?;
+        let mut guard = self.pmtiles.write().await;
+        *guard = new_reader;
+        Ok(())
+    }
 }
+
 #[async_trait]
 impl Source for PmtilesSource {
     fn get_id(&self) -> &str {
@@ -122,6 +164,7 @@ impl Source for PmtilesSource {
     fn clone_source(&self) -> BoxedSource {
         Box::new(self.clone())
     }
+
     fn get_version(&self) -> Option<String> {
         self.tilejson.version.clone()
     }
@@ -139,23 +182,49 @@ impl Source for PmtilesSource {
         xyz: TileCoord,
         _url_query: Option<&UrlQuery>,
     ) -> MartinCoreResult<TileData> {
-        let coord = pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
-        if let Some(t) = self
-            .pmtiles
-            .get_tile(coord)
-            .await
-            .map_err(PmtilesError::PmtError)?
-        {
-            Ok(t.to_vec())
-        } else {
-            trace!(
-                source.id = %self.id,
-                tile.z = xyz.z,
-                tile.x = xyz.x,
-                tile.y = xyz.y,
-                "Couldn't find tile data"
-            );
-            Ok(Vec::new())
+        let coord =
+            pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
+
+        let result = {
+            let reader = self.pmtiles.read().await;
+            reader.get_tile(coord).await
+        };
+
+        match result {
+            Ok(Some(t)) => return Ok(t.to_vec()),
+            Ok(None) => {
+                trace!(
+                    source.id = %self.id,
+                    tile.z = xyz.z,
+                    tile.x = xyz.x,
+                    tile.y = xyz.y,
+                    "Couldn't find tile data"
+                );
+                return Ok(Vec::new());
+            }
+            Err(PmtError::SourceModified) => {
+                info!(source.id = %self.id, "PMTiles source modified; reloading");
+                self.reload().await?;
+                self.reload_signal.notify_one();
+            }
+            Err(e) => return Err(PmtilesError::PmtError(e).into()),
+        }
+
+        // Retry once after successful reload
+        let reader = self.pmtiles.read().await;
+        match reader.get_tile(coord).await {
+            Ok(Some(t)) => Ok(t.to_vec()),
+            Ok(None) => {
+                trace!(
+                    source.id = %self.id,
+                    tile.z = xyz.z,
+                    tile.x = xyz.x,
+                    tile.y = xyz.y,
+                    "Couldn't find tile data"
+                );
+                Ok(Vec::new())
+            }
+            Err(e) => Err(PmtilesError::PmtError(e).into()),
         }
     }
 }

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -126,6 +126,7 @@ impl PmtilesSource {
     ///
     /// Callers (e.g. `PmtilesReloader`) can `await` this to learn when the
     /// tile-cache entries for this source should be invalidated.
+    #[must_use]
     pub fn reload_signal(&self) -> Arc<Notify> {
         Arc::clone(&self.reload_signal)
     }
@@ -182,8 +183,7 @@ impl Source for PmtilesSource {
         xyz: TileCoord,
         _url_query: Option<&UrlQuery>,
     ) -> MartinCoreResult<TileData> {
-        let coord =
-            pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
+        let coord = pmtiles::TileCoord::new(xyz.z, xyz.x, xyz.y).map_err(PmtilesError::PmtError)?;
 
         let result = {
             let reader = self.pmtiles.read().await;

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -79,7 +79,7 @@ fn create_test_directory() -> Result<pmtiles::Directory, pmtiles::PmtError> {
         0xD0, 0x0F, // offsets: first=1000, second=2000
     ];
 
-    pmtiles::Directory::try_from(bytes::Bytes::from(buf))
+    pmtiles::Directory::try_from(Bytes::from(buf))
 }
 
 #[tokio::test]

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -6,11 +6,15 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use bytes::Bytes;
 use martin_core::CacheZoomRange;
 use martin_core::tiles::Source as _;
 use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesError, PmtilesSource};
 use martin_tile_utils::{Encoding, Format, TileCoord};
 use object_store::local::LocalFileSystem;
+use object_store::memory::InMemory;
+use object_store::path::Path as ObjectStorePath;
+use object_store::{ObjectStoreExt as _, PutPayload};
 use pmtiles::{DirectoryCache as _, TileId};
 use rstest::rstest;
 use tokio::sync::oneshot;
@@ -264,6 +268,58 @@ async fn repeated_tile_requests_return_same_data() {
         "Second and third request should return identical data"
     );
     assert!(!tile1.is_empty(), "Tile data should not be empty");
+}
+
+#[tokio::test]
+async fn source_reloads_after_file_change() {
+    // When the underlying file is replaced, PmtilesSource should detect the change
+    // (via PmtError::SourceModified) and transparently reload, returning a valid tile
+    // to the caller rather than propagating the error.
+
+    let fixture_data = Bytes::from(
+        std::fs::read(fixtures_dir().join("stamen_toner__raster_CC-BY+ODbL_z3.pmtiles"))
+            .expect("fixture file exists"),
+    );
+
+    let store = InMemory::new();
+    let path = ObjectStorePath::from("test.pmtiles");
+
+    store
+        .put(&path, PutPayload::from(fixture_data.clone()))
+        .await
+        .expect("initial upload");
+
+    let cache = test_cache_bytes(0);
+    let source = PmtilesSource::new(
+        cache,
+        "reload_test".to_string(),
+        Box::new(store.clone()),
+        path.clone(),
+        CacheZoomRange::default(),
+    )
+    .await
+    .expect("source created");
+
+    let coord = TileCoord { z: 0, x: 0, y: 0 };
+
+    let tile = source
+        .get_tile(coord, None)
+        .await
+        .expect("first read succeeds");
+    assert!(!tile.is_empty(), "first tile should have data");
+
+    // Re-upload the same object so InMemory increments the ETag.
+    store
+        .put(&path, PutPayload::from(fixture_data))
+        .await
+        .expect("re-upload to simulate file change");
+
+    // An internal reload should result in a successful request.
+    let tile = source
+        .get_tile(coord, None)
+        .await
+        .expect("should succeed after source reloads");
+    assert!(!tile.is_empty(), "tile after reload should have data");
 }
 
 #[tokio::test]


### PR DESCRIPTION
What's left:

- [ ] Invalidate the local tile cache for this source
- [ ] Tests for invalidation

Fixes [issue #2713](https://github.com/maplibre/martin/issues/2713)