### PR TITLE
fix(ci): stop compiling bundled DuckDB in non-duckdb test builds and other CI stability fixes

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,9 +1,15 @@
 name: Setup Rust
-description: Free runner disk space, then install and select the stable Rust toolchain.
+description: Free runner disk space, install the stable Rust toolchain, and install the build tooling.
 inputs:
   components:
     description: Space-separated rustup components to add, e.g. "clippy rustfmt".
     default: ""
+  tools:
+    description: Comma-separated tools to install via taiki-e/install-action, e.g. "just,cargo-binstall". Empty to skip.
+    default: "just"
+  rendering:
+    description: Install the system dependencies needed to build maplibre-native. No-op on non-Linux runners.
+    default: "false"
 runs:
   using: composite
   steps:
@@ -27,3 +33,9 @@ runs:
       env:
         COMPONENTS: ${{ inputs.components }}
       run: rustup component add $COMPONENTS
+    - if: inputs.tools != ''
+      uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+      with: { tool: '${{ inputs.tools }}' }
+    - if: inputs.rendering == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: just install-dependencies

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,16 +1,15 @@
 name: Setup Rust
-description: Optionally free runner disk space, then install and select the stable Rust toolchain.
+description: Free runner disk space, then install and select the stable Rust toolchain.
 inputs:
-  free-disk-space:
-    description: Free runner disk space before building. No-op on non-Linux runners. Needed by jobs that compile the bundled DuckDB and maplibre-native C++ trees, which otherwise exhaust the default runner disk.
-    default: "false"
   components:
     description: Space-separated rustup components to add, e.g. "clippy rustfmt".
     default: ""
 runs:
   using: composite
   steps:
-    - if: inputs.free-disk-space == 'true' && runner.os == 'Linux'
+    # Frees ~25GB. martin compiles the bundled DuckDB and maplibre-native C++ trees, which
+    # otherwise exhaust the default runner disk. No-op on non-Linux runners.
+    - if: runner.os == 'Linux'
       uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
       with:
         tool-cache: false

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,30 @@
+name: Setup Rust
+description: Optionally free runner disk space, then install and select the stable Rust toolchain.
+inputs:
+  free-disk-space:
+    description: Free runner disk space before building. No-op on non-Linux runners. Needed by jobs that compile the bundled DuckDB and maplibre-native C++ trees, which otherwise exhaust the default runner disk.
+    default: "false"
+  components:
+    description: Space-separated rustup components to add, e.g. "clippy rustfmt".
+    default: ""
+runs:
+  using: composite
+  steps:
+    - if: inputs.free-disk-space == 'true' && runner.os == 'Linux'
+      uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
+      with:
+        tool-cache: false
+        mandb:   true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
+    - shell: bash
+      run: rustup update stable && rustup default stable
+    - if: inputs.components != ''
+      shell: bash
+      env:
+        COMPONENTS: ${{ inputs.components }}
+      run: rustup component add $COMPONENTS

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -39,3 +39,6 @@ runs:
     - if: inputs.rendering == 'true' && runner.os == 'Linux'
       shell: bash
       run: just install-dependencies
+    - if: runner.os == 'Linux'
+      shell: bash
+      run: just env-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,16 @@ jobs:
           -c "exec docker-entrypoint.sh ${{ matrix.args }}"
     steps:
       - run: rustup update stable && rustup default stable
+      - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
+        with:
+          tool-cache: false
+          mandb:   true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,11 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
+        with: { rendering: true }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         with:
           key: ${{ matrix.os }}
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just' }
-      - name: Install rendering dependencies
-        if: runner.os == 'Linux'
-        run: just install-dependencies
       - name: Install uv
         if: runner.os == 'Linux'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0 # zizmor: ignore[cache-poisoning] dev-only tool cache; poisoning risk accepted
@@ -78,13 +74,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { components: clippy rustfmt }
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just' }
+        with: { components: clippy rustfmt, rendering: true }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main'
-      - name: Install rendering dependencies
-        run: just install-dependencies
       - run: just env-info
       - run: just clippy
       - run: just check
@@ -631,8 +623,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just' }
       - name: Init database
         run: tests/fixtures/initdb.sh
         env:
@@ -660,8 +650,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just' }
       - name: Unit Tests
         run: just test-minio
 
