### PR TITLE
fix(ci): enable renovate lock file maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   ],
   schedule: ['before 5am on the first day of the month'],
   minimumReleaseAge: '7 days',
+  lockFileMaintenance: { enabled: true },
   prConcurrentLimit: 10,
   packageRules: [
     {


### PR DESCRIPTION
Enables lock file maintenance so Renovate can rebuild lockfiles consistently with `minimumReleaseAge`, clearing the dashboard's npm `--before` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)