### PR TITLE
fix: gate idr lint expectations on absence of consuming backends

### DIFF
--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -353,7 +353,12 @@ impl Config {
     #[cfg(feature = "_tiles")]
     #[instrument(skip_all, err(Debug))]
     #[cfg_attr(
-        feature = "unstable-duckdb",
+        not(any(
+            feature = "postgres",
+            feature = "pmtiles",
+            feature = "mbtiles",
+            feature = "unstable-cog"
+        )),
         expect(
             unused_variables,
             reason = "idr is only consumed by the non-duckdb tile backends"
@@ -365,7 +370,12 @@ impl Config {
         #[cfg(feature = "pmtiles")] pmtiles_cache: PmtCache,
     ) -> MartinResult<(Vec<Vec<BoxedSource>>, Vec<TileSourceWarning>)> {
         #[cfg_attr(
-            feature = "unstable-duckdb",
+            not(any(
+                feature = "postgres",
+                feature = "pmtiles",
+                feature = "mbtiles",
+                feature = "unstable-cog"
+            )),
             expect(
                 unused_mut,
                 reason = "the non-duckdb tile backends push resolved sources here"


### PR DESCRIPTION
Fixes the unfulfilled `unused_variables`/`unused_mut` lint expectations that broke CI when `unstable-duckdb` is built alongside another tile backend.