### PR TITLE
feat: update to mlt-core 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -1093,7 +1093,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1180,6 +1180,24 @@ name = "bsdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6709158fe6ca66c1f32eb27b4ae5997c67b0df350ae185831233af3e7a91213"
+
+[[package]]
+name = "buffa"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec95898e2ef31d6266042f21c398fa5ff8334d14d6b2ac5fb38b55448d94f595"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "compact_str 0.9.1",
+ "ecow",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "built"
@@ -1427,7 +1445,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1474,6 +1492,21 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -2216,6 +2249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dup-indexer"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c882fa8d131819ebc485e3c98abf54c8324b526345ea0fa5031b7fa7a27c9069"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2438,6 +2486,21 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-mvt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075da97a9d841b90a396a2c5b26808fce818ca21989bc8398d2d2122c8eae197"
+dependencies = [
+ "buffa",
+ "dup-indexer",
+ "geo-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "usize_cast",
+]
 
 [[package]]
 name = "fast_hilbert"
@@ -3064,6 +3127,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -3213,7 +3277,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hdrhistogram",
- "hotpath-macros",
+ "hotpath-macros 0.16.1",
  "hotpath-meta",
  "libc",
  "pin-project-lite",
@@ -3232,6 +3296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotpath"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ffc47505087fdc3825511dd51e7c9758ef729737d5764568f36fb671c0dee8"
+dependencies = [
+ "hotpath-macros 0.17.0",
+]
+
+[[package]]
 name = "hotpath-macros"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3314,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "hotpath-macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87c69fd35b5116b60e56c449afabc6cc6c05aac9d6d31aa3b565916d6b572db"
 
 [[package]]
 name = "hotpath-macros-meta"