@@ -765,10 +753,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just,cargo-binstall' }
-      - name: Install rendering dependencies
-        run: just install-dependencies
+        with: { tools: 'just,cargo-binstall', rendering: true }
       - name: Test packaging
         run: cargo publish --workspace --dry-run
       - name: Test cargo-binstall metadata
@@ -972,10 +957,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { fetch-depth: 0, persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
-        with: { tool: 'just' }
-      - name: Install rendering dependencies
-        run: just install-dependencies
+        with: { rendering: true }
       - name: Publish to crates.io if crate's version is newer
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5.129
         id: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,21 +49,11 @@ jobs:
         # 2. Run on all three OS platforms when merging to main
         os: ${{ fromJSON('["ubuntu-latest", "macos-latest"]') || (github.ref == 'refs/heads/main' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]')) }}
     steps:
-      - run: rustup update stable && rustup default stable
-      - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
-        if: runner.os == 'Linux'
-        with:
-          tool-cache: false
-          mandb:   true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
+        with: { free-disk-space: true }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         with:
@@ -85,11 +75,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - run: rustup update stable && rustup default stable
-      - run: rustup component add clippy rustfmt
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
+        with: { free-disk-space: true, components: clippy rustfmt }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
@@ -638,20 +628,11 @@ jobs:
           postgis/postgis:${{ matrix.img_ver }}
           -c "exec docker-entrypoint.sh ${{ matrix.args }}"
     steps:
-      - run: rustup update stable && rustup default stable
-      - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
-        with:
-          tool-cache: false
-          mandb:   true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
+        with: { free-disk-space: true }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - name: Init database
@@ -677,10 +658,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - name: Unit Tests
@@ -782,10 +763,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - run: rustup update stable && rustup default stable
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
+        with: { free-disk-space: true }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just,cargo-binstall' }
       - name: Install rendering dependencies
@@ -990,9 +972,9 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - run: rustup update stable && rustup default stable
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { fetch-depth: 0, persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - name: Install rendering dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         with: { components: clippy rustfmt, rendering: true }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main'
-      - run: just env-info
       - run: just clippy
       - run: just check
       - run: just check-doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { free-disk-space: true }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         with:
@@ -79,7 +78,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { free-disk-space: true, components: clippy rustfmt }
+        with: { components: clippy rustfmt }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning] dev-only build cache, keyed per matrix; poisoning risk accepted
@@ -632,7 +631,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { free-disk-space: true }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just' }
       - name: Init database
@@ -767,7 +765,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { free-disk-space: true }
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with: { tool: 'just,cargo-binstall' }
       - name: Install rendering dependencies

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -225,7 +225,6 @@ walkdir = { workspace = true, optional = true }
 [dev-dependencies]
 backon.workspace = true
 criterion.workspace = true
-duckdb.workspace = true
 image-compare.workspace = true
 indoc.workspace = true
 insta = { workspace = true, features = ["json", "yaml", "redactions"] }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -289,13 +289,18 @@ clean_headers_dump() {
   $SED --in-place '1d' "$FILE"
 }
 
-# Stage the fixture alongside the destination and rename it in, so it appears atomically.
+# Stage the fixture outside the watched directory and rename it in, so it appears atomically.
 # A plain `cp` writes in place, letting the reload watcher read a 0-byte file mid-copy.
+# Staging inside the watched directory is not enough either: the watcher still observes the
+# intermediate `.staging` file and warns when it is renamed away mid-scan.
+# The staging path is in the destination's parent directory, which shares its filesystem, so the
+# rename is atomic and the watcher only ever sees the finished file appear in one step.
 install_watched_fixture() {
   SRC="$1"
   DEST="$2"
-  cp "$SRC" "$DEST.staging"
-  mv "$DEST.staging" "$DEST"
+  STAGING="$(dirname "$DEST")/../$(basename "$DEST").staging"
+  cp "$SRC" "$STAGING"
+  mv "$STAGING" "$DEST"
 }
 
 test_log_has_str() {


### PR DESCRIPTION
A non-optional `duckdb` dev-dependency was force-building DuckDB's bundled C++ into every `martin` test target (including PG-only jobs), exhausting runner disk; the optional duckdb dependency already covers the feature-gated tests, and the PG service job now frees disk like its sibling.