### PR TITLE
chore: disable uv CI cache and drop unused image/utoipa-actix-web deps

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -79,6 +79,7 @@ jobs:
       # rules (trailing newline, etc.) - same tiebreaker the bless job uses.
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
       - run: uvx pre-commit run --files schemas/config.json schemas/openapi.json martin/martin-ui/src/lib/types.gen.ts
         continue-on-error: true
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
@@ -128,6 +129,7 @@ jobs:
         run: just install-dependencies
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
 
       - run: just bless
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
           key: ${{ matrix.os }}
       - name: Install uv
         if: runner.os == 'Linux'
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0 # zizmor: ignore[cache-poisoning] dev-only tool cache; poisoning risk accepted
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
       - name: Run cargo test
         run: just test-packages-ci
       - run: just test-doc
@@ -121,7 +122,8 @@ jobs:
       - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with: { tool: 'just' }
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0 # zizmor: ignore[cache-poisoning] dev-only tool cache; poisoning risk accepted
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
       - run: just test-schemas
   lint-rust-dependencies:
     name: Lint Rust dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install rendering dependencies
         run: just install-dependencies
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
 
       - name: Generate code coverage
         run: just coverage --codecov --output-path target/codecov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4759,7 +4759,6 @@ dependencies = [
  "tracing-test",
  "url",
  "utoipa",
- "utoipa-actix-web",
  "walkdir",
  "xxhash-rust",
 ]
@@ -9357,17 +9356,6 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-actix-web"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7eda9c23c05af0fb812f6a177514047331dac4851a2c8e9c4b895d6d826967f"
-dependencies = [
- "actix-service",
- "actix-web",
- "utoipa",
 ]
 
 [[package]]

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -55,9 +55,9 @@ postgres = [
     "dep:serde_json",
     "_tiles",
 ]
-unstable-cog = ["dep:png", "dep:tiff", "dep:image", "dep:serde_json", "_tiles"]
+unstable-cog = ["dep:png", "dep:tiff", "dep:serde_json", "_tiles"]
 overlay = ["dep:geojson", "dep:strum"]
-rendering = ["styles", "overlay", "dep:maplibre_native", "dep:image", "dep:flume"]
+rendering = ["styles", "overlay", "dep:maplibre_native", "dep:flume"]
 fonts = [
     "dep:bit-set",
     "dep:pbf_font_tools",
@@ -116,7 +116,6 @@ geo-types = { workspace = true, optional = true }
 geojson = { workspace = true, optional = true }
 geozero = { workspace = true, optional = true }
 hotpath.workspace = true
-image = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 martin-tile-utils.workspace = true
 mbtiles = { workspace = true, optional = true }
@@ -160,6 +159,7 @@ criterion = { workspace = true }
 env_logger.workspace = true
 fast-mvt.workspace = true
 futures.workspace = true
+image.workspace = true
 image-compare.workspace = true
 insta = { workspace = true, features = ["json", "yaml"] }
 rstest.workspace = true

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -141,7 +141,6 @@ _catalog = []
 unstable-schemas = [
     "dep:schemars",
     "dep:utoipa",
-    "dep:utoipa-actix-web",
     "martin-core/unstable-schemas",
     "fonts",
     "mbtiles",
@@ -225,7 +224,6 @@ tracing-subscriber = { workspace = true, default-features = false, features = [
 ] }
 url.workspace = true
 utoipa = { workspace = true, optional = true }
-utoipa-actix-web = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
 xxhash-rust = { workspace = true, optional = true }
 


### PR DESCRIPTION
Split out of #2945 so it can land independently of the rendering-not-default change: disable the uv download cache (one-off `uvx` tool runner, no Python deps to cache) which also lets the redundant `zizmor: ignore[cache-poisoning]` comments go, move martin-core's `image` to a dev-dependency (only used in the rendering test), and drop martin's unused `utoipa-actix-web` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)