### PR TITLE
chore(ci): group docker updates by datasource, keep postgis pinned at 11

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,6 @@
     'config:recommended',
     ':dependencyDashboard',
   ],
-  // Bi-weekly: only open/update PRs on the 1st and 15th of each month.
   schedule: ['* * 1,15 * *'],
   minimumReleaseAge: '7 days',
   automerge: true,
@@ -40,14 +39,20 @@
       groupName: 'npm dependencies',
     },
     {
-      matchManagers: ['dockerfile', 'docker-compose'],
+      matchDatasources: ['docker'],
       groupName: 'docker images',
     },
     {
-      // martin's own image updates without waiting out the cooldown.
       matchDatasources: ['docker'],
       matchPackageNames: ['ghcr.io/maplibre/martin'],
       minimumReleaseAge: '0 days',
+    },
+    {
+      // Test setup intentionally pins Postgres 11 (oldest version we support).
+      matchDatasources: ['docker'],
+      matchPackageNames: ['postgis/postgis'],
+      matchCurrentValue: '/^11/',
+      enabled: false,
     },
   ],
 }


### PR DESCRIPTION
Groups docker updates by datasource so workflow service-container images (e.g. postgis in ci.yml) join the docker group instead of the github-actions one, and disables upgrades for the intentionally-pinned Postgres 11 test image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)