@@ -3472,7 +3551,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4427,7 +4506,7 @@ dependencies = [
  "dashmap",
  "enum-display",
  "futures",
- "hotpath",
+ "hotpath 0.16.1",
  "humantime-serde",
  "image",
  "image-compare",
@@ -4497,7 +4576,7 @@ dependencies = [
  "env_logger",
  "flume",
  "futures",
- "hotpath",
+ "hotpath 0.16.1",
  "image",
  "image-compare",
  "insta",
@@ -4589,7 +4668,7 @@ dependencies = [
  "flate2",
  "flume",
  "futures",
- "hotpath",
+ "hotpath 0.16.1",
  "insta",
  "itertools 0.14.0",
  "martin-tile-utils",
@@ -4728,24 +4807,23 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07859e6e217e342840d9e3d0d85de44f4a307d7676377388088736f2a9e4b2d7"
+checksum = "9d8cb46ec2c8b5bbca77249949d3c648f2b20cc59e621d21974c5608cccc8af6"
 dependencies = [
  "bitvec",
  "bytemuck",
  "derive-debug",
  "enum_dispatch",
+ "fast-mvt",
  "fastpfor",
  "fsst-rs",
  "geo",
  "geo-types",
  "hex",
  "hilbert_2d",
- "hotpath",
+ "hotpath 0.17.0",
  "integer-encoding",
- "mvt",
- "mvt-reader",
  "num-traits",
  "num_enum",
  "probabilistic-collections",
@@ -4754,6 +4832,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "union-find",
+ "usize_cast",
  "wide",
  "zigzag",
 ]
@@ -4803,30 +4882,6 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
-
-[[package]]
-name = "mvt"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7366256c268a8333bbc0951831f4706ae927f5c2db073ab38c491e7515c1b9"
-dependencies = [
- "log",
- "num-traits",
- "pointy",
- "prost 0.14.3",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "mvt-reader"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5057362d82a08bc3c84e420c42939463aff5c3e21a91a41d8b7af94c8f061189"
-dependencies = [
- "geo-types",
- "num-traits",
- "prost 0.13.5",
-]
 
 [[package]]
 name = "native-tls"
@@ -5342,7 +5397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568e834fc9c115ccc1bcd7d79248a1c795d334e166ad4b657c86932df0246c43"
 dependencies = [
  "futures",
- "prost 0.14.3",
+ "prost",
  "sdf_glyph_renderer",
  "thiserror 2.0.18",
  "tokio",
@@ -5530,15 +5585,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "pointy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7319aff932c05d448afab77f22ae717fa30d5b289ff397e249d91bb654156413"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5737,35 +5783,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prost-derive",
 ]
 
 [[package]]
@@ -5775,7 +5798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5787,7 +5810,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -5880,7 +5903,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5918,7 +5941,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6093,7 +6116,7 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.11.1",
  "cassowary",
- "compact_str",
+ "compact_str 0.8.1",
  "crossterm 0.28.1",
  "indoc",
  "instability",
@@ -7272,6 +7295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8348,7 +8381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost",
  "tonic",
 ]
 
@@ -8728,6 +8761,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "usize_cast"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810f3a98a85147e3ad2a1331aa6dac66490e802d65fa0ab283c383058e3f9751"
 
 [[package]]
 name = "usvg"
@@ -9117,9 +9156,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "mlt-core"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8cb46ec2c8b5bbca77249949d3c648f2b20cc59e621d21974c5608cccc8af6"
+checksum = "5235ab2650a1831191ddb1d89ccca0b8a12c74c55bea8c597a32c21aca5e0a79"
 dependencies = [
  "bitvec",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,4 +168,3 @@ similar.opt-level = 3
 # Make release binaries a bit smaller
 lto = true
 codegen-units = 1
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.4" }
 mbtiles = { path = "./mbtiles", version = "0.18.0" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
-mlt-core = { version = "0.11.0", default-features = false }
+mlt-core = { version = "0.11.1", default-features = false }
 moka = { version = "0.12", default-features = false }
 notify = "8.2.0"
 num_cpus = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.4" }
 mbtiles = { path = "./mbtiles", version = "0.18.0" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
-mlt-core = { version = "0.9.1", default-features = false }
+mlt-core = { version = "0.11.0", default-features = false }
 moka = { version = "0.12", default-features = false }
 notify = "8.2.0"
 num_cpus = "1"
@@ -168,3 +168,4 @@ similar.opt-level = 3
 # Make release binaries a bit smaller
 lto = true
 codegen-units = 1
+

--- a/demo/frontend/package-lock.json
+++ b/demo/frontend/package-lock.json
@@ -2567,6 +2567,22 @@
         }
       }
     },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -68,7 +68,7 @@ cache:
 # - explicitely configured
 convert_to_mlt:
   # Allow `FastPFOR` integer compression.
-  allow_fpf: null
+  allow_fastpfor: null
   # Allow FSST string compression.
   allow_fsst: null
   # Allow string grouping into shared dictionaries.
@@ -129,7 +129,7 @@ mbtiles:
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
     # Allow `FastPFOR` integer compression.
-    allow_fpf: null
+    allow_fastpfor: null
     # Allow FSST string compression.
     allow_fsst: null
     # Allow string grouping into shared dictionaries.
@@ -172,7 +172,7 @@ pmtiles:
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
     # Allow `FastPFOR` integer compression.
-    allow_fpf: null
+    allow_fastpfor: null
     # Allow FSST string compression.
     allow_fsst: null
     # Allow string grouping into shared dictionaries.
@@ -290,7 +290,7 @@ postgres:
   # - explicitely configured
   convert_to_mlt:
     # Allow `FastPFOR` integer compression.
-    allow_fpf: null
+    allow_fastpfor: null
     # Allow FSST string compression.
     allow_fsst: null
     # Allow string grouping into shared dictionaries.

--- a/docs/content/using-guides/mlt.md
+++ b/docs/content/using-guides/mlt.md
@@ -109,7 +109,7 @@ Only the fields you specify override the defaults; unset fields keep their `mlt-
 | `try_spatial_hilbert_sort` | Disable if Morton sort doesn't compress well for your data                                                  |
 | `try_id_sort`              | Enable when features have sequential IDs and spatial sorting isn't beneficial                               |
 | `allow_fsst`               | Disable to reduce search space                                                                              |
-| `allow_fpf`                | Disable to reduce search space                                                                              |
+| `allow_fastpfor`           | Disable to reduce search space                                                                              |
 | `allow_shared_dict`        | Disable to reduce search space                                                                              |
 
 !!! note

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -133,7 +133,7 @@ convert-to-mlt:
   try_spatial_hilbert_sort: true # Disable if Morton sort doesn't compress well for your data
   try_id_sort: false # Enable when features have sequential IDs and spatial sorting isn't beneficial
   allow_fsst: true # Disable to reduce search space
-  allow_fpf: true # Disable to reduce search space
+  allow_fastpfor: true # Disable to reduce search space
   allow_shared_dict: true # Disable to reduce search space
 ```
 

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.16",

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -69,7 +69,7 @@ pub struct MltEncoderConfig {
     /// Allow FSST string compression.
     pub allow_fsst: Option<bool>,
     /// Allow `FastPFOR` integer compression.
-    pub allow_fpf: Option<bool>,
+    pub allow_fastpfor: Option<bool>,
     /// Allow string grouping into shared dictionaries.
     pub allow_shared_dict: Option<bool>,
 
@@ -101,7 +101,7 @@ impl From<MltEncoderConfig> for EncoderConfig {
             try_spatial_hilbert_sort,
             try_id_sort,
             allow_fsst,
-            allow_fpf,
+            allow_fastpfor,
             allow_shared_dict,
             // Unrecognized keys are reported via the warning path during finalize();
             // they intentionally don't influence the resulting EncoderConfig.
@@ -116,7 +116,7 @@ impl From<MltEncoderConfig> for EncoderConfig {
                 .unwrap_or(Self::default().try_spatial_hilbert_sort),
             try_id_sort: try_id_sort.unwrap_or(Self::default().try_id_sort),
             allow_fsst: allow_fsst.unwrap_or(Self::default().allow_fsst),
-            allow_fpf: allow_fpf.unwrap_or(Self::default().allow_fpf),
+            allow_fastpfor: allow_fastpfor.unwrap_or(Self::default().allow_fastpfor),
             allow_shared_dict: allow_shared_dict.unwrap_or(Self::default().allow_shared_dict),
         }
     }

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -69,6 +69,7 @@ pub struct MltEncoderConfig {
     /// Allow FSST string compression.
     pub allow_fsst: Option<bool>,
     /// Allow `FastPFOR` integer compression.
+    #[serde(alias="allow_fpf")]
     pub allow_fastpfor: Option<bool>,
     /// Allow string grouping into shared dictionaries.
     pub allow_shared_dict: Option<bool>,

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -69,7 +69,7 @@ pub struct MltEncoderConfig {
     /// Allow FSST string compression.
     pub allow_fsst: Option<bool>,
     /// Allow `FastPFOR` integer compression.
-    #[serde(alias="allow_fpf")]
+    #[serde(alias = "allow_fpf")]
     pub allow_fastpfor: Option<bool>,
     /// Allow string grouping into shared dictionaries.
     pub allow_shared_dict: Option<bool>,

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -597,7 +597,7 @@
     "MltEncoderConfig": {
       "description": "Explicit encoder configuration for MLT conversion.\nAll fields are optional; unset fields use `mlt-core`'s defaults.",
       "properties": {
-        "allow_fpf": {
+        "allow_fastpfor": {
           "description": "Allow `FastPFOR` integer compression.",
           "type": ["boolean", "null"]
         },


### PR DESCRIPTION
Note: this breaks the martin config because `allow_fpf` was renamed to `allow_fastpfor`



(In pursuit of my "get martin generated MLT working with native and www")