### PR TITLE
ci: fetch deps with retry+backoff before cargo recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,9 +38,6 @@ PGPORT := '5411'
 
 export DATABASE_URL := ('postgres://postgres:postgres@localhost:' + PGPORT + '/db' + (if PGPARAMS != '' { '?' + PGPARAMS } else { '' }))
 export CARGO_TERM_COLOR := 'always'
-# Be resilient to flaky networks when fetching crates/registries
-export CARGO_NET_RETRY := env('CARGO_NET_RETRY', '10')
-export CARGO_HTTP_TIMEOUT := env('CARGO_HTTP_TIMEOUT', '60')
 
 # Set AWS variables for testing pmtiles from S3
 export AWS_SKIP_CREDENTIALS := '1'
@@ -50,7 +47,7 @@ export AWS_REGION := 'eu-central-1'
     {{just}} --list
 
 # Run benchmark tests
-bench:
+bench: fetch
     cargo bench --bench sources
     open target/criterion/report/index.html
 
@@ -68,11 +65,11 @@ bench-http requests='10m' pg_requests='500k':  (cargo-install 'oha')
     oha --latency-correction -n {{requests}}            http://localhost:3000/stamen_toner__raster_CC-BY-ODbL_z3/0/0/0
 
 # Start release-compiled Martin server and a test database
-bench-server: start
+bench-server: fetch start
     cargo run --release -- tests/fixtures/mbtiles tests/fixtures/pmtiles
 
 # Build martin with hotpath profiling support
-build-hotpath:
+build-hotpath: fetch
     RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable" cargo build --release --features hotpath
 
 # Start release-compiled Martin server with hotpath profiling (MCP on port 6771)
@@ -80,7 +77,7 @@ bench-server-hotpath: start build-hotpath
     exec target/release/martin tests/fixtures/mbtiles tests/fixtures/pmtiles
 
 # Regenerate configs' JSON Schema, HTTP OpenAPI spec, and TS types
-gen-schemas:
+gen-schemas: fetch
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p schemas
@@ -189,7 +186,7 @@ bless:
 
 # Run insta snapshot tests and save their output as the new expected output.
 # On Linux, replay the rendering tests' tiles from the cassette (like `coverage`).
-bless-insta *args:  (cargo-install 'cargo-insta')
+bless-insta *args:  fetch (cargo-install 'cargo-insta')
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "$(uname)" = Linux ]; then
@@ -204,14 +201,14 @@ bless-int: start
     tests/test.sh
     rm -rf tests/expected && mv tests/output tests/expected
 
-bless-pg: start  (cargo-install 'cargo-insta')
+bless-pg: fetch start  (cargo-install 'cargo-insta')
     cargo insta test --accept --features test-pg --no-default-features --test pg_function_source_test --test pg_reload_test --test pg_server_test --test pg_table_source_test
     cargo insta test --accept --features test-pg --no-default-features --package martin --lib
     cargo insta test --accept --features test-pg --package martin-core --no-default-features --lib
 
 # Build binaries for a target. In release mode (default), strips debug info.
 # Set RELEASE_MODE='' to build in debug mode (used for PRs in CI to reduce build time).
-build-release target:
+build-release target: fetch
     #!/usr/bin/env bash
     set -euo pipefail
     # on debian we need to build a deb package
@@ -229,14 +226,14 @@ build-release target:
 # Build debian package
 # Note: rendering feature is excluded because the Debian build targets older glibc (ubuntu-22.04)
 # and maplibre_native pre-built libraries require newer glibc.
-build-deb output: (cargo-install 'cargo-deb')
+build-deb output: fetch (cargo-install 'cargo-deb')
     sudo apt-get install -y dpkg dpkg-dev liblzma-dev
     cargo deb -v -p martin {{if release_mode == '1' {''} else {'--profile dev'} }} --output {{output}} -- --no-default-features --features {{stable_features}}
 
 # Build for musl target using zigbuild
 # Set RELEASE_MODE='' to build in debug mode (used for PRs in CI to reduce build time).
 # Note: rendering feature is excluded because maplibre_native cannot be cross-compiled for musl targets.
