### PR TITLE
feat(martin): suffix source etag on MVT/MLT conversion

### DIFF
--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -230,6 +230,28 @@ mod tests {
         assert!(!decoded.data.is_empty());
     }
 
+    /// Converting MVT->MLT keeps the source etag with a `+mlt` suffix instead of
+    /// re-hashing, so the converted bytes get a distinct-but-stable etag. Converting
+    /// back to MVT appends `+mvt`.
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[test]
+    fn conversion_suffixes_source_etag() {
+        let tile = Tile::new_with_etag(
+            mvt_with_feature_bytes(),
+            TileInfo::new(Format::Mvt, Encoding::Uncompressed),
+            "upstream-etag".to_string(),
+        );
+        let mlt =
+            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
+        assert_eq!(mlt.info.format, Format::Mlt);
+        assert_eq!(mlt.etag, "upstream-etag+mlt");
+
+        let mvt =
+            apply_pre_cache_processors(mlt, &ProcessConfig::default(), Some(Format::Mvt)).unwrap();
+        assert_eq!(mvt.info.format, Format::Mvt);
+        assert_eq!(mvt.etag, "upstream-etag+mlt+mvt");
+    }
+
     /// MLT source tile with MVT Accept header converts to MVT.
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     #[test]

--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -230,9 +230,6 @@ mod tests {
         assert!(!decoded.data.is_empty());
     }
 
-    /// Converting MVT->MLT keeps the source etag with a `+mlt` suffix instead of
-    /// re-hashing, so the converted bytes get a distinct-but-stable etag. Converting
-    /// back to MVT appends `+mvt`.
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     #[test]
     fn conversion_suffixes_source_etag() {

--- a/martin/src/srv/tiles/process/to_mlt.rs
+++ b/martin/src/srv/tiles/process/to_mlt.rs
@@ -9,9 +9,15 @@ use crate::srv::tiles::process::ProcessError;
 ///
 /// Handles decompression if the tile is compressed, then converts MVT->MLT
 /// using `mlt-core`, and returns an uncompressed MLT tile.
+///
+/// The output keeps the source tile's etag with a `+mlt` suffix rather than
+/// re-hashing the (potentially large) converted bytes. This keeps the converted
+/// etag distinct from the original so the client->martin 304 path stays correct
+/// while passthrough sources can surface an upstream `ETag` verbatim.
 pub fn convert_mvt_to_mlt(tile: Tile, cfg: EncoderConfig) -> Result<Tile, ProcessError> {
     use martin_tile_utils::{Encoding, TileInfo};
 
+    let etag = format!("{}+mlt", tile.etag);
     let decoded =
         content::decode(tile).map_err(|e| ProcessError::DecompressionFailed(e.to_string()))?;
 
@@ -26,8 +32,9 @@ pub fn convert_mvt_to_mlt(tile: Tile, cfg: EncoderConfig) -> Result<Tile, Proces
         mlt_bytes.extend_from_slice(&layer_bytes);
     }
 
-    Ok(Tile::new_hash_etag(
+    Ok(Tile::new_with_etag(
         mlt_bytes,
         TileInfo::new(Format::Mlt, Encoding::Internal),
+        etag,
     ))
 }

--- a/martin/src/srv/tiles/process/to_mvt.rs
+++ b/martin/src/srv/tiles/process/to_mvt.rs
@@ -10,7 +10,11 @@ use crate::srv::tiles::process::ProcessError;
 ///
 /// Decompresses the tile if needed, decodes the MLT layers into row-oriented
 /// `TileLayer`s, and re-encodes them as MVT via `mlt-core`.
+///
+/// The output keeps the source tile's etag with a `+mvt` suffix rather than
+/// re-hashing the converted bytes, mirroring [`convert_mvt_to_mlt`](super::to_mlt::convert_mvt_to_mlt).
 pub fn convert_mlt_to_mvt(tile: Tile) -> Result<Tile, ProcessError> {
+    let etag = format!("{}+mvt", tile.etag);
     let mlt =
         content::decode(tile).map_err(|e| ProcessError::DecompressionFailed(e.to_string()))?;
 
@@ -34,9 +38,10 @@ pub fn convert_mlt_to_mvt(tile: Tile) -> Result<Tile, ProcessError> {
     let mvt_bytes =
         tile_layers_to_mvt(tile_layers).map_err(|e| ProcessError::MvtConversion(e.to_string()))?;
 
-    Ok(Tile::new_hash_etag(
+    Ok(Tile::new_with_etag(
         mvt_bytes,
         TileInfo::new(Format::Mvt, Encoding::Uncompressed),
+        etag,
     ))
 }
 

--- a/tests/expected/process/proc_mlt_table_source.mlt.headers
+++ b/tests/expected/process/proc_mlt_table_source.mlt.headers
@@ -1,4 +1,4 @@
 content-length: 916
 content-type: application/vnd.maplibre-tile
-etag: "lXHvDME1tnH4A_nFoOrKkA"
+etag: "lDkxk7p2r2HsWFzhXDsD5A+mlt"
 vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers


### PR DESCRIPTION
MVT<->MLT conversion now appends `+mlt`/`+mvt` to the source tile's etag instead of re-hashing the converted bytes, keeping a stable but distinct etag.