### PR TITLE
feat: duckdb-config-parsing

### DIFF
--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -101,6 +101,7 @@ required-features = ["postgres"]
 
 [features]
 default = [
+    "duckdb",
     "fonts",
     "lambda",
     "mbtiles",
@@ -115,6 +116,7 @@ default = [
 ]
 unstable-cog = ["martin-core/unstable-cog", "_tiles"]
 rendering = ["styles", "martin-core/rendering", "dep:image"]
+duckdb = ["martin-core/duckdb", "_tiles"]
 fonts = ["martin-core/fonts", "_catalog"]
 lambda = ["dep:lambda-web"]
 mbtiles = ["martin-core/mbtiles", "dep:mbtiles", "_tiles"]

--- a/martin/src/config/args/bounds.rs
+++ b/martin/src/config/args/bounds.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use clap::ValueEnum;
+use enum_display::EnumDisplay;
+use serde::{Deserialize, Serialize};
+
+// Must match the help string for BoundsType::Quick
+pub const DEFAULT_BOUNDS_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(
+    PartialEq, Eq, Default, Debug, Clone, Copy, Serialize, Deserialize, ValueEnum, EnumDisplay,
+)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+#[enum_display(case = "Kebab")]
+pub enum BoundsCalcType {
+    /// Compute table geometry bounds, but abort if it takes longer than 5 seconds.
+    #[default]
+    Quick,
+    /// Compute table geometry bounds. The startup time may be significant. Make sure all GEO columns have indexes.
+    Calc,
+    /// Skip bounds calculation. The bounds will be set to the whole world.
+    Skip,
+}

--- a/martin/src/config/args/mod.rs
+++ b/martin/src/config/args/mod.rs
@@ -1,10 +1,13 @@
 mod connections;
 pub use connections::State;
 
+mod bounds;
+pub use bounds::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT};
+
 #[cfg(feature = "postgres")]
 mod postgres;
 #[cfg(feature = "postgres")]
-pub use postgres::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT, PostgresArgs};
+pub use postgres::{PostgresArgs};
 
 mod root;
 pub use root::*;

--- a/martin/src/config/args/mod.rs
+++ b/martin/src/config/args/mod.rs
@@ -7,7 +7,7 @@ pub use bounds::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT};
 #[cfg(feature = "postgres")]
 mod postgres;
 #[cfg(feature = "postgres")]
-pub use postgres::{PostgresArgs};
+pub use postgres::PostgresArgs;
 
 mod root;
 pub use root::*;

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -1,8 +1,3 @@
-use std::time::Duration;
-
-use clap::ValueEnum;
-use enum_display::EnumDisplay;
-use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use super::connections::Arguments;
@@ -13,24 +8,7 @@ use crate::config::file::postgres::{
 };
 use crate::config::primitives::env::Env;
 use crate::config::primitives::{OptBoolObj, OptOneMany};
-// Must match the help string for BoundsType::Quick
-pub const DEFAULT_BOUNDS_TIMEOUT: Duration = Duration::from_secs(5);
-
-#[derive(
-    PartialEq, Eq, Default, Debug, Clone, Copy, Serialize, Deserialize, ValueEnum, EnumDisplay,
-)]
-#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
-#[serde(rename_all = "lowercase")]
-#[enum_display(case = "Kebab")]
-pub enum BoundsCalcType {
-    /// Compute table geometry bounds, but abort if it takes longer than 5 seconds.
-    #[default]
-    Quick,
-    /// Compute table geometry bounds. The startup time may be significant. Make sure all GEO columns have indexes.
-    Calc,
-    /// Skip bounds calculation. The bounds will be set to the whole world.
-    Skip,
-}
+use super::bounds::{BoundsCalcType};
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
 #[command(about, version)]

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -1,5 +1,6 @@
 use tracing::{info, warn};
 
+use super::bounds::BoundsCalcType;
 use super::connections::Arguments;
 use super::connections::State::{Ignore, Take};
 use crate::config::file::UnrecognizedValues;
@@ -8,7 +9,6 @@ use crate::config::file::postgres::{
 };
 use crate::config::primitives::env::Env;
 use crate::config::primitives::{OptBoolObj, OptOneMany};
