### PR TITLE
chore(ci): retry action on fail

### DIFF
--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -1,0 +1,33 @@
+name: CI auto-retry
+
+on:
+  # zizmor: ignore[dangerous-triggers] we never check out or run code from the triggering run, only `gh run rerun`
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  retry:
+    name: Retry failed CI
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # Retry actions
+    steps:
+      - name: retry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.event.repository.full_name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # Get info about the run
+          output=$(gh run view --repo "$REPO" "$RUN_ID")
+          echo "$output"
+
+          # Rerun the failed workflow if needed
+          if echo "$output" | grep -q "Process completed with exit code 1"; then
+            gh run rerun "$RUN_ID" --repo "$REPO" --failed
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,8 +955,23 @@ jobs:
       - test-aws-lambda
       - test-publish
     if: always()
-    permissions: {}
+    permissions:
+      actions: write # Retry actions
+      checks: read   # Get info about the run
     steps:
+      - name: retry
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+        run: |
+          # Get info about the run
+          $output = gh run view --repo "${{ github.event.repository.full_name }}" "${{ github.event.workflow_run.id }}"
+          $output
+
+          # Rerun the failed workflow if needed
+          if ($output -match "Process completed with exit code 1") {
+            gh run rerun "${{ github.event.workflow_run.id }}" --repo "${{ github.event.repository.full_name }}"" --failed
+          }
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Result of the needed steps
         run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,23 +955,8 @@ jobs:
       - test-aws-lambda
       - test-publish
     if: always()
-    permissions:
-      actions: write # Retry actions
-      checks: read   # Get info about the run
+    permissions: {}
     steps:
-      - name: retry
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
-        run: |
-          # Get info about the run
-          $output = gh run view --repo "${{ github.event.repository.full_name }}" "${{ github.event.workflow_run.id }}"
-          $output
-
-          # Rerun the failed workflow if needed
-          if ($output -match "Process completed with exit code 1") {
-            gh run rerun "${{ github.event.workflow_run.id }}" --repo "${{ github.event.repository.full_name }}"" --failed
-          }
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Result of the needed steps
         run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}


### PR DESCRIPTION
very anoying that our CI is this flaky.
This is mostly to stem the bleeding rather than actualyl fix it.

Most of our CI runs have at least one networking fail nowerdays, which we are not very tolerant to.