### PR TITLE
fix(ci): remove '*' from renovate matchPackageNames

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,6 @@
       // group gives each its own PR for manual review.
       matchManagers: ['cargo'],
       matchPackageNames: [
-        '*',
         '!libdeflater',
         '!libdeflate-sys',
         '!insta',
@@ -33,7 +32,7 @@
     },
     {
       matchManagers: ['npm'],
-      matchPackageNames: ['*', '!@biomejs/biome'],
+      matchPackageNames: ['!@biomejs/biome'],
       groupName: 'npm dependencies',
     },
     {


### PR DESCRIPTION
Renovate rejects combining `*` with negative patterns (issue #2948); the negation-only list already means "everything except these".

🤖 Generated with [Claude Code](https://claude.com/claude-code)