### PR TITLE
fix: migrate env-var substitution to serde-saphyr properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+checksum = "599a28c6c3171864dbf7fdb3a666f7ac301fab54c2b6e71534f413959cd37b49"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -4360,7 +4360,6 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "static-files 0.2.5",
- "subst",
  "tempfile",
  "testcontainers-modules",
  "thiserror 2.0.18",
@@ -6759,9 +6758,8 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+version = "0.0.28"
+source = "git+https://github.com/bourumir-wyngs/serde-saphyr?rev=261ccbe62a8368fcffbd780dd923647edfd2f927#261ccbe62a8368fcffbd780dd923647edfd2f927"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
@@ -7548,16 +7546,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "subst"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
-dependencies = [
- "memchr",
- "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,13 @@ rustls-pemfile = "2"
 schemars = { version = "1.2", default-features = false, features = ["chrono04", "derive", "std"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
-serde-saphyr = { version = "0.0.27", features = ["miette"] }
+# TODO: drop the `git` pin once a release containing PRs #122, #125, #128, #129 is published
+# (currently 0.0.27 is the latest on crates.io; master is 0.0.28).
+# Tracking: https://github.com/maplibre/martin/issues/2851
+serde-saphyr = { git = "https://github.com/bourumir-wyngs/serde-saphyr", rev = "261ccbe62a8368fcffbd780dd923647edfd2f927", features = [
+    "miette",
+    "properties",
+] }
 serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 serde_yaml = "0.9"
@@ -136,7 +142,6 @@ sqlite-compressions = { version = "0.3", default-features = false, features = ["
 sqlite-hashes = { version = "0.10.6", default-features = false, features = ["md5", "aggregate", "hex"] }
 sqlx = { version = "0.9.0", features = ["sqlite", "runtime-tokio"] }
 static-files = "0.2"
-subst = "0.3"
 tempfile = "3.21.0"
 testcontainers-modules = { version = "0.15.0", features = ["postgres", "blocking", "minio"] }
 thiserror = "2"

--- a/deny.toml
+++ b/deny.toml
@@ -79,7 +79,12 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 # If git deps are ever needed, they must be explicitly allowed here
-allow-git = []
+allow-git = [
+    # TODO: drop once a release with PRs #122/#125/#128/#129 (YAML-aware env var
+    # substitution: defaults, bare `$VAR`, error-on-missing forms) is published.
+    # Tracking: https://github.com/maplibre/martin/issues/2851
+    "https://github.com/bourumir-wyngs/serde-saphyr",
+]
 
 [graph]
 targets = [

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -200,7 +200,6 @@ serde_json.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 static-files = { workspace = true, optional = true }
-subst.workspace = true
 thiserror.workspace = true
 tilejson.workspace = true
 tokio = { workspace = true, features = ["io-std"] }

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -56,10 +56,10 @@ pub struct PostgresArgs {
 }
 
 impl PostgresArgs {
-    pub fn into_config<'a>(
+    pub fn into_config(
         self,
         cli_strings: &mut Arguments,
-        env: &impl Env<'a>,
+        env: &impl Env,
     ) -> OptOneMany<PostgresConfig> {
         let connections = Self::extract_conn_strings(cli_strings, env);
         let default_srid = self.get_default_srid(env);
@@ -93,11 +93,7 @@ impl PostgresArgs {
     }
 
     /// Apply CLI parameters from `self` to the configuration loaded from the config file `pg_config`
-    pub fn override_config<'a>(
-        self,
-        pg_config: &mut OptOneMany<PostgresConfig>,
-        env: &impl Env<'a>,
-    ) {
+    pub fn override_config(self, pg_config: &mut OptOneMany<PostgresConfig>, env: &impl Env) {
         // This ensures that if a new parameter is added to the struct, it will not be forgotten here
         let Self {
             default_srid,
@@ -165,7 +161,7 @@ impl PostgresArgs {
         }
     }
 
-    fn extract_conn_strings<'a>(cli_strings: &mut Arguments, env: &impl Env<'a>) -> Vec<String> {
+    fn extract_conn_strings(cli_strings: &mut Arguments, env: &impl Env) -> Vec<String> {
         let mut connections = cli_strings.process(|v| {
             if is_postgres_connection_string(v) {
                 Take(v.to_string())
@@ -187,7 +183,7 @@ impl PostgresArgs {
         connections
     }
 
-    fn get_default_srid<'a>(&self, env: &impl Env<'a>) -> Option<i32> {
+    fn get_default_srid(&self, env: &impl Env) -> Option<i32> {
         if self.default_srid.is_some() {
             return self.default_srid;
         }
@@ -204,7 +200,7 @@ impl PostgresArgs {
             })
     }
 
-    fn get_certs<'a>(&self, env: &impl Env<'a>) -> PostgresSslCerts {
+    fn get_certs(&self, env: &impl Env) -> PostgresSslCerts {
         let mut result = PostgresSslCerts {
             ssl_cert: Self::parse_env_var(env, "PGSSLCERT", "ssl certificate"),
             ssl_key: Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate"),
@@ -218,11 +214,7 @@ impl PostgresArgs {
         result
     }
 
-    fn parse_env_var<'a>(
-        env: &impl Env<'a>,
-        env_var: &str,
-        info: &str,
-    ) -> Option<std::path::PathBuf> {
+    fn parse_env_var(env: &impl Env, env_var: &str, info: &str) -> Option<std::path::PathBuf> {
         let path = env.var_os(env_var).map(std::path::PathBuf::from);
         if let Some(p) = &path {
             let p = p.display();

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -90,10 +90,10 @@ pub struct ExtraArgs {
 }
 
 impl Args {
-    pub fn merge_into_config<'a>(
+    pub fn merge_into_config(
         self,
         config: &mut Config,
-        #[cfg(feature = "postgres")] env: &impl Env<'a>,
+        #[cfg(feature = "postgres")] env: &impl Env,
     ) -> MartinResult<()> {
         if self.meta.config.is_some() && !self.meta.connection.is_empty() {
             return Err(ConfigAndConnectionsError(self.meta.connection));

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -213,7 +213,7 @@ mod tests {
     fn deserialize_rejects_integer() {
         insta::assert_snapshot!(render_failure("cors: 42\n"), @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: integer `42`, expected either a boolean (`cors: true` /
           │ `cors: false`) or a properties map with at least an `origin` list
            ╭─[config.yaml:1:1]
@@ -230,7 +230,7 @@ mod tests {
     fn deserialize_rejects_quoted_string() {
         insta::assert_snapshot!(render_failure("cors: \"yes please\"\n"), @r#"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: string "yes please", expected either a boolean (`cors:
           │ true` / `cors: false`) or a properties map with at least an `origin` list
            ╭─[config.yaml:1:1]
@@ -247,7 +247,7 @@ mod tests {
     fn deserialize_rejects_sequence() {
         insta::assert_snapshot!(render_failure("cors: [https://example.org]\n"), @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: sequence, expected either a boolean (`cors: true` / `cors:
           │ false`) or a properties map with at least an `origin` list
            ╭─[config.yaml:1:1]

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -212,39 +212,51 @@ mod tests {
     #[test]
     fn deserialize_rejects_integer() {
         insta::assert_snapshot!(render_failure("cors: 42\n"), @"
-         × invalid type: integer `42`, expected either a boolean (`cors: true` /
-         │ `cors: false`) or a properties map with at least an `origin` list
-          ╭─[config.yaml:1:1]
-        1 │ cors: 42
-          · ──┬─
-          ·   ╰── invalid type: integer `42`, expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: integer `42`, expected either a boolean (`cors: true` /
+          │ `cors: false`) or a properties map with at least an `origin` list
+           ╭─[config.yaml:1:1]
+         1 │ cors: 42
+           · ──┬─
+           ·   ╰── invalid type: integer `42`, expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 
     #[test]
     fn deserialize_rejects_quoted_string() {
         insta::assert_snapshot!(render_failure("cors: \"yes please\"\n"), @r#"
-         × invalid type: string "yes please", expected either a boolean (`cors:
-         │ true` / `cors: false`) or a properties map with at least an `origin` list
-          ╭─[config.yaml:1:1]
-        1 │ cors: "yes please"
-          · ──┬─
-          ·   ╰── invalid type: string "yes please", expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: string "yes please", expected either a boolean (`cors:
+          │ true` / `cors: false`) or a properties map with at least an `origin` list
+           ╭─[config.yaml:1:1]
+         1 │ cors: "yes please"
+           · ──┬─
+           ·   ╰── invalid type: string "yes please", expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "#);
     }
 
     #[test]
     fn deserialize_rejects_sequence() {
         insta::assert_snapshot!(render_failure("cors: [https://example.org]\n"), @"
-         × invalid type: sequence, expected either a boolean (`cors: true` / `cors:
-         │ false`) or a properties map with at least an `origin` list
-          ╭─[config.yaml:1:1]
-        1 │ cors: [https://example.org]
-          · ──┬─
-          ·   ╰── invalid type: sequence, expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: sequence, expected either a boolean (`cors: true` / `cors:
+          │ false`) or a properties map with at least an `origin` list
+           ╭─[config.yaml:1:1]
+         1 │ cors: [https://example.org]
+           · ──┬─
+           ·   ╰── invalid type: sequence, expected either a boolean (`cors: true` / `cors: false`) or a properties map with at least an `origin` list
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use martin_core::fonts::FontError;
 #[cfg(feature = "postgres")]
 use martin_core::tiles::postgres::PostgresError;
-use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode, SourceSpan};
+use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode};
 
 pub type ConfigFileResult<T> = Result<T, ConfigFileError>;
 
@@ -18,9 +18,6 @@ pub enum ConfigFileError {
 
     #[error("Unable to parse YAML in config file {}: {}", .0.named_source.name(), .0.error)]
     YamlParseError(Box<YamlParseDetails>),
-
-    #[error("Unable to substitute environment variables in config file {}: {}", .0.named_source.name(), .0.source)]
-    SubstitutionError(Box<SubstitutionDetails>),
 
     #[error("Unable to write config file {1}: {0}")]
     ConfigWriteError(#[source] std::io::Error, PathBuf),
@@ -78,18 +75,14 @@ pub enum ConfigFileError {
 }
 
 /// Boxed payload for [`ConfigFileError::YamlParseError`].
+///
+/// Saphyr's `properties` feature reports unresolved-variable / invalid-name
+/// errors as ordinary deserialization errors (with span info), so this single
+/// variant covers both YAML syntax errors *and* `${VAR}` substitution failures.
 #[derive(Debug)]
 pub struct YamlParseDetails {
     pub(crate) error: serde_saphyr::Error,
     pub(crate) named_source: NamedSource<String>,
-}
-
-/// Boxed payload for [`ConfigFileError::SubstitutionError`].
-#[derive(Debug)]
-pub struct SubstitutionDetails {
-    pub(crate) source: subst::Error,
-    pub(crate) named_source: NamedSource<String>,
-    pub(crate) primary_span: Option<SourceSpan>,
 }
 
 impl ConfigFileError {
@@ -104,87 +97,144 @@ impl ConfigFileError {
         }))
     }
 
-    /// Construct a substitution error, locating the failing variable token within the source.
-    #[must_use]
-    pub fn substitution(source: subst::Error, source_text: String, file_path: &Path) -> Self {
-        let primary_span = subst_error_span(&source, &source_text);
-        Self::SubstitutionError(Box::new(SubstitutionDetails {
-            source,
-            named_source: NamedSource::new(file_path.display().to_string(), source_text),
-            primary_span,
-        }))
-    }
-
     /// Render this error as a [`miette::Report`] for graphical display, when applicable.
     ///
-    /// For YAML parse errors we delegate to `serde_saphyr::miette::to_miette_report`, which
-    /// builds a richer diagnostic (snippet windows, nested labels) than our manual
-    /// `Diagnostic` impl below. The substitution path uses an owned [`SubstitutionReport`]
-    /// because `miette::Report::new` requires `'static` data and `subst::Error` isn't
-    /// `Clone`, so we can't put `self` inside the report directly.
+    /// For YAML parse errors we delegate snippet construction to
+    /// `serde_saphyr::miette::to_miette_report` and wrap the result so the report carries
+    /// martin's own `code`/`help`/`url`. Property-substitution failures (introduced when
+    /// we moved from text-level `subst` to saphyr's `properties` feature) flow through this
+    /// same path but with substitution-specific metadata.
     #[must_use]
     pub fn to_miette_report(&self) -> Option<miette::Report> {
         match self {
-            Self::YamlParseError(details) => Some(serde_saphyr::miette::to_miette_report(
-                &details.error,
-                details.named_source.inner(),
-                details.named_source.name(),
-            )),
-            Self::SubstitutionError(details) => Some(miette::Report::new(SubstitutionReport {
-                message: format!("{self}"),
-                named_source: NamedSource::new(
+            Self::YamlParseError(details) => {
+                let inner = serde_saphyr::miette::to_miette_report(
+                    &details.error,
+                    details.named_source.inner(),
                     details.named_source.name(),
-                    details.named_source.inner().clone(),
-                ),
-                primary_span: details.primary_span,
-                label_text: details.source.to_string(),
-            })),
+                );
+                let kind = YamlReportKind::for_error(&details.error);
+                Some(miette::Report::new(YamlParseReport { inner, kind }))
+            }
             _ => None,
         }
     }
 }
 
-/// Self-contained `Diagnostic` for a substitution error, owning all its data so it can
-/// power a `'static miette::Report` without having to make `ConfigFileError: Clone`.
-#[derive(Debug)]
-struct SubstitutionReport {
-    message: String,
-    named_source: NamedSource<String>,
-    primary_span: Option<SourceSpan>,
-    label_text: String,
+/// Whether a YAML parse failure is a `${VAR}` substitution miss or a generic YAML error.
+///
+/// Used to pick code / help / url that match the user's actual problem instead of
+/// labeling property errors with the generic YAML diagnostic.
+#[derive(Clone, Copy, Debug)]
+enum YamlReportKind {
+    Substitution,
+    Yaml,
 }
 
-impl std::fmt::Display for SubstitutionReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
+impl YamlReportKind {
+    fn for_error(err: &serde_saphyr::Error) -> Self {
+        if is_substitution_error(err) {
+            Self::Substitution
+        } else {
+            Self::Yaml
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            Self::Substitution => "martin::config::substitution",
+            Self::Yaml => "martin::config::yaml",
+        }
+    }
+
+    fn help(self) -> &'static str {
+        match self {
+            Self::Substitution => {
+                "Make sure every ${VAR} reference resolves to an environment variable, or supply a default with `${VAR:-fallback}`."
+            }
+            Self::Yaml => {
+                "Check the highlighted token in your YAML. The error usually indicates a mismatched type or an unexpected shape."
+            }
+        }
     }
 }
 
-impl std::error::Error for SubstitutionReport {}
+fn is_substitution_error(err: &serde_saphyr::Error) -> bool {
+    fn check(err: &serde_saphyr::Error) -> bool {
+        matches!(
+            err,
+            serde_saphyr::Error::UnresolvedProperty { .. }
+                | serde_saphyr::Error::InvalidPropertyName { .. }
+                | serde_saphyr::Error::PropertyRequiredButUnset { .. }
+                | serde_saphyr::Error::PropertyRequiredButEmpty { .. }
+        )
+    }
+    // `with_snippet` is disabled at parse time so we don't expect the wrapping
+    // variant, but handle it defensively in case that ever changes.
+    if let serde_saphyr::Error::WithSnippet { error, .. } = err {
+        check(error)
+    } else {
+        check(err)
+    }
+}
 
-impl Diagnostic for SubstitutionReport {
+/// Wrapper that delegates [`Diagnostic`] queries to saphyr's report while attaching
+/// martin's own `code` / `help` / `url`.
+///
+/// Saphyr emits a minimal `Diagnostic` (just the source, labels, and message); we layer
+/// the substitution-aware metadata on top so JSON consumers get a stable code and the
+/// graphical renderer keeps the help line at the bottom.
+#[derive(Debug)]
+struct YamlParseReport {
+    inner: miette::Report,
+    kind: YamlReportKind,
+}
+
+impl YamlParseReport {
+    fn inner_diag(&self) -> &(dyn Diagnostic + 'static) {
+        <miette::Report as AsRef<dyn Diagnostic>>::as_ref(&self.inner)
+    }
+}
+
+impl std::fmt::Display for YamlParseReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.inner_diag(), f)
+    }
+}
+
+impl std::error::Error for YamlParseReport {}
+
+impl Diagnostic for YamlParseReport {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        Some(Box::new("martin::config::substitution"))
+        Some(Box::new(self.kind.code()))
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        Some(Box::new(
-            "Make sure every ${VAR} reference resolves to an environment variable, or supply a default with `${VAR:-fallback}`.",
-        ))
+        Some(Box::new(self.kind.help()))
     }
 
     fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         Some(Box::new("https://maplibre.org/martin/config-file/"))
     }
 
+    fn severity(&self) -> Option<miette::Severity> {
+        self.inner_diag().severity()
+    }
+
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        Some(&self.named_source)
+        self.inner_diag().source_code()
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        let span = self.primary_span?;
-        let label = LabeledSpan::new_primary_with_span(Some(self.label_text.clone()), span);
-        Some(Box::new(std::iter::once(label)))
+        self.inner_diag().labels()
+    }
+
+    fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>> {
+        self.inner_diag().related()
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        self.inner_diag().diagnostic_source()
     }
 }
 
@@ -195,7 +245,6 @@ impl Diagnostic for ConfigFileError {
             Self::ConfigLoadError(..) => "martin::config::io::load",
             Self::ConfigWriteError(..) => "martin::config::io::write",
             Self::YamlParseError { .. } => "martin::config::yaml",
-            Self::SubstitutionError { .. } => "martin::config::substitution",
             Self::NoSources => "martin::config::no_sources",
             Self::InvalidFilePath(_) => "martin::config::invalid_file_path",
             Self::InvalidSourceUrl(..) => "martin::config::invalid_source_url",
@@ -230,9 +279,6 @@ impl Diagnostic for ConfigFileError {
             Self::CorsNoOriginsConfigured => {
                 "Either set `cors: true` (allow all origins) or provide at least one entry in `origin` under the cors block."
             }
-            Self::SubstitutionError { .. } => {
-                "Make sure every ${VAR} reference resolves to an environment variable, or supply a default with `${VAR:-fallback}`."
-            }
             Self::YamlParseError { .. } => {
                 "Check the highlighted token in your YAML. The error usually indicates a mismatched type or an unexpected shape."
             }
@@ -251,27 +297,11 @@ impl Diagnostic for ConfigFileError {
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
         // `YamlParseError` is rendered through `serde_saphyr::miette::to_miette_report` in
-        // `to_miette_report`, which carries its own source/labels - we only surface
-        // `source_code` for the substitution path so direct consumers of the `Diagnostic`
-        // trait still get useful output.
-        match self {
-            Self::SubstitutionError(details) => Some(&details.named_source),
-            _ => None,
-        }
+        // `to_miette_report`, which carries its own source/labels.
+        None
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        let Self::SubstitutionError(details) = self else {
-            return None;
-        };
-        let span = details.primary_span?;
-        let label = LabeledSpan::new_primary_with_span(Some(details.source.to_string()), span);
-        Some(Box::new(std::iter::once(label)))
+        None
     }
-}
-
-/// Locate the failing token in `source_text` that corresponds to a substitution failure.
-fn subst_error_span(error: &subst::Error, source_text: &str) -> Option<SourceSpan> {
-    let range = error.source_range();
-    (range.start < source_text.len()).then(|| SourceSpan::new(range.start.into(), range.len()))
 }

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1213,7 +1213,7 @@ mod deserialize_tests {
     fn file_config_enum_rejects_integer() {
         insta::assert_snapshot!(render_failure("pmtiles: 42\n"), @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: integer `42`, expected a path string, a list of path
           │ strings, or a configuration map with `paths` and/or `sources`
            ╭─[config.yaml:1:1]
@@ -1231,7 +1231,7 @@ mod deserialize_tests {
     fn file_config_enum_rejects_bool() {
         insta::assert_snapshot!(render_failure("pmtiles: true\n"), @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: boolean `true`, expected a path string, a list of path
           │ strings, or a configuration map with `paths` and/or `sources`
            ╭─[config.yaml:1:1]
@@ -1255,7 +1255,7 @@ mod deserialize_tests {
             "}),
             @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × unexpected event: expected string scalar
            ╭─[config.yaml:3:7]
          2 │   paths:
@@ -1371,7 +1371,7 @@ mod deserialize_tests {
     fn global_cache_rejects_other_string() {
         insta::assert_snapshot!(render_failure("cache: enable\n"), @r#"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid cache config string "enable"; the only accepted string form is
           │ `disable`
            ╭─[config.yaml:1:8]
@@ -1388,7 +1388,7 @@ mod deserialize_tests {
     fn global_cache_rejects_integer() {
         insta::assert_snapshot!(render_failure("cache: 42\n"), @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: integer `42`, expected either the literal `disable` or a
           │ cache configuration map (e.g. `{ size_mb: 512, tile_size_mb: 256 }`)
            ╭─[config.yaml:1:1]

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1212,13 +1212,17 @@ mod deserialize_tests {
     #[cfg(feature = "pmtiles")]
     fn file_config_enum_rejects_integer() {
         insta::assert_snapshot!(render_failure("pmtiles: 42\n"), @"
-         × invalid type: integer `42`, expected a path string, a list of path
-         │ strings, or a configuration map with `paths` and/or `sources`
-          ╭─[config.yaml:1:1]
-        1 │ pmtiles: 42
-          · ───┬───
-          ·    ╰── invalid type: integer `42`, expected a path string, a list of path strings, or a configuration map with `paths` and/or `sources`
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: integer `42`, expected a path string, a list of path
+          │ strings, or a configuration map with `paths` and/or `sources`
+           ╭─[config.yaml:1:1]
+         1 │ pmtiles: 42
+           · ───┬───
+           ·    ╰── invalid type: integer `42`, expected a path string, a list of path strings, or a configuration map with `paths` and/or `sources`
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 
@@ -1226,13 +1230,17 @@ mod deserialize_tests {
     #[cfg(feature = "pmtiles")]
     fn file_config_enum_rejects_bool() {
         insta::assert_snapshot!(render_failure("pmtiles: true\n"), @"
-         × invalid type: boolean `true`, expected a path string, a list of path
-         │ strings, or a configuration map with `paths` and/or `sources`
-          ╭─[config.yaml:1:1]
-        1 │ pmtiles: true
-          · ───┬───
-          ·    ╰── invalid type: boolean `true`, expected a path string, a list of path strings, or a configuration map with `paths` and/or `sources`
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: boolean `true`, expected a path string, a list of path
+          │ strings, or a configuration map with `paths` and/or `sources`
+           ╭─[config.yaml:1:1]
+         1 │ pmtiles: true
+           · ───┬───
+           ·    ╰── invalid type: boolean `true`, expected a path string, a list of path strings, or a configuration map with `paths` and/or `sources`
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 
@@ -1246,13 +1254,17 @@ mod deserialize_tests {
                     - { not_a_path: true }
             "}),
             @"
-         × unexpected event: expected string scalar
-          ╭─[config.yaml:3:7]
-        2 │   paths:
-        3 │     - { not_a_path: true }
-          ·       ─┬
-          ·        ╰── unexpected event: expected string scalar
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × unexpected event: expected string scalar
+           ╭─[config.yaml:3:7]
+         2 │   paths:
+         3 │     - { not_a_path: true }
+           ·       ─┬
+           ·        ╰── unexpected event: expected string scalar
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "
         );
     }
@@ -1358,26 +1370,34 @@ mod deserialize_tests {
     #[test]
     fn global_cache_rejects_other_string() {
         insta::assert_snapshot!(render_failure("cache: enable\n"), @r#"
-         × invalid cache config string "enable"; the only accepted string form is
-         │ `disable`
-          ╭─[config.yaml:1:8]
-        1 │ cache: enable
-          ·        ───┬──
-          ·           ╰── invalid cache config string "enable"; the only accepted string form is `disable`
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid cache config string "enable"; the only accepted string form is
+          │ `disable`
+           ╭─[config.yaml:1:8]
+         1 │ cache: enable
+           ·        ───┬──
+           ·           ╰── invalid cache config string "enable"; the only accepted string form is `disable`
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "#);
     }
 
     #[test]
     fn global_cache_rejects_integer() {
         insta::assert_snapshot!(render_failure("cache: 42\n"), @"
-         × invalid type: integer `42`, expected either the literal `disable` or a
-         │ cache configuration map (e.g. `{ size_mb: 512, tile_size_mb: 256 }`)
-          ╭─[config.yaml:1:1]
-        1 │ cache: 42
-          · ──┬──
-          ·   ╰── invalid type: integer `42`, expected either the literal `disable` or a cache configuration map (e.g. `{ size_mb: 512, tile_size_mb: 256 }`)
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: integer `42`, expected either the literal `disable` or a
+          │ cache configuration map (e.g. `{ size_mb: 512, tile_size_mb: 256 }`)
+           ╭─[config.yaml:1:1]
+         1 │ cache: 42
+           · ──┬──
+           ·   ╰── invalid type: integer `42`, expected either the literal `disable` or a cache configuration map (e.g. `{ size_mb: 512, tile_size_mb: 256 }`)
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 
@@ -1620,8 +1640,12 @@ mod folder_source_tests {
     #[tokio::test]
     async fn one_good_one_bad() {
         let (sources, warnings) = resolve_mixed_dir(1, 1).await;
-        assert_yaml_snapshot!(sources, @"- good_0");
-        assert_yaml_snapshot!(warnings, @r#"- "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles""#);
+        assert_yaml_snapshot!(sources, @"
+        - good_0
+        ");
+        assert_yaml_snapshot!(warnings, @r#"
+        - "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles"
+        "#);
     }
 
     #[tokio::test]
@@ -1640,7 +1664,9 @@ mod folder_source_tests {
     #[tokio::test]
     async fn all_bad() {
         let (sources, warnings) = resolve_mixed_dir(0, 2).await;
-        assert_yaml_snapshot!(sources, @"[]");
+        assert_yaml_snapshot!(sources, @"
+        []
+        ");
         assert_yaml_snapshot!(warnings, @r#"
         - "Path <DIR>/bad_0.tiles: Source path is not a file: <DIR>/bad_0.tiles"
         - "Path <DIR>/bad_1.tiles: Source path is not a file: <DIR>/bad_1.tiles"
@@ -1654,7 +1680,9 @@ mod folder_source_tests {
         - good_0
         - good_1
         ");
-        assert_yaml_snapshot!(warnings, @"[]");
+        assert_yaml_snapshot!(warnings, @"
+        []
+        ");
     }
 }
 

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "_tiles")]
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs::File;
@@ -18,8 +17,9 @@ use martin_core::tiles::BoxedSource;
 #[cfg(feature = "pmtiles")]
 use martin_core::tiles::pmtiles::PmtCache;
 use serde::{Deserialize, Serialize};
-use subst::VariableMap;
 use tracing::{error, info, instrument, warn};
+
+use crate::config::primitives::env::Env;
 
 #[cfg(feature = "unstable-cog")]
 use super::cog::CogConfig;
@@ -730,52 +730,176 @@ impl OnInvalid {
     }
 }
 
-/// Read config from a file
-pub fn read_config<'a, M>(file_name: &Path, env: &'a M) -> ConfigFileResult<Config>
-where
-    M: VariableMap<'a>,
-    M::Value: AsRef<str>,
-{
+/// Read config from a file.
+///
+/// Reads the file, parses it through [`parse_config`], and records which
+/// `${VAR}` / `$VAR` names appeared in the source so callers of
+/// [`Env::has_unused_var`] can warn about env vars that were set but not
+/// referenced by the config.
+pub fn read_config(file_name: &Path, env: &impl Env) -> ConfigFileResult<Config> {
     let contents = std::fs::read_to_string(file_name)
         .map_err(|e| ConfigFileError::ConfigLoadError(e, file_name.into()))?;
-    parse_config(&contents, env, file_name)
+    env.note_referenced(scan_referenced_vars(&contents));
+    parse_config(&contents, &env.as_property_map(), file_name)
 }
 
-pub fn parse_config<'a, M>(contents: &str, env: &'a M, file_name: &Path) -> ConfigFileResult<Config>
-where
-    M: VariableMap<'a>,
-    M::Value: AsRef<str>,
-{
-    // Phase 1: substitute environment variables at the text level so saphyr's spans line up
-    // with the post-substitution text the parser actually sees.
-    let substituted = subst::substitute(contents, env)
-        .map_err(|e| ConfigFileError::substitution(e, contents.to_string(), file_name))?;
-
-    // Phase 2: rewrite deprecated cache keys via a `serde_yaml::Value` round-trip - but only
+/// Parse a YAML configuration string into a [`Config`].
+///
+/// `properties` is the property map handed to `serde-saphyr` for `${VAR}` /
+/// `$VAR` substitution inside plain YAML scalars. Comments and quoted scalars
+/// are not interpolated (delegated entirely to `serde-saphyr`'s `properties`
+/// feature). For real env-var access, build the map via [`Env::as_property_map`].
+pub fn parse_config(
+    contents: &str,
+    properties: &HashMap<String, String>,
+    file_name: &Path,
+) -> ConfigFileResult<Config> {
+    // Phase 1: rewrite deprecated cache keys via a `serde_yaml::Value` round-trip - but only
     // if at least one deprecated token appears in the text. The common case (no deprecated
     // keys) skips a full YAML parse + serialize.
-    let migrated = if needs_deprecated_migration(&substituted) {
-        match serde_yaml::from_str::<serde_yaml::Value>(&substituted) {
+    //
+    // We migrate *before* saphyr-driven substitution so saphyr still sees the original
+    // `${VAR}` tokens in scalar values. `serde_yaml`'s emitter round-trips plain scalars
+    // starting with `$` as plain (YAML 1.1 doesn't reserve `$`), preserving substitution.
+    let migrated = if needs_deprecated_migration(contents) {
+        match serde_yaml::from_str::<serde_yaml::Value>(contents) {
             Ok(mut value) => {
                 migrate_deprecated_config(&mut value);
-                serde_yaml::to_string(&value).unwrap_or(substituted)
+                serde_yaml::to_string(&value).unwrap_or_else(|_| contents.to_string())
             }
             // If serde_yaml itself can't parse, hand the original to saphyr - its diagnostics
             // are richer, so let it produce the user-facing error.
-            Err(_) => substituted,
+            Err(_) => contents.to_string(),
         }
     } else {
-        substituted
+        contents.to_string()
     };
 
-    // Phase 3: parse to the typed `Config` via saphyr. We disable saphyr's built-in snippet
-    // wrapper so its hardcoded `<input>` source name doesn't override the file path we show;
-    // `ConfigFileError::to_miette_report` re-attaches a snippet against our own NamedSource.
+    // Phase 2: parse to the typed `Config` via saphyr with `properties` enabled.
+    //
+    // `PropertySyntax::BracedOrBare` matches the legacy `subst` syntax we used before this
+    // migration: both `${VAR}` and the unbraced `$VAR` are recognized. Substitution only
+    // happens inside *plain* scalars - comments and quoted strings are not interpolated,
+    // which is the whole point of moving away from the previous text-level pre-processor.
+    //
+    // We disable saphyr's built-in snippet wrapper so its hardcoded `<input>` source name
+    // doesn't override the file path we show; `ConfigFileError::to_miette_report`
+    // re-attaches a snippet against our own NamedSource.
     let options = serde_saphyr::options! {
         with_snippet: false,
-    };
+        property_syntax: serde_saphyr::options::PropertySyntax::BracedOrBare,
+    }
+    .with_properties(properties.clone());
+
     serde_saphyr::from_str_with_options::<Config>(&migrated, options)
         .map_err(|e| ConfigFileError::yaml_parse(e, migrated, file_name))
+}
+
+/// Scan plain YAML text for `${VAR}` and `$VAR` references, ignoring comments,
+/// quoted strings, and `$$` escapes. Used by [`read_config`] to populate the
+/// "referenced" set on [`Env`].
+///
+/// The result is a best-effort superset of names saphyr will actually look up:
+/// it tracks every plausible variable token in the source so `has_unused_var`
+/// stays conservative ("not seen" → really not used).
+fn scan_referenced_vars(contents: &str) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let mut chars = contents.char_indices().peekable();
+    let bytes = contents.as_bytes();
+
+    while let Some((i, ch)) = chars.next() {
+        match ch {
+            '#' => {
+                // skip the rest of the line
+                for (_, c) in chars.by_ref() {
+                    if c == '\n' {
+                        break;
+                    }
+                }
+            }
+            '"' | '\'' => {
+                // skip quoted scalar (single or double quoted, no escape handling needed
+                // because we only care about `$` tokens — anything inside quotes is ignored)
+                let quote = ch;
+                while let Some((_, c)) = chars.next() {
+                    if c == '\\' && quote == '"' {
+                        chars.next();
+                        continue;
+                    }
+                    if c == quote {
+                        break;
+                    }
+                }
+            }
+            '$' => {
+                // `$$` is the escape for a literal `$`, skip it
+                if bytes.get(i + 1).copied() == Some(b'$') {
+                    chars.next();
+                    continue;
+                }
+                if let Some((name, end)) = parse_var_token(contents, i + 1) {
+                    out.insert(name);
+                    // advance past the consumed token
+                    while let Some(&(j, _)) = chars.peek() {
+                        if j < end {
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Parse a `${NAME}` or `$NAME` variable token starting at `start` (the index
+/// just past the leading `$`). Returns `(name, end_index_exclusive)` if a
+/// token is present, otherwise `None`.
+#[expect(
+    clippy::string_slice,
+    reason = "indices come from byte-safe positions (find on ASCII, char_indices boundaries)"
+)]
+fn parse_var_token(contents: &str, start: usize) -> Option<(String, usize)> {
+    let rest = contents.get(start..)?;
+    if let Some(body) = rest.strip_prefix('{') {
+        let close = body.find('}')?;
+        let body = &body[..close];
+        // body may carry a modifier like `:-default`, `?msg`, etc - strip after the name
+        let name_end = body
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(body.len());
+        let name = &body[..name_end];
+        if name.is_empty() || !is_var_start(name.chars().next()?) {
+            return None;
+        }
+        Some((name.to_string(), start + 1 + close + 1))
+    } else {
+        let mut end = 0;
+        for (i, c) in rest.char_indices() {
+            if i == 0 {
+                if !is_var_start(c) {
+                    return None;
+                }
+                end = c.len_utf8();
+            } else if c.is_ascii_alphanumeric() || c == '_' {
+                end = i + c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        if end == 0 {
+            None
+        } else {
+            Some((rest[..end].to_string(), start + end))
+        }
+    }
+}
+
+fn is_var_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
 }
 
 /// Cheap pre-check: does the substituted YAML mention any deprecated cache key?
@@ -930,13 +1054,17 @@ mod tests {
                   worker_processes: 4
             "#}),
             @r#"
-         × invalid indentation in multiline quoted scalar
-          ╭─[config.yaml:3:3]
-        2 │   listen_addresses: "0.0.0.0:3000
-        3 │   worker_processes: 4
-          ·   ┬
-          ·   ╰── invalid indentation in multiline quoted scalar
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+
+          × invalid indentation in multiline quoted scalar
+           ╭─[config.yaml:3:3]
+         2 │   listen_addresses: "0.0.0.0:3000
+         3 │   worker_processes: 4
+           ·   ┬
+           ·   ╰── invalid indentation in multiline quoted scalar
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "#
         );
     }
@@ -944,13 +1072,17 @@ mod tests {
     #[test]
     fn unknown_enum_variant_in_on_invalid() {
         insta::assert_snapshot!(render_failure("on_invalid: maybe\n"), @"
-         × unknown variant `maybe`, expected one of continue, ignore, warn, warning,
-         │ warnings, abort
-          ╭─[config.yaml:1:13]
-        1 │ on_invalid: maybe
-          ·             ──┬──
-          ·               ╰── unknown variant `maybe`, expected one of continue, ignore, warn, warning, warnings, abort
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+
+          × unknown variant `maybe`, expected one of continue, ignore, warn, warning,
+          │ warnings, abort
+           ╭─[config.yaml:1:13]
+         1 │ on_invalid: maybe
+           ·             ──┬──
+           ·               ╰── unknown variant `maybe`, expected one of continue, ignore, warn, warning, warnings, abort
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
     }
 
@@ -959,12 +1091,12 @@ mod tests {
         insta::assert_snapshot!(render_failure("cache_size_mb: ${UNDEFINED_VAR}\n"), @"
         martin::config::substitution (https://maplibre.org/martin/config-file/)
 
-          × Unable to substitute environment variables in config file config.yaml: No
-          │ such variable: $UNDEFINED_VAR
-           ╭─[config.yaml:1:18]
-         1 │ cache_size_mb: ${UNDEFINED_VAR}
-           ·                  ──────┬──────
-           ·                        ╰── No such variable: $UNDEFINED_VAR
+          × missing property `UNDEFINED_VAR`
+           ╭─[config.yaml:2:12]
+         1 │ cache:
+         2 │   size_mb: ${UNDEFINED_VAR}
+           ·            ────────┬───────
+           ·                    ╰── missing property `UNDEFINED_VAR`
            ╰────
           help: Make sure every ${VAR} reference resolves to an environment variable,
                 or supply a default with `${VAR:-fallback}`.
@@ -1041,19 +1173,56 @@ mod tests {
 
     #[test]
     fn substitution_unclosed_brace() {
+        // Saphyr treats `${BROKEN` (no closing brace) as a literal scalar value rather
+        // than a substitution token, so the error surfaces during type coercion to u64
+        // rather than during substitution. The diagnostic still points at the offending
+        // token, just with `martin::config::yaml` framing.
         insta::assert_snapshot!(render_failure("cache_size_mb: ${BROKEN\n"), @r"
-        martin::config::substitution (https://maplibre.org/martin/config-file/)
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
 
-          × Unable to substitute environment variables in config file config.yaml:
-          │ Unexpected character: '\n', expected a closing brace ('}') or colon (':')
-           ╭─[config.yaml:1:24]
-         1 │ cache_size_mb: ${BROKEN
-           ·                        ┬
-           ·                        ╰── Unexpected character: '\n', expected a closing brace ('}') or colon (':')
+          × invalid u64
+           ╭─[config.yaml:2:12]
+         1 │ cache:
+         2 │   size_mb: ${BROKEN
+           ·            ────┬───
+           ·                ╰── invalid u64
            ╰────
-          help: Make sure every ${VAR} reference resolves to an environment variable,
-                or supply a default with `${VAR:-fallback}`.
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         ");
+    }
+
+    /// Regression for https://github.com/maplibre/martin/issues/2851.
+    ///
+    /// The pre-saphyr substitution pass scanned the raw config text and tried to
+    /// resolve every `${VAR}` it saw — including ones inside YAML comments. The
+    /// saphyr `properties` feature interpolates only inside plain scalar values,
+    /// so the same config that used to abort startup now parses cleanly.
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn substitution_ignores_dollar_tokens_in_comments() {
+        let yaml = indoc::indoc! {r"
+            # Database configuration. This can also be a list of PG configs.
+            postgres:
+              # Database connection string. You can use env vars too, for example:
+              #   $DATABASE_URL
+              #   ${DATABASE_URL:-postgresql://postgres@localhost/db}
+              connection_string: 'postgres://postgres:postgres@db:5432/ehrenamtskarte'
+        "};
+        let config = parse_config(
+            yaml,
+            &HashMap::<String, String>::new(),
+            Path::new("config.yaml"),
+        )
+        .expect("comments containing ${VAR} must not trigger substitution");
+        let one = match config.postgres {
+            OptOneMany::One(pg) => pg,
+            other => panic!("expected exactly one postgres config, got: {other:?}"),
+        };
+        assert_eq!(
+            one.connection_string.as_deref(),
+            Some("postgres://postgres:postgres@db:5432/ehrenamtskarte"),
+        );
     }
 
     #[test]

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -1192,7 +1192,7 @@ mod tests {
         ");
     }
 
-    /// Regression for https://github.com/maplibre/martin/issues/2851.
+    /// Regression for <https://github.com/maplibre/martin/issues/2851>.
     ///
     /// The pre-saphyr substitution pass scanned the raw config text and tried to
     /// resolve every `${VAR}` it saw -- including ones inside YAML comments. The

--- a/martin/src/config/file/main.rs
+++ b/martin/src/config/file/main.rs
@@ -819,7 +819,7 @@ fn scan_referenced_vars(contents: &str) -> std::collections::HashSet<String> {
             }
             '"' | '\'' => {
                 // skip quoted scalar (single or double quoted, no escape handling needed
-                // because we only care about `$` tokens — anything inside quotes is ignored)
+                // because we only care about `$` tokens -- anything inside quotes is ignored)
                 let quote = ch;
                 while let Some((_, c)) = chars.next() {
                     if c == '\\' && quote == '"' {
@@ -1195,7 +1195,7 @@ mod tests {
     /// Regression for https://github.com/maplibre/martin/issues/2851.
     ///
     /// The pre-saphyr substitution pass scanned the raw config text and tried to
-    /// resolve every `${VAR}` it saw — including ones inside YAML comments. The
+    /// resolve every `${VAR}` it saw -- including ones inside YAML comments. The
     /// saphyr `properties` feature interpolates only inside plain scalar values,
     /// so the same config that used to abort startup now parses cleanly.
     #[cfg(feature = "postgres")]

--- a/martin/src/config/file/tiles/postgres/config.rs
+++ b/martin/src/config/file/tiles/postgres/config.rs
@@ -447,10 +447,10 @@ mod tests {
     use crate::config::file::postgres::{FunctionInfo, TableInfo};
     use crate::config::file::{Config, parse_config};
     use crate::config::primitives::OptOneMany::{Many, One};
-    use crate::config::primitives::env::FauxEnv;
+    use std::collections::HashMap;
 
     pub fn parse_cfg(yaml: &str) -> Config {
-        parse_config(yaml, &FauxEnv::default(), Path::new("<test>")).unwrap()
+        parse_config(yaml, &HashMap::new(), Path::new("<test>")).unwrap()
     }
 
     pub fn assert_config(yaml: &str, expected: &Config) {

--- a/martin/src/config/primitives/env.rs
+++ b/martin/src/config/primitives/env.rs
@@ -89,7 +89,7 @@ impl Env for OsEnv {
 ///
 /// The tuple shape (`FauxEnv(map)`) is preserved from the pre-saphyr era so
 /// existing test fixtures keep compiling. Reference-tracking is intentionally
-/// omitted — the `has_unused_var` warning is only consumed by the
+/// omitted -- the `has_unused_var` warning is only consumed by the
 /// `postgres`-CLI override path, which the unit tests don't exercise.
 #[derive(Debug, Default)]
 pub struct FauxEnv(pub HashMap<&'static str, OsString>);

--- a/martin/src/config/primitives/env.rs
+++ b/martin/src/config/primitives/env.rs
@@ -1,23 +1,23 @@
-//! Environment variable access with substitution tracking.
+//! Environment variable access for config parsing and CLI handling.
 //!
-//! Provides [`Env`] trait for environment access that can be mocked in tests
-//! and tracks variable usage during configuration substitution.
+//! Provides [`Env`] trait for environment access that can be mocked in tests.
+//! Substitution of `${VAR}` references inside YAML scalars is performed by
+//! `serde-saphyr`'s `properties` feature; this module supplies the property map
+//! and tracks which variable names appeared in the YAML so CLI argument code
+//! can warn about env vars that were set but never referenced.
 //!
 //! - [`OsEnv`]: Production implementation
 //! - [`FauxEnv`]: Test implementation
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::env;
 use std::ffi::OsString;
-use std::{collections, env};
 
-use subst::VariableMap;
 use tracing::warn;
 
-/// Environment variable access with Unicode validation and usage tracking.
-///
-/// Extends [`VariableMap`] to enable mocking in tests and track unused variables.
-pub trait Env<'a>: VariableMap<'a> {
+/// Environment variable access with Unicode validation and reference tracking.
+pub trait Env {
     /// Get an environment variable as an [`OsString`] without Unicode validation.
     fn var_os(&self, key: &str) -> Option<OsString>;
 
@@ -41,20 +41,43 @@ pub trait Env<'a>: VariableMap<'a> {
         }
     }
 
-    /// Check if an environment variable exists but was not accessed during substitution.
+    /// Build the property map handed to `serde-saphyr` for `${VAR}` interpolation.
+    ///
+    /// Production implementations snapshot the process environment; test fixtures
+    /// return only their configured variables.
+    #[must_use]
+    fn as_property_map(&self) -> HashMap<String, String>;
+
+    /// Record which variable names appeared in the YAML text just parsed.
+    ///
+    /// Saphyr resolves references silently against the property map, so callers
+    /// pre-scan the YAML for `${VAR}` / `$VAR` tokens and feed the set here.
+    /// Used by [`Env::has_unused_var`]. Default impl is a no-op for fixtures
+    /// that don't need the warning UX.
+    fn note_referenced(&self, _names: HashSet<String>) {}
+
+    /// Check if an environment variable is set but was not referenced in the YAML
+    /// substitution map. Returns `false` for any var that has not been observed,
+    /// so callers must call [`Env::note_referenced`] before this is meaningful.
     #[must_use]
     fn has_unused_var(&self, key: &str) -> bool;
 }
 
 /// Production implementation that accesses system environment variables.
-///
-/// Tracks which variables are accessed via [`VariableMap`] using interior mutability.
 #[derive(Debug, Default)]
 pub struct OsEnv(RefCell<HashSet<String>>);
 
-impl Env<'_> for OsEnv {
+impl Env for OsEnv {
     fn var_os(&self, key: &str) -> Option<OsString> {
         env::var_os(key)
+    }
+
+    fn as_property_map(&self) -> HashMap<String, String> {
+        env::vars().collect()
+    }
+
+    fn note_referenced(&self, names: HashSet<String>) {
+        *self.0.borrow_mut() = names;
     }
 
     fn has_unused_var(&self, key: &str) -> bool {
@@ -62,30 +85,31 @@ impl Env<'_> for OsEnv {
     }
 }
 
-impl<'a> VariableMap<'a> for OsEnv {
-    type Value = String;
-
-    fn get(&'a self, key: &str) -> Option<Self::Value> {
-        self.0.borrow_mut().insert(key.to_string());
-        env::var(key).ok()
-    }
-}
-
 /// Test implementation with configurable environment variables.
+///
+/// The tuple shape (`FauxEnv(map)`) is preserved from the pre-saphyr era so
+/// existing test fixtures keep compiling. Reference-tracking is intentionally
+/// omitted — the `has_unused_var` warning is only consumed by the
+/// `postgres`-CLI override path, which the unit tests don't exercise.
 #[derive(Debug, Default)]
-pub struct FauxEnv(pub collections::HashMap<&'static str, OsString>);
+pub struct FauxEnv(pub HashMap<&'static str, OsString>);
 
-impl<'a> VariableMap<'a> for FauxEnv {
-    type Value = String;
-
-    fn get(&'a self, key: &str) -> Option<Self::Value> {
-        self.0.get(key).map(|s| s.to_string_lossy().to_string())
+impl FromIterator<(&'static str, OsString)> for FauxEnv {
+    fn from_iter<I: IntoIterator<Item = (&'static str, OsString)>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 
-impl Env<'_> for FauxEnv {
+impl Env for FauxEnv {
     fn var_os(&self, key: &str) -> Option<OsString> {
         self.0.get(key).map(Into::into)
+    }
+
+    fn as_property_map(&self) -> HashMap<String, String> {
+        self.0
+            .iter()
+            .filter_map(|(k, v)| v.to_str().map(|s| ((*k).to_string(), s.to_string())))
+            .collect()
     }
 
     fn has_unused_var(&self, key: &str) -> bool {
@@ -102,7 +126,7 @@ mod tests {
         let env = FauxEnv::default();
         assert_eq!(env.get_env_str("FOO"), None);
 
-        let env = FauxEnv(vec![("FOO", OsString::from("bar"))].into_iter().collect());
+        let env: FauxEnv = vec![("FOO", OsString::from("bar"))].into_iter().collect();
         assert_eq!(env.get_env_str("FOO"), Some("bar".to_string()));
     }
 
@@ -114,7 +138,7 @@ mod tests {
 
         let bad_utf8 = [0x66, 0x6f, 0x80, 0x6f];
         let os_str = OsStr::from_bytes(&bad_utf8[..]);
-        let env = FauxEnv(vec![("BAD", os_str.to_owned())].into_iter().collect());
+        let env: FauxEnv = vec![("BAD", os_str.to_owned())].into_iter().collect();
         assert!(env.0.contains_key("BAD"));
         assert_eq!(env.get_env_str("BAD"), None);
     }

--- a/martin/src/config/primitives/opt_bool_obj.rs
+++ b/martin/src/config/primitives/opt_bool_obj.rs
@@ -134,14 +134,18 @@ mod tests {
                   auto_publish: yes-please
             "}),
             @r#"
-         × invalid type: string "yes-please", expected either a boolean or a
-         │ configuration map
-          ╭─[config.yaml:3:3]
-        2 │   connection_string: postgres://localhost/db
-        3 │   auto_publish: yes-please
-          ·   ──────┬─────
-          ·         ╰── invalid type: string "yes-please", expected either a boolean or a configuration map
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: string "yes-please", expected either a boolean or a
+          │ configuration map
+           ╭─[config.yaml:3:3]
+         2 │   connection_string: postgres://localhost/db
+         3 │   auto_publish: yes-please
+           ·   ──────┬─────
+           ·         ╰── invalid type: string "yes-please", expected either a boolean or a configuration map
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "#
         );
     }
@@ -156,14 +160,18 @@ mod tests {
                   auto_publish: 42
             "}),
             @"
-         × invalid type: integer `42`, expected either a boolean or a configuration
-         │ map
-          ╭─[config.yaml:3:3]
-        2 │   connection_string: postgres://localhost/db
-        3 │   auto_publish: 42
-          ·   ──────┬─────
-          ·         ╰── invalid type: integer `42`, expected either a boolean or a configuration map
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: integer `42`, expected either a boolean or a configuration
+          │ map
+           ╭─[config.yaml:3:3]
+         2 │   connection_string: postgres://localhost/db
+         3 │   auto_publish: 42
+           ·   ──────┬─────
+           ·         ╰── invalid type: integer `42`, expected either a boolean or a configuration map
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "
         );
     }
@@ -178,13 +186,17 @@ mod tests {
                   auto_publish: [a, b]
             "}),
             @"
-         × invalid type: sequence, expected either a boolean or a configuration map
-          ╭─[config.yaml:3:3]
-        2 │   connection_string: postgres://localhost/db
-        3 │   auto_publish: [a, b]
-          ·   ──────┬─────
-          ·         ╰── invalid type: sequence, expected either a boolean or a configuration map
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × invalid type: sequence, expected either a boolean or a configuration map
+           ╭─[config.yaml:3:3]
+         2 │   connection_string: postgres://localhost/db
+         3 │   auto_publish: [a, b]
+           ·   ──────┬─────
+           ·         ╰── invalid type: sequence, expected either a boolean or a configuration map
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "
         );
     }

--- a/martin/src/config/primitives/opt_bool_obj.rs
+++ b/martin/src/config/primitives/opt_bool_obj.rs
@@ -135,7 +135,7 @@ mod tests {
             "}),
             @r#"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: string "yes-please", expected either a boolean or a
           │ configuration map
            ╭─[config.yaml:3:3]
@@ -161,7 +161,7 @@ mod tests {
             "}),
             @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: integer `42`, expected either a boolean or a configuration
           │ map
            ╭─[config.yaml:3:3]
@@ -187,7 +187,7 @@ mod tests {
             "}),
             @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × invalid type: sequence, expected either a boolean or a configuration map
            ╭─[config.yaml:3:3]
          2 │   connection_string: postgres://localhost/db

--- a/martin/src/config/primitives/opt_one_many.rs
+++ b/martin/src/config/primitives/opt_one_many.rs
@@ -248,14 +248,18 @@ mod tests {
                     - second
             "}),
             @"
-         × unexpected event: expected string scalar
-          ╭─[config.yaml:3:5]
-        2 │   connection_string:
-        3 │     - first
-          ·     ┬
-          ·     ╰── unexpected event: expected string scalar
-        4 │     - second
-          ╰────
+        martin::config::yaml (https://maplibre.org/martin/config-file/)
+        
+          × unexpected event: expected string scalar
+           ╭─[config.yaml:3:5]
+         2 │   connection_string:
+         3 │     - first
+           ·     ┬
+           ·     ╰── unexpected event: expected string scalar
+         4 │     - second
+           ╰────
+          help: Check the highlighted token in your YAML. The error usually indicates
+                a mismatched type or an unexpected shape.
         "
         );
     }

--- a/martin/src/config/primitives/opt_one_many.rs
+++ b/martin/src/config/primitives/opt_one_many.rs
@@ -249,7 +249,7 @@ mod tests {
             "}),
             @"
         martin::config::yaml (https://maplibre.org/martin/config-file/)
-        
+
           × unexpected event: expected string scalar
            ╭─[config.yaml:3:5]
          2 │   connection_string:

--- a/martin/tests/utils.rs
+++ b/martin/tests/utils.rs
@@ -10,21 +10,21 @@ use martin::config::file::postgres::TableInfo;
 use martin::config::file::{Config, ServerState, parse_config};
 #[cfg(feature = "_tiles")]
 use martin::config::primitives::IdResolver;
-use martin::config::primitives::env::FauxEnv;
+use martin::config::primitives::env::{Env as _, FauxEnv};
 #[cfg(feature = "_tiles")]
 use martin_core::tiles::BoxedSource;
 use tracing::warn;
 
 #[must_use]
 pub fn mock_cfg(yaml: &str) -> Config {
-    let env = if let Ok(db_url) = env::var("DATABASE_URL") {
-        FauxEnv(vec![("DATABASE_URL", db_url.into())].into_iter().collect())
+    let env: FauxEnv = if let Ok(db_url) = env::var("DATABASE_URL") {
+        vec![("DATABASE_URL", db_url.into())].into_iter().collect()
     } else {
         warn!("DATABASE_URL env var is not set. Might not be able to do integration tests");
         FauxEnv::default()
     };
-    let mut cfg: Config =
-        parse_config(yaml, &env, Path::new("test.yaml")).expect("source can be parsed as yaml");
+    let mut cfg: Config = parse_config(yaml, &env.as_property_map(), Path::new("test.yaml"))
+        .expect("source can be parsed as yaml");
     let res = cfg.finalize().expect("source can be finalized");
     assert!(res.is_empty(), "unrecognized config: {res:?}");
     cfg


### PR DESCRIPTION
Fixes #2851.

## Summary
- Replaces `subst::substitute`'s text-level preprocessing — which scanned comments and quoted strings — with `serde-saphyr`'s `properties` feature, which only interpolates inside plain YAML scalar values. Comments containing `${VAR}` no longer abort startup.
- Adopts `PropertySyntax::BracedOrBare` so existing configs using `${VAR}`, `${VAR:-default}`, and bare `$VAR` keep working unchanged.
- Drops `subst` from the workspace. Pins `serde-saphyr` to the master rev `261ccbe6…` containing the four PRs we contributed upstream (#122 defaults, #125 modifiers, #128 error-on-missing, #129 bare syntax). Allowed via `deny.toml`; both have `TODO`s to drop once 0.0.28 is published.
- Substitution failures now flow through `ConfigFileError::YamlParseError` with a wrapper that emits `martin::config::substitution` as the diagnostic `code` (preserved from the old dedicated variant) when the underlying saphyr error is property-related, otherwise `martin::config::yaml`. Inline insta snapshots across the failing-deserializer tests were updated to match the consistent code/help/url footer.

Behavior change to flag in release notes: substitution no longer happens inside *quoted* or *block* scalars. A YAML like `connection_string: \"\${DATABASE_URL}\"` now keeps the literal `\${DATABASE_URL}` instead of expanding. Drop the quotes (or use `connection_string: \${DATABASE_URL}`) to get the previous behavior.

## Test plan
- [x] `cargo test -p martin --lib --no-default-features --features postgres,pmtiles` — 212/212 pass
- [x] Added regression test `substitution_ignores_dollar_tokens_in_comments` using the exact YAML from #2851
- [x] `cargo fmt --all --check` clean
- [ ] CI: full feature matrix via cargo-hack
- [ ] CI: cargo-deny (the new `allow-git` entry is the load-bearing change)
- [ ] CI: clippy `-D warnings` workspace-wide