-use super::bounds::{BoundsCalcType};
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
 #[command(about, version)]

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -77,7 +77,9 @@ pub enum ConfigFileError {
     DuckDbPoolSizeInvalid,
 
     #[cfg(feature = "duckdb")]
-    #[error("Atleast one duckdb source (database / local geoparquet / remote geoparquet) must be provided")]
+    #[error(
+        "Atleast one duckdb source (database / local geoparquet / remote geoparquet) must be provided"
+    )]
     DuckDbSourcesEmpty,
 
     #[cfg(feature = "duckdb")]

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -72,6 +72,22 @@ pub enum ConfigFileError {
     #[error("Failed to list objects under {1}: {0}")]
     ObjectStoreList(object_store::Error, String),
 
+    #[cfg(feature = "duckdb")]
+    #[error("The duckdb pool_size must be greater than or equal to 1")]
+    DuckDbPoolSizeInvalid,
+
+    #[cfg(feature = "duckdb")]
+    #[error("Atleast one duckdb source (database / local geoparquet / remote geoparquet) must be provided")]
+    DuckDbSourcesEmpty,
+
+    #[cfg(feature = "duckdb")]
+    #[error("Each duckdb source must specify either `database` or `geoparquet`")]
+    DuckDbSourceTargetMissing,
+
+    #[cfg(feature = "duckdb")]
+    #[error("Each duckdb source must specify exactly one of `database` or `geoparquet`")]
+    DuckDbSourceTargetAmbiguous,
+
     #[cfg(all(feature = "rendering", target_os = "linux"))]
     #[error("Failed to start style render pool: {0}")]
     RendererPoolSpawnFailed(#[source] std::io::Error),
@@ -216,6 +232,14 @@ impl Diagnostic for ConfigFileError {
             Self::ObjectStoreUrlParsing(..) => "martin::config::pmtiles::object_store_url",
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreList(..) => "martin::config::pmtiles::object_store_list",
+            #[cfg(feature = "duckdb")]
+            Self::DuckDbPoolSizeInvalid => "martin::config::duckdb::pool_size",
+            #[cfg(feature = "duckdb")]
+            Self::DuckDbSourcesEmpty => "martin::config::duckdb::sources",
+            #[cfg(feature = "duckdb")]
+            Self::DuckDbSourceTargetMissing => "martin::config::duckdb::source_target",
+            #[cfg(feature = "duckdb")]
+            Self::DuckDbSourceTargetAmbiguous => "martin::config::duckdb::source_target",
             #[cfg(all(feature = "rendering", target_os = "linux"))]
             Self::RendererPoolSpawnFailed(_) => "martin::config::styles::render_pool_spawn",
         };

--- a/martin/src/config/file/tiles/duckdb/builder.rs
+++ b/martin/src/config/file/tiles/duckdb/builder.rs
@@ -1,0 +1,5 @@
+//! DuckDB source auto-discovery and instantiation.
+
+/// Builder for [`DuckDBSource`](martin_core::tiles::duckdb::DuckDBSource) auto-discovery.
+#[derive(Debug, Default)]
+pub struct DuckDbAutoDiscoveryBuilder;

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -1,0 +1,765 @@
+use std::path::PathBuf;
+
+use martin_tile_utils::TileInfo;
+use serde::{Deserialize, Serialize};
+use tilejson::TileJSON;
+
+use super::{DuckDbGeoParquetSourceConfig, MacroInfoSources, TableInfoSources};
+use crate::config::args::BoundsCalcType;
+use crate::config::file::{
+    CachePolicy, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks, ResolutionResult,
+    UnrecognizedKeys, UnrecognizedValues, copy_unrecognized_keys_from_config,
+};
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::{MltProcessConfig, MvtProcessConfig};
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::primitives::AutoOption;
+use crate::config::primitives::{IdResolver, OptBoolObj, OptOneMany};
+
+/// Default DuckDB connection pool size for tile serving.
+pub const DEFAULT_POOL_SIZE: usize = 4;
+
+pub trait DuckDbInfo {
+    fn format_id(&self) -> String;
+    fn to_tilejson(&self, source_id: String) -> TileJSON;
+    /// Return the tile format and encoding for this source.
+    fn tile_info(&self) -> TileInfo;
+}
+
+/// Top-level DuckDB configuration block.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbConfig {
+    /// Maximum DuckDB connection pool size \[default: 4\]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4usize))]
+    pub pool_size: Option<usize>,
+    /// Specify how bounds should be computed for spatial sources \[default: quick\]
+    ///
+    /// Options:
+    /// - `calc` compute geometry bounds on startup.
+    /// - `quick` same as 'calc', but the calculation will be aborted after 5 seconds.
+    /// - `skip` does not compute geometry bounds on startup.
+    pub auto_bounds: Option<BoundsCalcType>,
+    /// If a spatial table has SRID 0, this SRID is used as a fallback.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4326i32))]
+    pub default_srid: Option<i32>,
+    /// DuckDB threads per query. Omitted values defer to DuckDB defaults (nCPU).
+    pub threads_per_query: Option<usize>,
+    /// DuckDB memory limit in megabytes. Omitted values defer to DuckDB defaults (80% RAM).
+    pub memory_limit_mb: Option<usize>,
+    /// DuckDB source entries (database files and GeoParquet datasets).
+    #[serde(default)]
+    pub sources: Vec<DuckDbSourceConfig>,
+    /// MVT->MLT encoder settings for all sources from this connection.
+    /// Overrides global; overridden by per-source `convert_to_mlt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitely configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mlt: Option<MltProcessConfig>,
+
+    /// MLT->MVT conversion settings for all sources from this connection.
+    /// Overrides global; overridden by per-source `convert_to_mvt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mvt: Option<MvtProcessConfig>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl Default for DuckDbConfig {
+    fn default() -> Self {
+        Self {
+            pool_size: Some(DEFAULT_POOL_SIZE),
+            auto_bounds: None,
+            default_srid: None,
+            threads_per_query: None,
+            memory_limit_mb: None,
+            sources: Vec::new(),
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            convert_to_mlt: None,
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            convert_to_mvt: None,
+            unrecognized: UnrecognizedValues::default(),
+        }
+    }
+}
+
+/// One configured DuckDB source entry under `duckdb.sources`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DuckDbSourceConfig {
+    Database(DuckDbDatabaseSourceConfig),
+    GeoParquet(DuckDbGeoParquetSourceConfig),
+}
+
+/// Database-file source entry under `duckdb.sources`.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbDatabaseSourceConfig {
+    /// Path to the DuckDB database file.
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = &"/data/tiles.duckdb")
+    )]
+    pub database: PathBuf,
+    /// Override wrapper-level pool size for this database \[default: inherit\]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4usize))]
+    pub pool_size: Option<usize>,
+    /// Override wrapper-level bounds calculation for this database \[default: inherit\]
+    pub auto_bounds: Option<BoundsCalcType>,
+    /// Override wrapper-level query thread count for this database \[default: inherit\]
+    pub threads_per_query: Option<usize>,
+    /// Override wrapper-level memory limit for this database \[default: inherit\]
+    pub memory_limit_mb: Option<usize>,
+    /// Enable automatic discovery of tables and macros. \[default: null\]
+    ///
+    /// Options:
+    /// - `true`: run automatic discovery (`true` may be omitted if further configuration is provided)
+    /// - `false`: disable automatic discovery
+    /// - null: run automatic discovery if `tables` and `macros` are null
+    #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
+    pub auto_publish: OptBoolObj<DuckDbCfgPublish>,
+    /// Associative array of table sources keyed by source ID
+    pub tables: Option<TableInfoSources>,
+    /// Associative array of macro sources keyed by source ID
+    pub macros: Option<MacroInfoSources>,
+
+    /// MVT->MLT encoder settings for all sources from this database file.
+    /// Overrides wrapper-level and global settings; overridden by per-source `convert_to_mlt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the wrapper or global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mlt: Option<MltProcessConfig>,
+
+    /// MLT->MVT conversion settings for all sources from this database file.
+    /// Overrides wrapper-level and global settings; overridden by per-source `convert_to_mvt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the wrapper or global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mvt: Option<MvtProcessConfig>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbCfgPublish {
+    /// Optionally limit to just these schemas
+    #[serde(alias = "from_schema")]
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub from_schemas: OptOneMany<String>,
+    /// Here we enable both tables and macros auto discovery.
+    /// You can also enable just one of them by not mentioning the other, or
+    /// setting it to false. Setting one to true disables the other one as well.
+    /// E.g. `tables: false` enables just the macros auto-discovery.
+    #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
+    pub tables: OptBoolObj<DuckDbCfgPublishTables>,
+    #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
+    pub macros: OptBoolObj<DuckDbCfgPublishMacros>,
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbCfgPublishTables {
+    /// Add more schemas to the ones listed above
+    #[serde(alias = "from_schema")]
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub from_schemas: OptOneMany<String>,
+    /// Optionally set how source ID should be generated based on the table's name,
+    /// schema, and geometry column
+    #[serde(alias = "id_format")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = &"{table}")
+    )]
+    pub source_id_format: Option<String>,
+    /// A table column to use as the feature ID.
+    /// If a table has no column with this name, `id_column` will not be set for
+    /// that table.
+    /// If a list of strings is given, the first found column will be treated as a
+    /// feature ID.
+    #[serde(alias = "id_column")]
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub id_columns: OptOneMany<String>,
+    /// Controls if geometries should be clipped or encoded as is \[default: true\]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &true))]
+    pub clip_geom: Option<bool>,
+    /// Buffer distance in tile coordinate space to optionally clip geometries,
+    /// optional, default to 64
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &64u32))]
+    pub buffer: Option<u32>,
+    /// Tile extent in tile coordinate space, optional, default to 4096
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4096u32))]
+    pub extent: Option<std::num::NonZeroU32>,
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbCfgPublishMacros {
+    /// Optionally limit to just these schemas
+    #[serde(alias = "from_schema")]
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub from_schemas: OptOneMany<String>,
+    /// Optionally set how source ID should be generated based on the macro's
+    /// name and schema
+    #[serde(alias = "id_format")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = &"{macro}")
+    )]
+    pub source_id_format: Option<String>,
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigurationLivecycleHooks for DuckDbCfgPublish {
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        let mut keys = self
+            .unrecognized
+            .keys()
+            .cloned()
+            .collect::<UnrecognizedKeys>();
+        match &self.tables {
+            OptBoolObj::NoValue | OptBoolObj::Bool(_) => {}
+            OptBoolObj::Object(o) => keys.extend(
+                o.get_unrecognized_keys()
+                    .iter()
+                    .map(|k| format!("tables.{k}")),
+            ),
+        }
+        match &self.macros {
+            OptBoolObj::NoValue | OptBoolObj::Bool(_) => {}
+            OptBoolObj::Object(o) => keys.extend(
+                o.get_unrecognized_keys()
+                    .iter()
+                    .map(|k| format!("macros.{k}")),
+            ),
+        }
+        keys
+    }
+}
+
+impl ConfigurationLivecycleHooks for DuckDbCfgPublishTables {
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        self.unrecognized.keys().cloned().collect()
+    }
+}
+
+impl ConfigurationLivecycleHooks for DuckDbCfgPublishMacros {
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        self.unrecognized.keys().cloned().collect()
+    }
+}
+
+impl DuckDbSourceConfig {
+    #[must_use]
+    pub fn pool_size(&self) -> Option<usize> {
+        match self {
+            Self::Database(cfg) => cfg.pool_size,
+            Self::GeoParquet(cfg) => cfg.pool_size,
+        }
+    }
+
+    #[must_use]
+    pub fn auto_bounds(&self) -> Option<BoundsCalcType> {
+        match self {
+            Self::Database(cfg) => cfg.auto_bounds,
+            Self::GeoParquet(cfg) => cfg.auto_bounds,
+        }
+    }
+
+    #[must_use]
+    pub fn threads_per_query(&self) -> Option<usize> {
+        match self {
+            Self::Database(cfg) => cfg.threads_per_query,
+            Self::GeoParquet(cfg) => cfg.threads_per_query,
+        }
+    }
+
+    #[must_use]
+    pub fn memory_limit_mb(&self) -> Option<usize> {
+        match self {
+            Self::Database(cfg) => cfg.memory_limit_mb,
+            Self::GeoParquet(cfg) => cfg.memory_limit_mb,
+        }
+    }
+}
+
+impl DuckDbConfig {
+    #[must_use]
+    pub fn effective_pool_size(&self, source: &DuckDbSourceConfig) -> usize {
+        source
+            .pool_size()
+            .or(self.pool_size)
+            .unwrap_or(DEFAULT_POOL_SIZE)
+    }
+
+    #[must_use]
+    pub fn effective_auto_bounds(&self, source: &DuckDbSourceConfig) -> BoundsCalcType {
+        source
+            .auto_bounds()
+            .or(self.auto_bounds)
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn effective_threads_per_query(&self, source: &DuckDbSourceConfig) -> Option<usize> {
+        source.threads_per_query().or(self.threads_per_query)
+    }
+
+    #[must_use]
+    pub fn effective_memory_limit_mb(&self, source: &DuckDbSourceConfig) -> Option<usize> {
+        source.memory_limit_mb().or(self.memory_limit_mb)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        for source in &self.sources {
+            source.validate()?;
+        }
+        Ok(())
+    }
+
+    pub async fn resolve(
+        &mut self,
+        _id_resolver: IdResolver,
+        _default_cache: CachePolicy,
+    ) -> ResolutionResult {
+        //TODO: Discovery and instantiation to be implemented 
+        Ok((Vec::new(), Vec::new()))
+    }
+}
+
+impl ConfigurationLivecycleHooks for DuckDbConfig {
+    fn finalize(&mut self) -> ConfigFileResult<()> {
+        if self.pool_size.is_some_and(|size| size < 1) {
+            return Err(ConfigFileError::DuckDbPoolSizeInvalid);
+        }
+        if self.sources.is_empty() {
+            return Err(ConfigFileError::DuckDbSourcesEmpty);
+        }
+
+        for source in &mut self.sources {
+            source.finalize()?;
+        }
+
+        Ok(())
+    }
+
+    fn get_unrecognized_keys(&self) -> UnrecognizedKeys {
+        let mut keys = self
+            .unrecognized
+            .keys()
+            .cloned()
+            .collect::<UnrecognizedKeys>();
+
+        for (idx, source) in self.sources.iter().enumerate() {
+            let prefix = format!("sources[{idx}].");
+            keys.extend(source.get_unrecognized_keys_with_prefix(&prefix));
+        }
+
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        {
+            if let Some(AutoOption::Explicit(cfg)) = self.convert_to_mlt.as_ref() {
+                keys.extend(
+                    cfg.unrecognized_keys()
+                        .map(|k| format!("convert_to_mlt.{k}")),
+                );
+            }
+            if let Some(AutoOption::Explicit(cfg)) = self.convert_to_mvt.as_ref() {
+                keys.extend(
+                    cfg.unrecognized_keys()
+                        .map(|k| format!("convert_to_mvt.{k}")),
+                );
+            }
+        }
+
+        keys
+    }
+}
+
+impl DuckDbSourceConfig {
+    fn finalize(&mut self) -> ConfigFileResult<()> {
+        if self.pool_size().is_some_and(|size| size < 1) {
+            return Err(ConfigFileError::DuckDbPoolSizeInvalid);
+        }
+
+        match self {
+            Self::Database(cfg) => {
+                if cfg.tables.is_none() && cfg.macros.is_none() && cfg.auto_publish.is_none() {
+                    cfg.auto_publish = OptBoolObj::Bool(true);
+                }
+                Ok(())
+            }
+            Self::GeoParquet(cfg) => cfg.finalize_target(),
+        }
+    }
+
+    fn get_unrecognized_keys_with_prefix(&self, prefix: &str) -> UnrecognizedKeys {
+        match self {
+            Self::Database(cfg) => {
+                let mut keys = cfg
+                    .unrecognized
+                    .keys()
+                    .cloned()
+                    .map(|k| format!("{prefix}{k}"))
+                    .collect::<UnrecognizedKeys>();
+
+                if let Some(ref tables) = cfg.tables {
+                    for (k, v) in tables {
+                        copy_unrecognized_keys_from_config(
+                            &mut keys,
+                            &format!("{prefix}tables.{k}."),
+                            &v.unrecognized,
+                        );
+                    }
+                }
+                if let Some(ref macros) = cfg.macros {
+                    for (k, v) in macros {
+                        copy_unrecognized_keys_from_config(
+                            &mut keys,
+                            &format!("{prefix}macros.{k}."),
+                            &v.unrecognized,
+                        );
+                    }
+                }
+                match &cfg.auto_publish {
+                    OptBoolObj::NoValue | OptBoolObj::Bool(_) => {}
+                    OptBoolObj::Object(o) => keys.extend(
+                        o.get_unrecognized_keys()
+                            .iter()
+                            .map(|k| format!("{prefix}auto_publish.{k}")),
+                    ),
+                }
+                #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                {
+                    if let Some(AutoOption::Explicit(mlt_cfg)) = cfg.convert_to_mlt.as_ref() {
+                        keys.extend(
+                            mlt_cfg
+                                .unrecognized_keys()
+                                .map(|k| format!("{prefix}convert_to_mlt.{k}")),
+                        );
+                    }
+                    if let Some(AutoOption::Explicit(mvt_cfg)) = cfg.convert_to_mvt.as_ref() {
+                        keys.extend(
+                            mvt_cfg
+                                .unrecognized_keys()
+                                .map(|k| format!("{prefix}convert_to_mvt.{k}")),
+                        );
+                    }
+                }
+                keys
+            }
+            Self::GeoParquet(cfg) => {
+                let mut keys = cfg
+                    .unrecognized
+                    .keys()
+                    .cloned()
+                    .map(|k| format!("{prefix}{k}"))
+                    .collect::<UnrecognizedKeys>();
+                #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                {
+                    if let Some(AutoOption::Explicit(mlt_cfg)) = cfg.convert_to_mlt.as_ref() {
+                        keys.extend(
+                            mlt_cfg
+                                .unrecognized_keys()
+                                .map(|k| format!("{prefix}convert_to_mlt.{k}")),
+                        );
+                    }
+                    if let Some(AutoOption::Explicit(mvt_cfg)) = cfg.convert_to_mvt.as_ref() {
+                        keys.extend(
+                            mvt_cfg
+                                .unrecognized_keys()
+                                .map(|k| format!("{prefix}convert_to_mvt.{k}")),
+                        );
+                    }
+                }
+                keys
+            }
+        }
+    }
+    /// Validates a single source to ensure no ambiguous keys were swept into `unrecognized`
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            DuckDbSourceConfig::Database(db) => {
+                if db.unrecognized.contains_key("geoparquet") {
+                    return Err("ambiguous source: contains exactly one database or geoparquet target".to_string());
+                }
+            }
+            DuckDbSourceConfig::GeoParquet(geo) => {
+                if geo.unrecognized.contains_key("database") {
+                    return Err("ambiguous source: contains exactly one database or geoparquet target".to_string());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+    use std::path::PathBuf;
+
+    use indoc::indoc;
+    use url::Url;
+
+    use super::*;
+    use crate::config::primitives::OptOneMany::{Many, One};
+
+    fn finalize(mut cfg: DuckDbConfig) -> DuckDbConfig {
+        cfg.finalize().expect("duckdb config should finalize");
+        cfg
+    }
+
+    #[test]
+    fn parses_database_source_with_wrapper_defaults() {
+        let cfg = finalize(
+            serde_yaml::from_str(indoc! {"
+            pool_size: 4
+            auto_bounds: quick
+            default_srid: 4326
+            sources:
+              - database: /data/tiles.duckdb
+                tables:
+                  roads:
+                    schema: main
+                    table: roads
+                    geometry_column: geom
+                    srid: 4326
+        "})
+            .expect("parse duckdb config"),
+        );
+
+        assert_eq!(cfg.pool_size, Some(4));
+        assert_eq!(cfg.auto_bounds, Some(BoundsCalcType::Quick));
+        assert_eq!(cfg.default_srid, Some(4326));
+        assert_eq!(cfg.sources.len(), 1);
+        match &cfg.sources[0] {
+            DuckDbSourceConfig::Database(db) => {
+                assert_eq!(db.database, PathBuf::from("/data/tiles.duckdb"));
+                assert!(db.tables.is_some());
+            }
+            DuckDbSourceConfig::GeoParquet(_) => panic!("expected database source"),
+        }
+    }
+
+    #[test]
+    fn parses_geoparquet_into_local_target() {
+        let cfg = finalize(
+            serde_yaml::from_str(indoc! {"
+            sources:
+              - geoparquet: /data/buildings.parquet
+                layer_id: buildings
+        "})
+            .expect("parse duckdb config"),
+        );
+
+        match &cfg.sources[0] {
+            DuckDbSourceConfig::GeoParquet(gp) => {
+                assert_eq!(gp.layer_id.as_deref(), Some("buildings"));
+                assert_eq!(
+                    gp.target(),
+                    &super::super::config_geoparquet::GeoParquetTarget::Local(PathBuf::from(
+                        "/data/buildings.parquet"
+                    ))
+                );
+            }
+            DuckDbSourceConfig::Database(_) => panic!("expected geoparquet source"),
+        }
+    }
+
+    #[test]
+    fn parses_geoparquet_into_remote_target() {
+        let cfg = finalize(
+            serde_yaml::from_str(indoc! {"
+            sources:
+              - geoparquet: s3://bucket/roads.parquet
+        "})
+            .expect("parse duckdb config"),
+        );
+
+        match &cfg.sources[0] {
+            DuckDbSourceConfig::GeoParquet(gp) => {
+                assert!(matches!(
+                    gp.target(),
+                    super::super::config_geoparquet::GeoParquetTarget::Remote(_)
+                ));
+                if let super::super::config_geoparquet::GeoParquetTarget::Remote(url) = gp.target()
+                {
+                    assert_eq!(url, &Url::parse("s3://bucket/roads.parquet").unwrap());
+                }
+            }
+            DuckDbSourceConfig::Database(_) => panic!("expected geoparquet source"),
+        }
+    }
+
+    #[test]
+    fn rejects_ambiguous_source_target() {
+        let config = serde_yaml::from_str::<DuckDbConfig>(indoc! {"
+            sources:
+              - database: /data/tiles.duckdb
+                geoparquet: /data/buildings.parquet
+        "})
+        .expect("semantically invalid configuration");
+        let err = config.validate().expect_err("ambiguous source should fail validation");
+        assert!(err.contains("exactly one"));
+    }
+
+    #[test]
+    fn effective_pool_size_uses_wrapper_default() {
+        let cfg = finalize(
+            serde_yaml::from_str(indoc! {"
+            sources:
+              - database: /data/tiles.duckdb
+        "})
+            .expect("parse duckdb config"),
+        );
+        assert_eq!(cfg.effective_pool_size(&cfg.sources[0]), DEFAULT_POOL_SIZE);
+    }
+
+    #[test]
+    fn parses_sample_config_structure() {
+        let cfg = finalize(
+            serde_yaml::from_str(indoc! {"
+            pool_size: 4
+            auto_bounds: quick
+            sources:
+              - database: /data/tiles.duckdb
+                auto_publish:
+                  tables:
+                    from_schemas: autodetect
+                    source_id_format: '{table}'
+                    id_columns: [id, gid]
+                    extent: 4096
+                    buffer: 64
+                    clip_geom: true
+                  macros:
+                    from_schemas: autodetect
+                    source_id_format: '{macro}'
+                tables:
+                  roads:
+                    schema: main
+                    table: roads
+                    geometry_column: geom
+                    srid: 4326
+                    minzoom: 0
+                    maxzoom: 14
+                    properties:
+                      id: int4
+                      name: varchar
+                macros:
+                  custom:
+                    schema: main
+                    macro: get_custom_tile
+              - geoparquet: /data/buildings.parquet
+                layer_id: buildings
+                geometry_column: geom
+                srid: 4326
+                minzoom: 0
+                maxzoom: 14
+                extent: 4096
+                buffer: 64
+        "})
+            .expect("parse duckdb config"),
+        );
+
+        assert_eq!(cfg.pool_size, Some(4));
+        assert_eq!(cfg.auto_bounds, Some(BoundsCalcType::Quick));
+        assert_eq!(cfg.sources.len(), 2);
+
+        match &cfg.sources[0] {
+            DuckDbSourceConfig::Database(db) => {
+                assert_eq!(db.database, PathBuf::from("/data/tiles.duckdb"));
+                let OptBoolObj::Object(auto_publish) = &db.auto_publish else {
+                    panic!("expected auto_publish object");
+                };
+                let OptBoolObj::Object(tables_cfg) = &auto_publish.tables else {
+                    panic!("expected auto_publish.tables object");
+                };
+                assert_eq!(tables_cfg.from_schemas, One("autodetect".to_string()));
+                assert_eq!(tables_cfg.source_id_format.as_deref(), Some("{table}"));
+                assert_eq!(
+                    tables_cfg.id_columns,
+                    Many(vec!["id".to_string(), "gid".to_string()])
+                );
+                assert_eq!(tables_cfg.extent.map(NonZeroU32::get), Some(4096));
+                assert_eq!(tables_cfg.buffer, Some(64));
+                assert_eq!(tables_cfg.clip_geom, Some(true));
+
+                let OptBoolObj::Object(macros_cfg) = &auto_publish.macros else {
+                    panic!("expected auto_publish.macros object");
+                };
+                assert_eq!(macros_cfg.from_schemas, One("autodetect".to_string()));
+                assert_eq!(macros_cfg.source_id_format.as_deref(), Some("{macro}"));
+
+                let roads = db.tables.as_ref().unwrap().get("roads").unwrap();
+                assert_eq!(roads.schema, "main");
+                assert_eq!(roads.table, "roads");
+                assert_eq!(roads.geometry_column, "geom");
+                assert_eq!(roads.srid, 4326);
+                assert_eq!(roads.minzoom, Some(0));
+                assert_eq!(roads.maxzoom, Some(14));
+
+                let custom = db.macros.as_ref().unwrap().get("custom").unwrap();
+                assert_eq!(custom.schema, "main");
+                assert_eq!(custom.macro_name, "get_custom_tile");
+            }
+            DuckDbSourceConfig::GeoParquet(_) => panic!("expected database source"),
+        }
+
+        match &cfg.sources[1] {
+            DuckDbSourceConfig::GeoParquet(gp) => {
+                assert_eq!(gp.layer_id.as_deref(), Some("buildings"));
+                assert_eq!(gp.geometry_column.as_deref(), Some("geom"));
+                assert_eq!(gp.srid, Some(4326));
+                assert_eq!(gp.minzoom, Some(0));
+                assert_eq!(gp.maxzoom, Some(14));
+                assert_eq!(gp.extent.map(NonZeroU32::get), Some(4096));
+                assert_eq!(gp.buffer, Some(64));
+            }
+            DuckDbSourceConfig::Database(_) => panic!("expected geoparquet source"),
+        }
+    }
+
+    #[test]
+    fn default_impl_yields_empty_sources() {
+        assert!(DuckDbConfig::default().sources.is_empty());
+    }
+}

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -360,7 +360,7 @@ impl DuckDbConfig {
         _id_resolver: IdResolver,
         _default_cache: CachePolicy,
     ) -> ResolutionResult {
-        //TODO: Discovery and instantiation to be implemented 
+        //TODO: Discovery and instantiation to be implemented
         Ok((Vec::new(), Vec::new()))
     }
 }
@@ -518,19 +518,24 @@ impl DuckDbSourceConfig {
         match self {
             DuckDbSourceConfig::Database(db) => {
                 if db.unrecognized.contains_key("geoparquet") {
-                    return Err("ambiguous source: contains exactly one database or geoparquet target".to_string());
+                    return Err(
+                        "ambiguous source: contains exactly one database or geoparquet target"
+                            .to_string(),
+                    );
                 }
             }
             DuckDbSourceConfig::GeoParquet(geo) => {
                 if geo.unrecognized.contains_key("database") {
-                    return Err("ambiguous source: contains exactly one database or geoparquet target".to_string());
+                    return Err(
+                        "ambiguous source: contains exactly one database or geoparquet target"
+                            .to_string(),
+                    );
                 }
             }
         }
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -638,7 +643,9 @@ mod tests {
                 geoparquet: /data/buildings.parquet
         "})
         .expect("semantically invalid configuration");
-        let err = config.validate().expect_err("ambiguous source should fail validation");
+        let err = config
+            .validate()
+            .expect_err("ambiguous source should fail validation");
         assert!(err.contains("exactly one"));
     }
 

--- a/martin/src/config/file/tiles/duckdb/config_geoparquet.rs
+++ b/martin/src/config/file/tiles/duckdb/config_geoparquet.rs
@@ -1,0 +1,251 @@
+use std::collections::BTreeMap;
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use martin_tile_utils::{Encoding, Format, TileInfo};
+use serde::{Deserialize, Serialize};
+use tilejson::{Bounds, TileJSON, VectorLayer};
+use url::Url;
+
+use super::DuckDbInfo;
+use crate::config::args::BoundsCalcType;
+#[cfg(feature = "unstable-schemas")]
+use crate::config::file::duckdb::config_table::bounds_world_example;
+use crate::config::file::file_config::is_remote_url;
+use crate::config::file::{CachePolicy, ConfigFileError, ConfigFileResult, UnrecognizedValues};
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::{MltProcessConfig, MvtProcessConfig};
+
+/// Resolved GeoParquet location after config finalization.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GeoParquetTarget {
+    /// Local `.parquet` file served via an in-memory DuckDB connection.
+    Local(PathBuf),
+    /// Remote parquet object served via DuckDB `httpfs`.
+    Remote(Url),
+}
+
+impl Display for GeoParquetTarget {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local(path) => Display::fmt(&path.display(), formatter),
+            Self::Remote(url) => Display::fmt(url, formatter),
+        }
+    }
+}
+
+/// Parse a configured `geoparquet:` value into the target type expected by `martin-core`.
+pub fn parse_geoparquet_target(raw: &str) -> ConfigFileResult<GeoParquetTarget> {
+    let path = Path::new(raw);
+    if is_remote_url(path) {
+        let url = Url::parse(raw)
+            .map_err(|source| ConfigFileError::InvalidSourceUrl(source, raw.to_string()))?;
+        Ok(GeoParquetTarget::Remote(url))
+    } else {
+        Ok(GeoParquetTarget::Local(PathBuf::from(raw)))
+    }
+}
+
+/// GeoParquet source entry under `duckdb.sources`.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct DuckDbGeoParquetSourceConfig {
+    /// Path to a local parquet file or remote URL (`s3://`, `https://`, ...).
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = &"/data/buildings.parquet")
+    )]
+    pub geoparquet: String,
+
+    /// Resolved target for pool construction. Populated by [`super::DuckDbConfig::finalize`].
+    #[serde(skip)]
+    pub target: Option<GeoParquetTarget>,
+
+    /// Tile source id. Defaults to the parquet filename stem.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"buildings"))]
+    pub layer_id: Option<String>,
+
+    /// Geometry column name. Auto-detected when omitted.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"geom"))]
+    pub geometry_column: Option<String>,
+
+    /// Geometry SRID. Auto-detected or defaults to wrapper `default_srid` when omitted.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4326i32))]
+    pub srid: Option<i32>,
+
+    /// An integer specifying the minimum zoom level
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &0u8))]
+    pub minzoom: Option<u8>,
+
+    /// An integer specifying the maximum zoom level. MUST be >= minzoom
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &14u8))]
+    pub maxzoom: Option<u8>,
+
+    /// The maximum extent of available map tiles. Bounds MUST define an area
+    /// covered by all zoom levels. The bounds are represented in WGS:84 latitude
+    /// and longitude values, in the order left, bottom, right, top.
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<[f64; 4]>"))]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = bounds_world_example())
+    )]
+    pub bounds: Option<Bounds>,
+
+    /// Tile extent in tile coordinate space
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4096u32))]
+    pub extent: Option<std::num::NonZeroU32>,
+
+    /// Buffer distance in tile coordinate space to optionally clip geometries
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &64u32))]
+    pub buffer: Option<u32>,
+
+    /// Boolean to control if geometries should be clipped or encoded as is
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &true))]
+    pub clip_geom: Option<bool>,
+
+    /// Zoom-level bounds for tile caching (overrides top-level cache).
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "Option<crate::config::file::CachePolicyShape>")
+    )]
+    pub cache: Option<CachePolicy>,
+
+    /// Override wrapper-level pool size for this source entry.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4usize))]
+    pub pool_size: Option<usize>,
+
+    /// Override wrapper-level bounds calculation for this source entry.
+    pub auto_bounds: Option<BoundsCalcType>,
+
+    /// Override wrapper-level query thread count for this source entry.
+    pub threads_per_query: Option<usize>,
+
+    /// Override wrapper-level memory limit for this source entry.
+    pub memory_limit_mb: Option<usize>,
+
+    /// MVT->MLT encoder settings for this source.
+    /// Overrides wrapper-level and global `convert_to_mlt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the wrapper or global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mlt: Option<MltProcessConfig>,
+
+    /// MLT->MVT conversion settings for this source.
+    /// Overrides wrapper-level and global `convert_to_mvt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the wrapper or global setting
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mvt: Option<MvtProcessConfig>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl DuckDbGeoParquetSourceConfig {
+    /// Returns the resolved target after [`super::DuckDbConfig::finalize`].
+    ///
+    /// # Panics
+    /// Panics if called before finalization.
+    #[must_use]
+    pub fn target(&self) -> &GeoParquetTarget {
+        self.target
+            .as_ref()
+            .expect("GeoParquet target should be set after DuckDbConfig::finalize()")
+    }
+
+    pub(crate) fn finalize_target(&mut self) -> ConfigFileResult<()> {
+        self.target = Some(parse_geoparquet_target(&self.geoparquet)?);
+        Ok(())
+    }
+}
+
+impl DuckDbInfo for DuckDbGeoParquetSourceConfig {
+    fn format_id(&self) -> String {
+        self.geoparquet.clone()
+    }
+
+    fn to_tilejson(&self, source_id: String) -> TileJSON {
+        let layer_id = self
+            .layer_id
+            .clone()
+            .unwrap_or_else(|| default_layer_id_from_geoparquet(&self.geoparquet));
+
+        let mut tilejson = tilejson::tilejson! {
+            tiles: vec![],
+            name: source_id,
+            description: self.format_id(),
+        };
+        tilejson.minzoom = self.minzoom;
+        tilejson.maxzoom = self.maxzoom;
+        tilejson.bounds = self.bounds;
+        tilejson.vector_layers = Some(vec![VectorLayer {
+            id: layer_id,
+            fields: BTreeMap::default(),
+            description: None,
+            maxzoom: None,
+            minzoom: None,
+            other: BTreeMap::default(),
+        }]);
+        tilejson
+    }
+
+    fn tile_info(&self) -> TileInfo {
+        TileInfo::new(Format::Mvt, Encoding::Uncompressed)
+    }
+}
+
+#[must_use]
+pub fn default_layer_id_from_geoparquet(geoparquet: &str) -> String {
+    Path::new(geoparquet)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(geoparquet)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_local_geoparquet_target() {
+        let target = parse_geoparquet_target("/data/buildings.parquet").unwrap();
+        assert_eq!(
+            target,
+            GeoParquetTarget::Local(PathBuf::from("/data/buildings.parquet"))
+        );
+    }
+
+    #[test]
+    fn parse_remote_geoparquet_target() {
+        let target = parse_geoparquet_target("s3://bucket/roads.parquet").unwrap();
+        assert!(matches!(target, GeoParquetTarget::Remote(_)));
+        if let GeoParquetTarget::Remote(url) = target {
+            assert_eq!(url.as_str(), "s3://bucket/roads.parquet");
+        }
+    }
+
+    #[test]
+    fn default_layer_id_uses_filename_stem() {
+        assert_eq!(
+            default_layer_id_from_geoparquet("/data/buildings.parquet"),
+            "buildings"
+        );
+        assert_eq!(
+            default_layer_id_from_geoparquet("s3://bucket/roads.parquet"),
+            "roads"
+        );
+    }
+}

