### PR TITLE
refactor(martin-core): derive font extensions from FontFormat via strum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,6 +4703,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "spreet",
+ "strum 0.28.0",
  "tempfile",
  "testcontainers-modules",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ sqlite-compressions = { version = "0.3", default-features = false, features = ["
 sqlite-hashes = { version = "0.10.6", default-features = false, features = ["md5", "aggregate", "hex"] }
 sqlx = { version = "0.9.0", features = ["sqlite", "runtime-tokio"] }
 static-files = "0.2"
+strum = { version = "0.28", features = ["derive"] }
 subst = "0.3"
 tempfile = "3.21.0"
 testcontainers-modules = { version = "0.15.0", features = ["postgres", "blocking", "minio"] }

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -46,6 +46,7 @@ fonts = [
     "dep:itertools",
     "dep:dashmap",
     "dep:walkdir",
+    "dep:strum",
 ]
 sprites = [
     "dep:actix-web",
@@ -114,6 +115,7 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 serde_with.workspace = true
 spreet = { workspace = true, optional = true }
+strum = { workspace = true, optional = true }
 thiserror.workspace = true
 tiff = { workspace = true, optional = true }
 tilejson.workspace = true

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -30,11 +30,10 @@ use pbf_font_tools::prost::Message as _;
 use pbf_font_tools::{Fontstack, Glyphs, render_sdf_glyph};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use strum::VariantNames as _;
 use tracing::{debug, info, instrument, warn};
 
 use crate::walk_files;
-
-const FONT_EXTENSIONS: &[&str] = &["otf", "ttf", "ttc"];
 
 /// Maximum Unicode codepoint supported.
 ///
@@ -101,8 +100,23 @@ fn get_available_codepoints(face: &mut Face) -> Option<GetGlyphInfo> {
 pub type FontCatalog = HashMap<String, CatalogFontEntry>;
 
 /// Source font file container format.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// The string serialization (serde and `strum`) is the lowercase file
+/// extension, so [`FontFormat::VARIANTS`] doubles as the list of recognised
+/// font extensions and [`str::parse`] maps an extension back to a variant.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    strum::EnumString,
+    strum::VariantNames,
+)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 #[cfg_attr(
     feature = "unstable-schemas",
     derive(schemars::JsonSchema, utoipa::ToSchema)
@@ -283,7 +297,7 @@ fn discover_fonts(
         if !path
             .extension()
             .and_then(OsStr::to_str)
-            .is_some_and(|e| FONT_EXTENSIONS.contains(&e))
+            .is_some_and(|e| FontFormat::VARIANTS.contains(&e))
         {
             return Err(FontError::InvalidFontFilePath(path));
         }
@@ -291,7 +305,7 @@ fn discover_fonts(
     }
 
     let start_count = fonts.len();
-    let font_files = walk_files(&path, FONT_EXTENSIONS)
+    let font_files = walk_files(&path, FontFormat::VARIANTS)
         .map_err(|e| FontError::IoError(e.into(), path.clone()))?;
     for font_path in font_files {
         parse_font(lib, fonts, font_path)?;
@@ -312,6 +326,13 @@ fn parse_font(
 ) -> Result<(), FontError> {
     static RE_SPACES: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(\s|/|,)+").expect("regex pattern is valid"));
+
+    // The discovery filter only admits the lowercase extensions in
+    // `FontFormat::VARIANTS`, so this parse succeeds for every file we reach.
+    let format = path
+        .extension()
+        .and_then(OsStr::to_str)
+        .and_then(|e| e.parse::<FontFormat>().ok());
 
     let mut face = lib.new_face(&path, 0)?;
     let num_faces = face.num_faces() as isize;
@@ -384,8 +405,7 @@ fn parse_font(
                         glyphs,
                         start,
                         end,
-                        // FIXME: derive from the font file extension / fc-query.
-                        format: None,
+                        format,
                         // FIXME: stat the font file and surface its mtime.
                         last_modified_at: None,
                     },
@@ -424,6 +444,27 @@ mod tests {
             sources.get_catalog().len(),
             1,
             "expected exactly one font, not duplicates from the ..data/..timestamped tree"
+        );
+    }
+
+    #[test]
+    fn catalog_reports_font_format_from_extension() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/fixtures/fonts");
+        let mut sources = FontSources::default();
+        sources.recursively_add_directory(dir).unwrap();
+
+        let formats: Vec<FontFormat> = sources
+            .get_catalog()
+            .values()
+            .filter_map(|e| e.format)
+            .collect();
+        assert!(
+            formats.contains(&FontFormat::Ttf),
+            "expected the .ttf fixture to report Ttf, got {formats:?}"
+        );
+        assert!(
+            formats.contains(&FontFormat::Otf),
+            "expected the .otf fixture to report Otf, got {formats:?}"
         );
     }
 

--- a/martin/martin-ui/src/lib/types.gen.ts
+++ b/martin/martin-ui/src/lib/types.gen.ts
@@ -299,6 +299,10 @@ export interface components {
         };
         /**
          * @description Source font file container format.
+         *
+         *     The string serialization (serde and `strum`) is the lowercase file
+         *     extension, so [`FontFormat::VARIANTS`] doubles as the list of recognised
+         *     font extensions and [`str::parse`] maps an extension back to a variant.
          * @enum {string}
          */
         FontFormat: "otf" | "ttf" | "ttc";

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -197,7 +197,7 @@
         "type": "object"
       },
       "FontFormat": {
-        "description": "Source font file container format.",
+        "description": "Source font file container format.\n\nThe string serialization (serde and `strum`) is the lowercase file\nextension, so [`FontFormat::VARIANTS`] doubles as the list of recognised\nfont extensions and [`str::parse`] maps an extension back to a variant.",
         "enum": ["otf", "ttf", "ttc"],
         "type": "string"
       },

--- a/tests/expected/auto/catalog_auto.json
+++ b/tests/expected/auto/catalog_auto.json
@@ -3,6 +3,7 @@
     "Overpass Mono Light": {
       "end": 128276,
       "family": "Overpass Mono",
+      "format": "otf",
       "glyphs": 988,
       "start": 0,
       "style": "Light"
@@ -10,6 +11,7 @@
     "Overpass Mono Regular": {
       "end": 128276,
       "family": "Overpass Mono",
+      "format": "ttf",
       "glyphs": 988,
       "start": 0,
       "style": "Regular"

--- a/tests/expected/configured/catalog_cfg.json
+++ b/tests/expected/configured/catalog_cfg.json
@@ -3,6 +3,7 @@
     "Overpass Mono Light": {
       "end": 128276,
       "family": "Overpass Mono",
+      "format": "otf",
       "glyphs": 988,
       "start": 0,
       "style": "Light"
@@ -10,6 +11,7 @@
     "Overpass Mono Regular": {
       "end": 128276,
       "family": "Overpass Mono",
+      "format": "ttf",
       "glyphs": 988,
       "start": 0,
       "style": "Regular"


### PR DESCRIPTION
Replace the `FONT_EXTENSIONS` constant with `strum::VariantNames` on `FontFormat` so the recognised font extensions and the enum stay in sync.

Claude picked this out of the larger overlay PR