### PR TITLE
docs: fix dangling rl-macos-x64 link reference

### DIFF
--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -33,7 +33,7 @@ You can download martin from [GitHub releases page](https://github.com/maplibre/
 | Platform | x64                                                                                              | ARM-64                                                                   |
 |----------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | Linux    | [.tar.gz][rl-linux-x64] (gnu)<br>[.tar.gz][rl-linux-x64-musl] (musl)<br>[.deb][rl-linux-x64-deb] | [.tar.gz][rl-linux-a64-gnu] (gnu)<br>[.tar.gz][rl-linux-a64-musl] (musl) |
-| macOS    | [.tar.gz][rl-macos-x64]                                                                          | [.tar.gz][rl-macos-a64]                                                  |
+| macOS    |                                                                                                  | [.tar.gz][rl-macos-a64]                                                  |
 | Windows  | [.zip][rl-win64-zip]                                                                             |                                                                          |
 
 [rl-linux-x64]: https://github.com/maplibre/martin/releases/latest/download/martin-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
#2965 removed the `[rl-macos-x64]` link definition (x86_64 macOS is no longer a release target) but left the table cell referencing it, breaking the `Build Docs` markdownlint (MD052) check on main.

x86_64 macOS is not built by the release pipeline, so leave the cell empty.