### PR TITLE
chore(renovate): give breaking cargo bumps their own PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,18 @@
       groupName: 'cargo dependencies',
     },
     {
+      // Breaking bumps get their own PR.
+      matchManagers: ['cargo'],
+      matchUpdateTypes: ['major'],
+      groupName: null,
+    },
+    {
+      matchManagers: ['cargo'],
+      matchUpdateTypes: ['minor'],
+      matchCurrentVersion: '/^0\\./',
+      groupName: null,
+    },
+    {
       matchManagers: ['npm'],
       matchPackageNames: ['!@biomejs/biome'],
       groupName: 'npm dependencies',


### PR DESCRIPTION
Excludes major bumps and pre-1.0 minor bumps (breaking under Cargo semver) from the `cargo dependencies` group so each lands in its own reviewable PR instead of failing the batched update.