--- a/martin/src/config/file/tiles/duckdb/config_macro.rs
+++ b/martin/src/config/file/tiles/duckdb/config_macro.rs
@@ -1,0 +1,128 @@
+use std::collections::BTreeMap;
+
+use martin_tile_utils::{Encoding, Format, TileInfo};
+use serde::{Deserialize, Serialize};
+use tilejson::{Bounds, TileJSON};
+
+use super::DuckDbInfo;
+#[cfg(feature = "unstable-schemas")]
+use crate::config::file::duckdb::config_table::bounds_world_example;
+use crate::config::file::duckdb::utils::patch_json;
+use crate::config::file::{CachePolicy, UnrecognizedValues};
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::{MltProcessConfig, MvtProcessConfig};
+
+pub type MacroInfoSources = BTreeMap<String, MacroInfo>;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct MacroInfo {
+    /// Schema name (required)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"main"))]
+    pub schema: String,
+
+    /// Macro name (required)
+    #[serde(rename = "macro")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"get_custom_tile"))]
+    pub macro_name: String,
+
+    /// An integer specifying the minimum zoom level
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &0u8))]
+    pub minzoom: Option<u8>,
+
+    /// An integer specifying the maximum zoom level. MUST be >= minzoom
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &21u8))]
+    pub maxzoom: Option<u8>,
+
+    /// The maximum extent of available map tiles. Bounds MUST define an area
+    /// covered by all zoom levels. The bounds are represented in WGS:84
+    /// latitude and longitude values, in the order left, bottom, right, top.
+    /// Values may be integers or floating point numbers.
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<[f64; 4]>"))]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = bounds_world_example()))]
+    pub bounds: Option<Bounds>,
+
+    /// Zoom-level bounds for tile caching.
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "Option<crate::config::file::CachePolicyShape>")
+    )]
+    pub cache: Option<CachePolicy>,
+
+    /// `TileJSON` provided by catalog metadata. Not serialized.
+    #[serde(skip)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub tilejson: Option<serde_json::Value>,
+
+    /// MVT->MLT encoder settings for this source.
+    /// Overrides source-type and global `convert_to_mlt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the source-type or global settings
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mlt: Option<MltProcessConfig>,
+
+    /// MLT->MVT conversion settings for this source.
+    /// Overrides source-type and global `convert_to_mvt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the source-type or global settings
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mvt: Option<MvtProcessConfig>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+impl MacroInfo {
+    #[must_use]
+    pub fn new(schema: String, macro_name: String, tilejson: Option<serde_json::Value>) -> Self {
+        Self {
+            schema,
+            macro_name,
+            tilejson,
+            ..Default::default()
+        }
+    }
+
+    /// For a given macro info discovered from the database, append the configuration info provided by the user.
+    #[must_use]
+    pub fn append_cfg_info(&self, cfg_inf: &Self) -> Self {
+        Self {
+            tilejson: self.tilejson.clone(),
+            ..cfg_inf.clone()
+        }
+    }
+}
+
+impl DuckDbInfo for MacroInfo {
+    fn format_id(&self) -> String {
+        format!("{}.{}", self.schema, self.macro_name)
+    }
+
+    fn to_tilejson(&self, source_id: String) -> TileJSON {
+        let mut tilejson = tilejson::tilejson! {
+            tiles: vec![],
+            name: source_id,
+            description: self.format_id(),
+        };
+        tilejson.minzoom = self.minzoom;
+        tilejson.maxzoom = self.maxzoom;
+        tilejson.bounds = self.bounds;
+        patch_json(tilejson, self.tilejson.as_ref())
+    }
+
+    fn tile_info(&self) -> TileInfo {
+        TileInfo::new(Format::Mvt, Encoding::Uncompressed)
+    }
+}

