### PR TITLE
fix(ci): drop renovate schedule so updates flow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,10 @@
     'config:recommended',
     ':dependencyDashboard',
   ],
-  schedule: ['before 5am on the first day of the month'],
   minimumReleaseAge: '7 days',
   lockFileMaintenance: { enabled: true },
   prConcurrentLimit: 10,
+  prHourlyLimit: 0,
   packageRules: [
     {
       matchManagers: ['github-actions'],


### PR DESCRIPTION
The monthly-anchored-to-the-1st schedule blocked all 8 queued update branches ('not-scheduled' in the job log); minimumReleaseAge: 7 days already throttles noise, so drop the schedule to let PRs open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)