### PR TITLE
fix(ci): free disk in the lint-rust-dependencies job

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,6 +1,9 @@
 name: Setup Rust
-description: Free runner disk space, install the stable Rust toolchain, and install the build tooling.
+description: Free runner disk space, install a Rust toolchain, and install the build tooling.
 inputs:
+  toolchain:
+    description: Rust toolchain to install and set as the default, e.g. "stable" or "nightly".
+    default: "stable"
   components:
     description: Space-separated rustup components to add, e.g. "clippy rustfmt".
     default: ""
@@ -27,7 +30,9 @@ runs:
         docker-images: true
         swap-storage: true
     - shell: bash
-      run: rustup update stable && rustup default stable
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
+      run: rustup update "$TOOLCHAIN" && rustup default "$TOOLCHAIN"
     - if: inputs.components != ''
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,11 @@ jobs:
       - lint-rust # not because it is needed, but because we want less concurrent jobs competing
     runs-on: ubuntu-latest
     steps:
-      - run: rustup default nightly
       - name: Checkout sources
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
-        with: { tool: 'cargo-shear,just' }
-      - name: Install rendering dependencies
-        run: just install-dependencies
-
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: nightly, tools: 'cargo-shear,just', rendering: true }
       - run: just shear
   build-aarch64-unknown-linux-musl:
     uses: ./.github/workflows/build-binary.yml


### PR DESCRIPTION
`lint-rust-dependencies` was the only Rust job not routed through `setup-rust`, so it never ran the `free-disk-space` step, and `just shear`'s bundled-DuckDB + maplibre-native compile exhausted the runner disk (`No space left on device`) — now it uses `setup-rust` via a new nightly `toolchain` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)