### PR TITLE
fix(deps): remove unused utoipa-actix-web workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,6 @@ tracing-subscriber = { version = "0.3", default-features = false }
 tracing-test = "0.2"
 url = "2.5"
 utoipa = { version = "5.4", default-features = false, features = ["chrono", "macros", "actix_extras"] }
-utoipa-actix-web = "0.1"
 walkdir = "2.5.0"
 wiremock = "0.6"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }


### PR DESCRIPTION
## What

Removes the `utoipa-actix-web = "0.1"` workspace dependency from the root `Cargo.toml`.
It is declared but referenced by no crate.

## Why

The `Lint Rust dependencies` CI job (`cargo shear`) is failing on `main`:

```
error: unused workspace dependency `utoipa-actix-web` (remove this dependency)
```

After removal, `cargo shear` reports no issues. The dependency was not present in `Cargo.lock`, so no lockfile change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)