--- a/martin/src/config/file/tiles/duckdb/config_table.rs
+++ b/martin/src/config/file/tiles/duckdb/config_table.rs
@@ -1,0 +1,253 @@
+use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroU32;
+
+use martin_tile_utils::{Encoding, Format, TileInfo};
+use serde::{Deserialize, Serialize};
+use tilejson::{Bounds, TileJSON, VectorLayer};
+use tracing::{info, warn};
+
+use super::DuckDbInfo;
+use crate::config::file::duckdb::utils::{normalize_key, patch_json};
+use crate::config::file::{CachePolicy, UnrecognizedValues};
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::{MltProcessConfig, MvtProcessConfig};
+
+pub type TableInfoSources = BTreeMap<String, TableInfo>;
+
+/// Example bounds covering the whole world, shared between table and macro
+/// configs so the rendered docs example matches what the curated `config.yaml`
+/// used to ship.
+#[cfg(feature = "unstable-schemas")]
+pub(crate) fn bounds_world_example() -> [f64; 4] {
+    [-180.0, -90.0, 180.0, 90.0]
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct TableInfo {
+    /// ID of the MVT layer (optional, defaults to table name)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"table_source"))]
+    pub layer_id: Option<String>,
+
+    /// Table schema (required)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"main"))]
+    pub schema: String,
+
+    /// Table name (required)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"roads"))]
+    pub table: String,
+
+    /// Geometry SRID (required)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4326i32))]
+    pub srid: i32,
+
+    /// Geometry column name (required)
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"geom"))]
+    pub geometry_column: String,
+
+    /// Geometry column has a spatial index
+    #[serde(skip)]
+    pub geometry_index: Option<bool>,
+
+    /// Feature id column name
+    pub id_column: Option<String>,
+
+    /// An integer specifying the minimum zoom level
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &0u8))]
+    pub minzoom: Option<u8>,
+
+    /// An integer specifying the maximum zoom level. MUST be >= minzoom
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &30u8))]
+    pub maxzoom: Option<u8>,
+
+    /// The maximum extent of available map tiles. Bounds MUST define an area
+    /// covered by all zoom levels. The bounds are represented in WGS:84 latitude
+    /// and longitude values, in the order left, bottom, right, top. Values may
+    /// be integers or floating point numbers.
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<[f64; 4]>"))]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(example = bounds_world_example())
+    )]
+    pub bounds: Option<Bounds>,
+
+    /// Tile extent in tile coordinate space
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &4096u32))]
+    pub extent: Option<NonZeroU32>,
+
+    /// Buffer distance in tile coordinate space to optionally clip geometries
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &64u32))]
+    pub buffer: Option<u32>,
+
+    /// Boolean to control if geometries should be clipped or encoded as is
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &true))]
+    pub clip_geom: Option<bool>,
+
+    /// Geometry type
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &"GEOMETRY"))]
+    pub geometry_type: Option<String>,
+
+    /// Zoom-level bounds for tile caching (overrides top-level cache).
+    /// default: null (inherit from top-level default)
+    /// Use `cache: disable` to disable caching for this source.
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "Option<crate::config::file::CachePolicyShape>")
+    )]
+    pub cache: Option<CachePolicy>,
+
+    /// List of columns, that should be encoded as tile properties (required)
+    ///
+    /// Keys and values are the names and descriptions of attributes available in this layer.
+    /// Each value (description) must be a string that describes the underlying data.
+    /// If no fields (=just the geometry) should be encoded, an empty object is allowed.
+    pub properties: Option<BTreeMap<String, String>>,
+
+    /// Mapping of properties to the actual table columns
+    #[serde(skip)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub prop_mapping: HashMap<String, String>,
+
+    /// MVT->MLT encoder settings for this source.
+    /// Overrides source-type and global `convert_to_mlt`.
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mlt: Option<MltProcessConfig>,
+
+    /// MLT->MVT conversion settings for this source.
+    /// Overrides source-type and global `convert_to_mvt`.
+    ///
+    /// Can be either:
+    /// - `null` (default) - defer to the source-type or global settings
+    /// - `auto` - we choose defaults which we think work best for most users
+    /// - `disabled` - no conversion
+    /// - explicitly configured
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[serde(default)]
+    pub convert_to_mvt: Option<MvtProcessConfig>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+
+    /// `TileJSON` provided by catalog metadata. Shouldn't be serialized.
+    #[serde(skip)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub tilejson: Option<serde_json::Value>,
+}
+
+impl DuckDbInfo for TableInfo {
+    fn format_id(&self) -> String {
+        format!("{}.{}.{}", self.schema, self.table, self.geometry_column)
+    }
+
+    /// Result `TileJson` will be patched by the `TileJson` from catalog metadata if provided.
+    /// The `source_id` will be replaced by `self.layer_id` in the vector layer info if set.
+    fn to_tilejson(&self, source_id: String) -> TileJSON {
+        let mut tilejson = tilejson::tilejson! {
+            tiles: vec![],
+            name: source_id.clone(),
+            description: self.format_id(),
+        };
+        tilejson.minzoom = self.minzoom;
+        tilejson.maxzoom = self.maxzoom;
+        tilejson.bounds = self.bounds;
+
+        let id = self.layer_id.clone().unwrap_or(source_id);
+        let layer = VectorLayer {
+            id,
+            fields: self.properties.clone().unwrap_or_default(),
+            description: None,
+            maxzoom: None,
+            minzoom: None,
+            other: BTreeMap::default(),
+        };
+        tilejson.vector_layers = Some(vec![layer]);
+        patch_json(tilejson, self.tilejson.as_ref())
+    }
+
+    fn tile_info(&self) -> TileInfo {
+        TileInfo::new(Format::Mvt, Encoding::Uncompressed)
+    }
+}
+
+impl TableInfo {
+    /// For a given table info discovered from the database, append the configuration info provided by the user.
+    #[must_use]
+    pub fn append_cfg_info(
+        &self,
+        cfg_inf: &Self,
+        new_id: &str,
+        default_srid: Option<i32>,
+    ) -> Option<Self> {
+        let mut inf = Self {
+            schema: self.schema.clone(),
+            table: self.table.clone(),
+            geometry_column: self.geometry_column.clone(),
+            geometry_index: self.geometry_index,
+            tilejson: self.tilejson.clone(),
+            srid: self.calc_srid(new_id, cfg_inf.srid, default_srid)?,
+            prop_mapping: HashMap::new(),
+            ..cfg_inf.clone()
+        };
+
+        match (&self.geometry_type, &cfg_inf.geometry_type) {
+            (Some(src), Some(cfg)) if src != cfg => {
+                warn!(
+                    "Table {} has geometry type={src}, but source {new_id} has {cfg}",
+                    self.format_id()
+                );
+            }
+            _ => {}
+        }
+
+        let empty = BTreeMap::new();
+        let props = self.properties.as_ref().unwrap_or(&empty);
+
+        if let Some(id_column) = &cfg_inf.id_column {
+            let prop = normalize_key(props, id_column.as_str(), "id_column", new_id)?;
+            inf.prop_mapping.insert(id_column.clone(), prop);
+        }
+
+        if let Some(p) = &cfg_inf.properties {
+            for key in p.keys() {
+                let prop = normalize_key(props, key.as_str(), "property", new_id)?;
+                inf.prop_mapping.insert(key.clone(), prop);
+            }
+        }
+
+        Some(inf)
+    }
+
+    /// Determine the SRID value to use for a table, or None if unknown, assuming self is a table info from the database.
+    #[must_use]
+    pub fn calc_srid(&self, new_id: &str, cfg_srid: i32, default_srid: Option<i32>) -> Option<i32> {
+        match (self.srid, cfg_srid, default_srid) {
+            (0, 0, Some(default_srid)) => {
+                info!(
+                    "Table {} has SRID=0, using provided default SRID={default_srid}",
+                    self.format_id()
+                );
+                Some(default_srid)
+            }
+            (0, 0, None) => {
+                warn!(
+                    "Table {} has SRID=0, skipping. Set `default_srid` on the duckdb config or specify this table's SRID.",
+                    self.format_id()
+                );
+                None
+            }
+            (0, cfg, _) => Some(cfg),
+            (src, 0, _) => Some(src),
+            (src, cfg, _) if src != cfg => {
+                warn!(
+                    "Table {} has SRID={src}, but source {new_id} has SRID={cfg}",
+                    self.format_id()
+                );
+                None
+            }
+            (_, cfg, _) => Some(cfg),
+        }
+    }
+}

