### PR TITLE
feat(tile-utils): make tile_bbox public

### DIFF
--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -448,7 +448,8 @@ pub fn xyz_to_bbox(zoom: u8, min_x: u32, min_y: u32, max_x: u32, max_y: u32) -> 
 }
 
 #[expect(clippy::cast_lossless)]
-fn tile_bbox(x: u32, y: u32, tile_length: f64) -> [f64; 4] {
+#[must_use]
+pub fn tile_bbox(x: u32, y: u32, tile_length: f64) -> [f64; 4] {
     let min_x = EARTH_CIRCUMFERENCE * -0.5 + x as f64 * tile_length;
     let max_y = EARTH_CIRCUMFERENCE * 0.5 - y as f64 * tile_length;
 

--- a/martin-tile-utils/src/lib.rs
+++ b/martin-tile-utils/src/lib.rs
@@ -692,6 +692,31 @@ mod tests {
     }
 
     #[rstest]
+    // Web Mercator bounds `[min_x, min_y, max_x, max_y]` in meters.
+    // Every value is an exact power-of-two fraction of `EARTH_CIRCUMFERENCE`.
+    #[case(0, 0, 0, [-20_037_508.342_789_25, -20_037_508.342_789_25, 20_037_508.342_789_25, 20_037_508.342_789_25])]
+    #[case(1, 0, 0, [-20_037_508.342_789_25, 0.0, 0.0, 20_037_508.342_789_25])]
+    #[case(1, 1, 1, [0.0, -20_037_508.342_789_25, 20_037_508.342_789_25, 0.0])]
+    #[case(2, 0, 0, [-20_037_508.342_789_25, 10_018_754.171_394_625, -10_018_754.171_394_625, 20_037_508.342_789_25])]
+    #[case(2, 2, 2, [0.0, -10_018_754.171_394_625, 10_018_754.171_394_625, 0.0])]
+    fn test_tile_bbox(
+        #[case] zoom: u8,
+        #[case] x: u32,
+        #[case] y: u32,
+        #[case] expected: [f64; 4],
+    ) {
+        let tile_length = EARTH_CIRCUMFERENCE / f64::from(1_u32 << zoom);
+        let bbox = tile_bbox(x, y, tile_length);
+        assert_relative_eq!(bbox[0], expected[0], epsilon = f64::EPSILON * 2.0);
+        assert_relative_eq!(bbox[1], expected[1], epsilon = f64::EPSILON * 2.0);
+        assert_relative_eq!(bbox[2], expected[2], epsilon = f64::EPSILON * 2.0);
+        assert_relative_eq!(bbox[3], expected[3], epsilon = f64::EPSILON * 2.0);
+        // a tile is a square with side `tile_length`
+        assert_relative_eq!(bbox[2] - bbox[0], tile_length, epsilon = f64::EPSILON * 2.0);
+        assert_relative_eq!(bbox[3] - bbox[1], tile_length, epsilon = f64::EPSILON * 2.0);
+    }
+
+    #[rstest]
     #[case(0, (0, 0, 0, 0))]
     #[case(1, (0, 1, 0, 1))]
     #[case(2, (0, 3, 0, 3))]


### PR DESCRIPTION
Expose `tile_bbox` so `martin-core` can compute a tile's Web Mercator bounds

Split out of #2538