-build-release-musl target:
+build-release-musl target: fetch
     rustup target add {{target}}
     {{if release_mode == '1' {'CARGO_TARGET_' + shoutysnakecase(target) + '_RUSTFLAGS="-C strip=debuginfo"'} else {''} }} cargo zigbuild {{if release_mode == '1' {'--release'} else {''} }} --target {{target}} --package mbtiles --locked
     {{if release_mode == '1' {'CARGO_TARGET_' + shoutysnakecase(target) + '_RUSTFLAGS="-C strip=debuginfo"'} else {''} }} cargo zigbuild {{if release_mode == '1' {'--release'} else {''} }} --target {{target}} --package martin --locked --no-default-features --features {{stable_features}}
@@ -265,11 +262,11 @@ move-artifacts target:
 
 
 # Quick compile without building a binary
-check: (cargo-install 'cargo-hack')
+check: fetch (cargo-install 'cargo-hack')
     cargo hack --exclude-features _tiles,_catalog,hotpath,hotpath_tui check --all-targets --each-feature --workspace
 
 # Verify cargo-binstall metadata resolves correctly
-check-binstall: (cargo-install 'cargo-binstall')
+check-binstall: fetch (cargo-install 'cargo-binstall')
     cargo binstall martin --manifest-path martin/Cargo.toml --dry-run --no-confirm
 
 # Test documentation generation
@@ -284,7 +281,7 @@ clean: clean-test stop ui::clean
     cargo clean
 
 # Run cargo clippy to lint the code
-clippy *args:
+clippy *args: fetch
     cargo clippy --workspace --all-targets {{args}}
 
 # Validate markdown URLs with markdown-link-check
@@ -355,7 +352,7 @@ seed-render-fixtures:
     {{just}} _run-render-proxy record "cargo test -p martin-core --features rendering --test rendering_test && cargo test -p martin --test styles_rendering_test"
 
 # Generate code coverage report. Will install `cargo llvm-cov` if missing.
-coverage *args='--no-clean --open':  (cargo-install 'cargo-llvm-cov') clean start
+coverage *args='--no-clean --open':  fetch (cargo-install 'cargo-llvm-cov') clean start
     #!/usr/bin/env bash
     set -euo pipefail
     if ! rustup component list | grep llvm-tools-preview > /dev/null; then \
@@ -380,7 +377,7 @@ coverage *args='--no-clean --open':  (cargo-install 'cargo-llvm-cov') clean star
     cargo llvm-cov report {{args}}
 
 # Start Martin server
-cp *args:
+cp *args: fetch
     cargo run --bin martin-cp -- {{args}}
 
 # Start Martin server and open a test page (not the integrated UI)
@@ -414,7 +411,7 @@ env-info:
     node --version
 
 # Reformat all code `cargo fmt`. If nightly is available, use it for better results
-fmt:
+fmt: fetch
     #!/usr/bin/env bash
     set -euo pipefail
     if (rustup toolchain list | grep nightly && rustup component list --toolchain nightly | grep rustfmt) &> /dev/null; then
@@ -495,7 +492,7 @@ install-dependencies backend='vulkan':
 lint: fmt check clippy ui::biome ui::type-check clippy-md fmt-toml
 
 # Run mbtiles command
-mbtiles *args:
+mbtiles *args: fetch
     cargo run -p mbtiles -- {{args}}
 
 # Create assets package
@@ -519,7 +516,7 @@ pg_dump *args:
     pg_dump {{args}} {{quote(DATABASE_URL)}}
 
 # Update sqlite database schema.
-prepare-sqlite: install-sqlx
+prepare-sqlite: fetch install-sqlx
     mkdir -p mbtiles/.sqlx
     cd mbtiles && cargo sqlx prepare --database-url sqlite://$PWD/../tests/fixtures/mbtiles/world_cities.mbtiles -- --lib --tests
 
@@ -538,15 +535,15 @@ restart:
     {{just}} start
 
 # Start Martin server
-run *args='--webui enable-for-all':
+run *args='--webui enable-for-all': fetch
     cargo run -p martin -- {{args}}
 
 # Start release-compiled Martin server and a test database