--- a/martin/src/config/file/tiles/duckdb/mod.rs
+++ b/martin/src/config/file/tiles/duckdb/mod.rs
@@ -1,0 +1,23 @@
+mod config;
+pub use config::*;
+
+mod config_geoparquet;
+pub use config_geoparquet::{
+    DuckDbGeoParquetSourceConfig, GeoParquetTarget, parse_geoparquet_target,
+};
+
+mod config_macro;
+pub use config_macro::*;
+
+mod config_table;
+pub use config_table::*;
+
+pub(crate) mod utils;
+
+mod builder;
+pub use builder::DuckDbAutoDiscoveryBuilder;
+
+mod spec;
+pub use spec::SourceSpec;
+
+pub mod resolver;

--- a/martin/src/config/file/tiles/duckdb/resolver/mod.rs
+++ b/martin/src/config/file/tiles/duckdb/resolver/mod.rs
@@ -1,0 +1,1 @@
+//! DuckDB catalog queries and SQL generation helpers.

--- a/martin/src/config/file/tiles/duckdb/spec.rs
+++ b/martin/src/config/file/tiles/duckdb/spec.rs
@@ -1,0 +1,68 @@
+//! A resolved tile-source description produced by `discover`, before instantiation.
+
+use std::hash::Hash as _;
+
+use martin_core::tiles::duckdb::DuckDBSqlInfo;
+
+use crate::config::file::duckdb::{DuckDbGeoParquetSourceConfig, MacroInfo, TableInfo};
+
+/// A resolved DuckDB tile-source description ready to be instantiated.
+#[derive(Clone, Debug)]
+pub enum SourceSpec {
+    /// A geometry table source. SQL and bounds are deferred to instantiate.
+    Table(TableInfo),
+    /// A macro source. SQL may already be known from catalog discovery.
+    Macro(MacroInfo, DuckDBSqlInfo),
+    /// A single-layer GeoParquet source.
+    GeoParquet(DuckDbGeoParquetSourceConfig),
+}
+
+impl SourceSpec {
+    /// Content hash over fields that affect served tile bytes or metadata.
+    #[must_use]
+    pub fn fingerprint(&self) -> u128 {
+        use xxhash_rust::xxh3::Xxh3;
+
+        let mut hasher = Xxh3::new();
+        match self {
+            Self::Table(info) => {
+                0u8.hash(&mut hasher);
+                info.layer_id.hash(&mut hasher);
+                info.schema.hash(&mut hasher);
+                info.table.hash(&mut hasher);
+                info.srid.hash(&mut hasher);
+                info.geometry_column.hash(&mut hasher);
+                info.id_column.hash(&mut hasher);
+                info.minzoom.hash(&mut hasher);
+                info.maxzoom.hash(&mut hasher);
+                info.extent.hash(&mut hasher);
+                info.buffer.hash(&mut hasher);
+                info.clip_geom.hash(&mut hasher);
+                info.geometry_type.hash(&mut hasher);
+                info.properties.hash(&mut hasher);
+            }
+            Self::Macro(info, sql) => {
+                1u8.hash(&mut hasher);
+                info.schema.hash(&mut hasher);
+                info.macro_name.hash(&mut hasher);
+                info.minzoom.hash(&mut hasher);
+                info.maxzoom.hash(&mut hasher);
+                sql.sql_query.hash(&mut hasher);
+                sql.signature.hash(&mut hasher);
+            }
+            Self::GeoParquet(info) => {
+                2u8.hash(&mut hasher);
+                info.geoparquet.hash(&mut hasher);
+                info.layer_id.hash(&mut hasher);
+                info.geometry_column.hash(&mut hasher);
+                info.srid.hash(&mut hasher);
+                info.minzoom.hash(&mut hasher);
+                info.maxzoom.hash(&mut hasher);
+                info.extent.hash(&mut hasher);
+                info.buffer.hash(&mut hasher);
+                info.clip_geom.hash(&mut hasher);
+            }
+        }
+        hasher.digest128()
+    }
+}

