### PR TITLE
ci: run PG unit-test variants in one job instead of a 3-way matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,9 +565,6 @@ jobs:
           retention-days: 5
 
   unit-test-svc-pg:
-    # Runs the PG unit tests against every supported PostGIS/sslmode combination in a
-    # single job so the variants share one runner slot instead of one each. The combos
-    # must match the versions of postgres used in the docker-compose.yml.
     name: Unit test against PostGIS variants
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,15 +629,19 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - name: Init databases
-        run: |
-          PGPORT="$PG11_ALPINE_PORT" tests/fixtures/initdb.sh
-          PGPORT="$PG18_ALPINE_PORT" tests/fixtures/initdb.sh
-          PGPORT="$PG18_SSL_PORT" tests/fixtures/initdb.sh
-        env:
-          PG11_ALPINE_PORT: ${{ job.services['pg11-alpine'].ports[5432] }}
-          PG18_ALPINE_PORT: ${{ job.services['pg18-alpine'].ports[5432] }}
-          PG18_SSL_PORT: ${{ job.services['pg18-ssl'].ports[5432] }}
+      - parallel:
+          - name: Init pg11-alpine database
+            run: tests/fixtures/initdb.sh
+            env:
+              PGPORT: ${{ job.services['pg11-alpine'].ports[5432] }}
+          - name: Init pg18-alpine database
+            run: tests/fixtures/initdb.sh
+            env:
+              PGPORT: ${{ job.services['pg18-alpine'].ports[5432] }}
+          - name: Init pg18-ssl database
+            run: tests/fixtures/initdb.sh
+            env:
+              PGPORT: ${{ job.services['pg18-ssl'].ports[5432] }}
       - name: Unit Tests postgis:11-3.0-alpine sslmode=disable
         run: |
           echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,9 +631,13 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - name: Init databases
         run: |
-          PGPORT='${{ job.services['pg11-alpine'].ports[5432] }}' tests/fixtures/initdb.sh
-          PGPORT='${{ job.services['pg18-alpine'].ports[5432] }}' tests/fixtures/initdb.sh
-          PGPORT='${{ job.services['pg18-ssl'].ports[5432] }}' tests/fixtures/initdb.sh
+          PGPORT="$PG11_ALPINE_PORT" tests/fixtures/initdb.sh
+          PGPORT="$PG18_ALPINE_PORT" tests/fixtures/initdb.sh
+          PGPORT="$PG18_SSL_PORT" tests/fixtures/initdb.sh
+        env:
+          PG11_ALPINE_PORT: ${{ job.services['pg11-alpine'].ports[5432] }}
+          PG18_ALPINE_PORT: ${{ job.services['pg18-alpine'].ports[5432] }}
+          PG18_SSL_PORT: ${{ job.services['pg18-ssl'].ports[5432] }}
       - name: Unit Tests postgis:11-3.0-alpine sslmode=disable
         run: |
           echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,42 +565,52 @@ jobs:
           retention-days: 5
 
   unit-test-svc-pg:
-    name: Unit test postgis:${{ matrix.img_ver }} sslmode=${{ matrix.sslmode }}
+    # Runs the PG unit tests against every supported PostGIS/sslmode combination in a
+    # single job so the variants share one runner slot instead of one each. The combos
+    # must match the versions of postgres used in the docker-compose.yml.
+    name: Unit test against PostGIS variants
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy: &svc-strategy
-      fail-fast: true
-      matrix:
-        include:
-          # These must match the versions of postgres used in the docker-compose.yml
-          - img_ver: 11-3.0-alpine
-            args: postgres
-            sslmode: disable
-          - img_ver: 18-3.6-alpine
-            args: postgres
-            sslmode: disable
-          # alpine images don't support SSL, so for this we use the debian images
-          - img_ver: 18-3.6
-            args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-            sslmode: require
-          #
-          # FIXME!
-          # DISABLED because Rustls fails to validate name (CN?) with the NotValidForName error
-          #- img_ver: 15-3.3
-          #  args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-          #  sslmode: verify-ca
-          #- img_ver: 15-3.3
-          #  args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-          #  sslmode: verify-full
-    env: &svc-env
+    env:
       PGDATABASE: test
       PGHOST: localhost
       PGUSER: postgres
       PGPASSWORD: postgres
     services:
-      postgres: &svc-postgres
-        image: postgis/postgis:${{ matrix.img_ver }}
+      pg11-alpine:
+        image: postgis/postgis:11-3.0-alpine
+        ports:
+          - 5432/tcp
+        options: >-
+          -e POSTGRES_DB=test
+          -e POSTGRES_USER=postgres
+          -e POSTGRES_PASSWORD=postgres
+          -e PGDATABASE=test
+          -e PGUSER=postgres
+          -e PGPASSWORD=postgres
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      pg18-alpine:
+        image: postgis/postgis:18-3.6-alpine
+        ports:
+          - 5432/tcp
+        options: >-
+          -e POSTGRES_DB=test
+          -e POSTGRES_USER=postgres
+          -e POSTGRES_PASSWORD=postgres
+          -e PGDATABASE=test
+          -e PGUSER=postgres
+          -e PGPASSWORD=postgres
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      # alpine images don't support SSL, so for sslmode=require we use the debian image
+      pg18-ssl:
+        image: postgis/postgis:18-3.6
         ports:
           - 5432/tcp
         options: >-
@@ -615,26 +625,36 @@ jobs:
           --health-timeout 5s
           --health-retries 5
           --entrypoint sh
-          postgis/postgis:${{ matrix.img_ver }}
-          -c "exec docker-entrypoint.sh ${{ matrix.args }}"
+          postgis/postgis:18-3.6
+          -c "exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
     steps:
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-      - name: Init database
-        run: tests/fixtures/initdb.sh
-        env:
-          PGPORT: ${{ job.services.postgres.ports[5432] }}
-      - name: Unit Tests
-        if: matrix.sslmode != 'verify-ca' && matrix.sslmode != 'verify-full'
+      - name: Init databases
+        run: |
+          PGPORT='${{ job.services['pg11-alpine'].ports[5432] }}' tests/fixtures/initdb.sh
+          PGPORT='${{ job.services['pg18-alpine'].ports[5432] }}' tests/fixtures/initdb.sh
+          PGPORT='${{ job.services['pg18-ssl'].ports[5432] }}' tests/fixtures/initdb.sh
+      - name: Unit Tests postgis:11-3.0-alpine sslmode=disable
         run: |
           echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"
-          echo "Same but as base64 to prevent GitHub obfuscation (this is not a secret):"
-          echo "$DATABASE_URL" | base64
           just test-pg
         env:
-          DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}?sslmode=${{ matrix.sslmode }}
+          DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services['pg11-alpine'].ports[5432] }}/${{ env.PGDATABASE }}?sslmode=disable
+      - name: Unit Tests postgis:18-3.6-alpine sslmode=disable
+        run: |
+          echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"
+          just test-pg
+        env:
+          DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services['pg18-alpine'].ports[5432] }}/${{ env.PGDATABASE }}?sslmode=disable
+      - name: Unit Tests postgis:18-3.6 sslmode=require
+        run: |
+          echo "Running unit tests, connecting to DATABASE_URL=$DATABASE_URL"
+          just test-pg
+        env:
+          DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGUSER }}@${{ env.PGHOST }}:${{ job.services['pg18-ssl'].ports[5432] }}/${{ env.PGDATABASE }}?sslmode=require
 
   unit-test-svc-minio:
     # Exercises the PmtilesReloader's S3-prefix polling against a MinIO testcontainer
@@ -658,10 +678,54 @@ jobs:
     permissions:
       contents: read
     needs: [ build-x86_64-unknown-linux-gnu, build-debian-x86_64, unit-test-svc-pg ]
-    strategy: *svc-strategy
-    env: *svc-env
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # These must match the versions of postgres used in the docker-compose.yml
+          - img_ver: 11-3.0-alpine
+            args: postgres
+            sslmode: disable
+          - img_ver: 18-3.6-alpine
+            args: postgres
+            sslmode: disable
+          # alpine images don't support SSL, so for this we use the debian images
+          - img_ver: 18-3.6
+            args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+            sslmode: require
+          #
+          # FIXME!
+          # DISABLED because Rustls fails to validate name (CN?) with the NotValidForName error
+          #- img_ver: 15-3.3
+          #  args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+          #  sslmode: verify-ca
+          #- img_ver: 15-3.3
+          #  args: postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+          #  sslmode: verify-full
+    env:
+      PGDATABASE: test
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
     services:
-      postgres: *svc-postgres
+      postgres:
+        image: postgis/postgis:${{ matrix.img_ver }}
+        ports:
+          - 5432/tcp
+        options: >-
+          -e POSTGRES_DB=test
+          -e POSTGRES_USER=postgres
+          -e POSTGRES_PASSWORD=postgres
+          -e PGDATABASE=test
+          -e PGUSER=postgres
+          -e PGPASSWORD=postgres
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --entrypoint sh
+          postgis/postgis:${{ matrix.img_ver }}
+          -c "exec docker-entrypoint.sh ${{ matrix.args }}"
     steps:
       - name: Checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Collapses the `unit-test-svc-pg` matrix into a single job with three PostGIS service containers, freeing two CI matrix slots.