-run-release *args='--webui enable-for-all': start
+run-release *args='--webui enable-for-all': fetch start
     cargo run -p martin --release -- {{args}}
 
 # Check semver compatibility with prior published version. Install it with `cargo install cargo-semver-checks`
-semver *args:  (cargo-install 'cargo-semver-checks')
+semver *args:  fetch (cargo-install 'cargo-semver-checks')
     cargo semver-checks {{args}}
 
 # Start a test database
@@ -569,13 +566,13 @@ stop:
     docker compose down --remove-orphans
 
 # runs cargo-shear to lint Rust dependencies
-shear:
+shear: fetch
     cargo shear --expand
     # in the future: add --deny-warnings
     # https://github.com/Boshen/cargo-shear/pull/386
 
 # Run all tests using a test database
-test: start
+test: fetch start
     {{just}} with-render-cache '{{just}} test-cargo --all-targets && cargo test -p martin-core --features rendering --test rendering_test'
     {{just}} test-pg
     {{just}} test-doc
@@ -583,21 +580,21 @@ test: start
     {{just}} test-int
 
 # Run PostgreSQL-requiring tests only
-test-pg: start
+test-pg: fetch start
     cargo test --features test-pg --no-default-features --test pg_function_source_test --test pg_reload_test --test pg_server_test --test pg_table_source_test
     cargo test --features test-pg --no-default-features --package martin --lib
     cargo test --features test-pg --package martin-core --no-default-features --lib
 
 # Run MinIO/S3-requiring tests only (Docker required)
-test-minio:
+test-minio: fetch
     cargo test --features test-minio --no-default-features --test pmt_minio_test
 
 # Run Rust unit tests (cargo test)
-test-cargo *args:
+test-cargo *args: fetch
     cargo test {{args}}
 
 # Run unit tests for each package in dependency order
-test-packages-ci:
+test-packages-ci: fetch
     #!/usr/bin/env bash
     set -euo pipefail
     cargo test --package martin-tile-utils
@@ -611,11 +608,11 @@ test-packages-ci:
     fi
 
 # Run Rust doc tests
-test-doc *args:
+test-doc *args: fetch
     cargo test --doc {{args}}
 
 # Test code formatting
-test-fmt: (cargo-install 'cargo-sort') && (fmt-toml '--check' '--check-format')
+test-fmt: fetch (cargo-install 'cargo-sort') && (fmt-toml '--check' '--check-format')
     cargo fmt --all -- --check
 
 # Run integration tests
@@ -715,7 +712,7 @@ test-ssl-cert: start-ssl-cert
     tests/test.sh
 
 # Update all dependencies, including breaking changes. Requires nightly toolchain (install with `rustup install nightly`)
-update:
+update: fetch
     cargo +nightly -Z unstable-options update --breaking
     # static-files is a direct dep, so reset its manifest cap after --breaking (synced with deny.toml)
     sed 's/^static-files = .*/static-files = "0.2"/' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
@@ -813,6 +810,25 @@ cargo-install $COMMAND $INSTALL_CMD='' *args='':
             cargo binstall ${INSTALL_CMD:-$COMMAND} {{binstall_args}} --locked
         fi
     fi
+
+# Fetch all workspace dependencies up front, retrying with exponential backoff to tolerate flaky networks
+[private]
+fetch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    delay=5
+    for attempt in $(seq 1 5); do
+        if cargo fetch --locked; then
+            exit 0
+        fi
+        if [[ "$attempt" -lt 5 ]]; then
+            echo "cargo fetch failed (attempt ${attempt}/5); retrying in ${delay}s..." >&2
+            sleep "$delay"
+            delay=$(( delay * 2 ))
+        fi
+    done
+    echo "cargo fetch failed after 5 attempts" >&2
+    exit 1
 
 # Delete test output files
 [private]


### PR DESCRIPTION
Follow-up to #2918: replaces the CARGO_NET_RETRY/CARGO_HTTP_TIMEOUT bump (which didn't help) with a `cargo fetch --locked` retry+exponential-backoff step run before every cargo-running just recipe.