### PR TITLE
ci: ignore RUSTSEC-2026-0189 (rmcp DNS rebinding)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0119,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0049,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2026-0105,RUSTSEC-2025-0141,RUSTSEC-2026-0145,RUSTSEC-2026-0179,RUSTSEC-2026-0180,RUSTSEC-2026-0178
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0119,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0049,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2026-0105,RUSTSEC-2025-0141,RUSTSEC-2026-0145,RUSTSEC-2026-0179,RUSTSEC-2026-0180,RUSTSEC-2026-0178,RUSTSEC-2026-0189
           # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing side channels => not used exploitably
           # RUSTSEC-2024-0436 = paste - no longer maintained
           # RUSTSEC-2025-0119 = number_prefix is unmaintained, but we need no change in this lib
@@ -53,6 +53,7 @@ jobs:
           # RUSTSEC-2026-0179 = postgres-protocol dos
           # RUSTSEC-2026-0180 = postgres-protocol dos
           # RUSTSEC-2026-0178 = tokio-postgres dos
+          # RUSTSEC-2026-0189 = rmcp Streamable HTTP DNS rebinding; only pulled in via hotpath's hotpath-mcp profiling tool, never compiled into the shipped server
   dependency-review:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
`rmcp` is only pulled in via `hotpath`'s `hotpath-mcp` profiling tool and is never compiled into the shipped server, so the DNS-rebinding issue cannot affect Martin users.