### PR TITLE
feat(martin-core): add Transport::from_string_headers

### DIFF
--- a/martin-core/src/tiles/passthrough/error.rs
+++ b/martin-core/src/tiles/passthrough/error.rs
@@ -12,6 +12,26 @@ pub enum PassthroughError {
     #[error("Passthrough upstream has no URL templates configured")]
     EmptyUrlList,
 
+    /// A configured request header name was not a valid HTTP header name.
+    #[error("Invalid header name {name:?} for passthrough upstream: {source}")]
+    InvalidHeaderName {
+        /// The offending header name as written in the config.
+        name: String,
+        /// Why the name was rejected.
+        #[source]
+        source: reqwest::header::InvalidHeaderName,
+    },
+
+    /// A configured request header value was not a valid HTTP header value.
+    #[error("Invalid value for header {name:?} for passthrough upstream: {source}")]
+    InvalidHeaderValue {
+        /// The header name whose value was rejected.
+        name: String,
+        /// Why the value was rejected.
+        #[source]
+        source: reqwest::header::InvalidHeaderValue,
+    },
+
     /// A configured tile-URL template is missing one of the `{z}`/`{x}`/`{y}` placeholders.
     #[error("Tile URL template {0} must contain {{z}}, {{x}} and {{y}} placeholders")]
     InvalidUrlTemplate(String),

--- a/martin-core/src/tiles/passthrough/source.rs
+++ b/martin-core/src/tiles/passthrough/source.rs
@@ -35,6 +35,39 @@ impl Transport {
             timeout,
         }
     }
+
+    /// Build a transport from string header pairs, validating each name and value.
+    ///
+    /// This lets callers (e.g. the `martin` crate's config layer) supply headers without
+    /// depending on `reqwest`'s header types directly.
+    pub fn from_string_headers<'a, I>(
+        timeout: Duration,
+        headers: I,
+    ) -> Result<Self, PassthroughError>
+    where
+        I: IntoIterator<Item = (&'a str, &'a str)>,
+    {
+        let mut header_map = HeaderMap::new();
+        for (name, value) in headers {
+            let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|source| {
+                PassthroughError::InvalidHeaderName {
+                    name: name.to_string(),
+                    source,
+                }
+            })?;
+            let header_value = HeaderValue::from_str(value).map_err(|source| {
+                PassthroughError::InvalidHeaderValue {
+                    name: name.to_string(),
+                    source,
+                }
+            })?;
+            header_map.insert(header_name, header_value);
+        }
+        Ok(Self {
+            headers: header_map,
+            timeout,
+        })
+    }
 }
 
 /// Operator-supplied metadata for a template upstream.
@@ -394,4 +427,43 @@ fn header_str(headers: &HeaderMap, name: &HeaderName) -> Option<String> {
         .get(name)
         .and_then(|value| value.to_str().ok())
         .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_string_headers_validates_and_collects() {
+        let transport = Transport::from_string_headers(
+            Duration::from_secs(1),
+            [("x-api-key", "secret"), ("accept", "application/x-protobuf")],
+        )
+        .unwrap();
+        assert_eq!(transport.headers.get("x-api-key").unwrap(), "secret");
+        assert_eq!(
+            transport.headers.get("accept").unwrap(),
+            "application/x-protobuf"
+        );
+    }
+
+    #[test]
+    fn from_string_headers_rejects_invalid_name() {
+        let err = Transport::from_string_headers(Duration::from_secs(1), [("bad name", "v")])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            PassthroughError::InvalidHeaderName { name, .. } if name == "bad name"
+        ));
+    }
+
+    #[test]
+    fn from_string_headers_rejects_invalid_value() {
+        let err = Transport::from_string_headers(Duration::from_secs(1), [("x-key", "bad\nvalue")])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            PassthroughError::InvalidHeaderValue { name, .. } if name == "x-key"
+        ));
+    }
 }

--- a/martin-core/src/tiles/passthrough/source.rs
+++ b/martin-core/src/tiles/passthrough/source.rs
@@ -437,7 +437,10 @@ mod tests {
     fn from_string_headers_validates_and_collects() {
         let transport = Transport::from_string_headers(
             Duration::from_secs(1),
-            [("x-api-key", "secret"), ("accept", "application/x-protobuf")],
+            [
+                ("x-api-key", "secret"),
+                ("accept", "application/x-protobuf"),
+            ],
         )
         .unwrap();
         assert_eq!(transport.headers.get("x-api-key").unwrap(), "secret");


### PR DESCRIPTION
Adds a validating `Transport` constructor that builds the header map from string pairs, letting callers supply headers without depending on `reqwest`'s header types.