### PR TITLE
chore(ci): let pre-commit own biome updates, not renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,14 @@
       groupName: 'npm dependencies',
     },
     {
+      // Biome is updated via .pre-commit-config.yaml, not renovate: pre-commit.ci
+      // bumps the biome hook rev and sync-biome-version propagates it to the
+      // biome.json schemas and package.json dependencies.
+      matchManagers: ['npm'],
+      matchPackageNames: ['@biomejs/biome'],
+      enabled: false,
+    },
+    {
       matchDatasources: ['docker'],
       groupName: 'docker images',
     },


### PR DESCRIPTION
Disables renovate updates for `@biomejs/biome` so biome is bumped solely via `.pre-commit-config.yaml` (pre-commit.ci bumps the hook rev, `sync-biome-version` propagates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vfDaDjmPHEViFahCB2ntM