--- a/martin/src/config/file/tiles/duckdb/utils.rs
+++ b/martin/src/config/file/tiles/duckdb/utils.rs
@@ -1,0 +1,102 @@
+use std::collections::BTreeMap;
+
+use itertools::Itertools as _;
+use tilejson::TileJSON;
+use tracing::{error, info};
+
+#[must_use]
+pub fn normalize_key<T>(
+    map: &BTreeMap<String, T>,
+    key: &str,
+    info: &str,
+    id: &str,
+) -> Option<String> {
+    find_info_kv(map, key, info, id)
+        .map(|(k, _)| k.to_string())
+        .ok()
+}
+
+pub fn find_info<'a, T>(
+    map: &'a BTreeMap<String, T>,
+    key: &'a str,
+    info: &str,
+    id: &str,
+) -> Result<&'a T, String> {
+    find_info_kv(map, key, info, id).map(|(_, v)| v)
+}
+
+fn find_info_kv<'a, T>(
+    map: &'a BTreeMap<String, T>,
+    key: &'a str,
+    info: &str,
+    id: &str,
+) -> Result<(&'a str, &'a T), String> {
+    if let Some(v) = map.get(key) {
+        return Ok((key, v));
+    }
+
+    match find_kv_ignore_case(map, key) {
+        Ok(None) => Err(format!(
+            "Unable to configure source {id} because {info} '{key}' was not found. Possible values are: {}",
+            map.keys().map(String::as_str).join(", ")
+        )),
+        Ok(Some(result)) => {
+            info!("For source {id}, {info} '{key}' was not found, but found '{result}' instead.");
+            let value = map.get(result).expect("guaranteed to be in the map");
+            Ok((result.as_str(), value))
+        }
+        Err(multiple) => Err(format!(
+            "Unable to configure source {id} because {info} '{key}' has no exact match and more than one potential matches: {}",
+            multiple.join(", ")
+        )),
+    }
+}
+
+pub fn find_kv_ignore_case<'a, T>(
+    map: &'a BTreeMap<String, T>,
+    key: &str,
+) -> Result<Option<&'a String>, Vec<String>> {
+    let key = key.to_lowercase();
+    let mut result = None;
+    let mut multiple = Vec::new();
+    for k in map.keys() {
+        if k.to_lowercase() == key {
+            match result {
+                None => result = Some(k),
+                Some(result) => {
+                    if multiple.is_empty() {
+                        multiple.push(result.clone());
+                    }
+                    multiple.push(k.clone());
+                }
+            }
+        }
+    }
+    if multiple.is_empty() {
+        Ok(result)
+    } else {
+        Err(multiple)
+    }
+}
+
+#[must_use]
+pub fn patch_json(target: TileJSON, patch: Option<&serde_json::Value>) -> TileJSON {
+    let Some(tj) = patch else {
+        return target;
+    };
+    let mut tilejson2 = match serde_json::to_value(target.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Failed to serialize tilejson, unable to merge comment: {e}");
+            return target;
+        }
+    };
+    json_patch::merge(&mut tilejson2, tj);
+    match serde_json::from_value(tilejson2.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Failed to deserialize merged comment tilejson: {e}");
+            target
+        }
+    }
+}

--- a/martin/src/config/file/tiles/mod.rs
+++ b/martin/src/config/file/tiles/mod.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "unstable-cog")]
 pub mod cog;
+#[cfg(feature = "duckdb")]
+pub mod duckdb;
 #[cfg(feature = "mbtiles")]
 pub mod mbtiles;
 #[cfg(feature = "pmtiles")]
 pub mod pmtiles;
 #[cfg(feature = "postgres")]
 pub mod postgres;
-#[cfg(feature = "duckdb")]
-pub mod duckdb;
 
 #[cfg(feature = "_tiles")]
 pub mod discovery;

--- a/martin/src/config/file/tiles/mod.rs
+++ b/martin/src/config/file/tiles/mod.rs
@@ -6,6 +6,8 @@ pub mod mbtiles;
 pub mod pmtiles;
 #[cfg(feature = "postgres")]
 pub mod postgres;
+#[cfg(feature = "duckdb")]
+pub mod duckdb;
 
 #[cfg(feature = "_tiles")]
 pub mod discovery;


### PR DESCRIPTION
#2264

This PR is in draft state right now. It implements config parsing for duckdb at `martin`. 

The core config parsing logic has been implemented. `builder` and `resolver` implementations need to be written. This is mostly similar to postgres with some adjustments based on the config structure for duckdb (which I am attaching below for reference):

```
duckdb:
  pool_size: 4
  auto_bounds: quick
  threads_per_query: 4
  memory_limit_mb: 2048
  sources:
    - database: /data/tiles.duckdb
      auto_publish:
        tables:
          from_schemas: autodetect
          source_id_format: "{table}"
          id_columns: [id, gid]
          extent: 4096
          buffer: 64
          clip_geom: true
        macros:
          from_schemas: autodetect
          source_id_format: "{macro}"

      tables:
        roads:
          schema: main
          table: roads
          geometry_column: geom
          srid: 4326
          minzoom: 0
          maxzoom: 14
          properties:
            id: int4
            name: varchar

      macros:
        custom:
          schema: main
          macro: get_custom_tile

    - geoparquet: /data/buildings.parquet
      layer_id: buildings
      geometry_column: geom
      srid: 4326
      minzoom: 0
      maxzoom: 14
      extent: 4096
      buffer: 64
```
