### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "approx",
  "brotli 8.0.4",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,9 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.8.3"
-martin-core = { path = "./martin-core", version = "0.8.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.4" }
-mbtiles = { path = "./mbtiles", version = "0.18.0" }
+martin-core = { path = "./martin-core", version = "0.9.0", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.5" }
+mbtiles = { path = "./mbtiles", version = "0.18.1" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.11.0
+    image: ghcr.io/maplibre/martin:1.12.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.11.0 \
+           ghcr.io/maplibre/martin:1.12.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.11.0
+    image: ghcr.io/maplibre/martin:1.12.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.11.0
+  ghcr.io/maplibre/martin:1.12.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.11.0 \
+  ghcr.io/maplibre/martin:1.12.0 \
   /files
 ```
 
@@ -42,7 +42,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.11.0
+  ghcr.io/maplibre/martin:1.12.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -53,7 +53,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.11.0
+  ghcr.io/maplibre/martin:1.12.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -64,5 +64,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.11.0
+  ghcr.io/maplibre/martin:1.12.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.11.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.12.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.11.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.12.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -393,7 +393,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.11.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.12.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/maplibre/martin/compare/martin-core-v0.8.0...martin-core-v0.9.0) - 2026-07-07
+
+### Added
+
+- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
+- *(geojson)* add GeoJSON tile source to martin-core ([#2925](https://github.com/maplibre/martin/pull/2925))
+- *(martin-core)* add static map overlay rendering engine ([#2922](https://github.com/maplibre/martin/pull/2922))
+- *(martin-core)* add Transport::from_string_headers ([#2913](https://github.com/maplibre/martin/pull/2913))
+- *(martin-core)* passthrough tile source ([#2908](https://github.com/maplibre/martin/pull/2908))
+
+### Fixed
+
+- *(postgres)* redact password in BadConnectionString error ([#2944](https://github.com/maplibre/martin/pull/2944))
+
+### Other
+
+- disable uv CI cache and drop unused image/utoipa-actix-web deps ([#2963](https://github.com/maplibre/martin/pull/2963))
+- *(martin-core)* derive font extensions from FontFormat via strum ([#2921](https://github.com/maplibre/martin/pull/2921))
+- duckdb bounds refactor and sql utils ([#2902](https://github.com/maplibre/martin/pull/2902))
+- fmt imports ([#2903](https://github.com/maplibre/martin/pull/2903))
+
 ## [0.8.0](https://github.com/maplibre/martin/compare/martin-core-v0.7.0...martin-core-v0.8.0) - 2026-06-16
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0](https://github.com/maplibre/martin/compare/martin-v1.11.0...martin-v1.12.0) - 2026-07-07
+
+### Added
+
+- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
+- *(rendering)* add static map overlay endpoint ([#2794](https://github.com/maplibre/martin/pull/2794))
+- geoparquet config and resolver wiring  ([#2931](https://github.com/maplibre/martin/pull/2931))
+- update to mlt-core 0.11.1 ([#2899](https://github.com/maplibre/martin/pull/2899))
+- *(geojson)* add GeoJSON tile source to martin-core ([#2925](https://github.com/maplibre/martin/pull/2925))
+- *(martin-core)* add static map overlay rendering engine ([#2922](https://github.com/maplibre/martin/pull/2922))
+- *(martin-core)* add Transport::from_string_headers ([#2913](https://github.com/maplibre/martin/pull/2913))
+- *(martin-core)* passthrough tile source ([#2908](https://github.com/maplibre/martin/pull/2908))
+- *(tile-utils)* make tile_bbox public ([#2924](https://github.com/maplibre/martin/pull/2924))
+- Add `mbtiles pack` and `mbtiles unpack` subcommands ([#2199](https://github.com/maplibre/martin/pull/2199))
+
+### Fixed
+
+- *(deps)* update npm dependencies ([#2955](https://github.com/maplibre/martin/pull/2955))
+- *(config)* accept legacy ${VAR:default} substitution syntax ([#2943](https://github.com/maplibre/martin/pull/2943))
+- *(ci)* stop compiling bundled DuckDB in non-duckdb test builds and other CI stability fixes ([#2920](https://github.com/maplibre/martin/pull/2920))
+- gate idr lint expectations on absence of consuming backends ([#2916](https://github.com/maplibre/martin/pull/2916))
+- *(postgres)* redact password in BadConnectionString error ([#2944](https://github.com/maplibre/martin/pull/2944))
+
+### Other
+
+- *(deps)* autoupdate pre-commit ([#2966](https://github.com/maplibre/martin/pull/2966))
+- disable uv CI cache and drop unused image/utoipa-actix-web deps ([#2963](https://github.com/maplibre/martin/pull/2963))
+- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2940](https://github.com/maplibre/martin/pull/2940))
+- better yaml parsing for configs, e.g. anchors, ... (config-6) ([#2870](https://github.com/maplibre/martin/pull/2870))
+- *(deps)* Bump js-yaml from 4.1.1 to 4.2.0 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2933](https://github.com/maplibre/martin/pull/2933))
+- *(deps)* autoupdate pre-commit ([#2932](https://github.com/maplibre/martin/pull/2932))
+- *(martin-core)* derive font extensions from FontFormat via strum ([#2921](https://github.com/maplibre/martin/pull/2921))
+- Fold unicode arrows to ASCII in pre-commit ([#2909](https://github.com/maplibre/martin/pull/2909))
+- duckdb bounds refactor and sql utils ([#2902](https://github.com/maplibre/martin/pull/2902))
+- *(deps)* update mlt-core ([#2906](https://github.com/maplibre/martin/pull/2906))
+- fmt imports ([#2903](https://github.com/maplibre/martin/pull/2903))
+- migrate YAML serialization to serde-saphyr, drop serde_yaml (config-5) ([#2877](https://github.com/maplibre/martin/pull/2877))
+- *(deps-dev)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2900](https://github.com/maplibre/martin/pull/2900))
+
 ## [1.11.0](https://github.com/maplibre/martin/compare/martin-v1.10.1...martin-v1.11.0) - 2026-06-16
 
 ### Live reloading for PostgreSQL, PMTiles and COG sources

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,42 +9,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.12.0](https://github.com/maplibre/martin/compare/martin-v1.11.0...martin-v1.12.0) - 2026-07-07
 
-### Added
+### GeoJSON tile source
 
-- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
-- *(rendering)* add static map overlay endpoint ([#2794](https://github.com/maplibre/martin/pull/2794))
-- geoparquet config and resolver wiring  ([#2931](https://github.com/maplibre/martin/pull/2931))
-- update to mlt-core 0.11.1 ([#2899](https://github.com/maplibre/martin/pull/2899))
-- *(geojson)* add GeoJSON tile source to martin-core ([#2925](https://github.com/maplibre/martin/pull/2925))
-- *(martin-core)* add static map overlay rendering engine ([#2922](https://github.com/maplibre/martin/pull/2922))
-- *(martin-core)* add Transport::from_string_headers ([#2913](https://github.com/maplibre/martin/pull/2913))
-- *(martin-core)* passthrough tile source ([#2908](https://github.com/maplibre/martin/pull/2908))
-- *(tile-utils)* make tile_bbox public ([#2924](https://github.com/maplibre/martin/pull/2924))
-- Add `mbtiles pack` and `mbtiles unpack` subcommands ([#2199](https://github.com/maplibre/martin/pull/2199))
+Martin can now serve vector tiles directly from a `.geojson`/`.json` file, no pre-processing into MBTiles/PMTiles required.
+
+How it works:
+
+- **On startup** the features are reprojected from WGS84 (EPSG:4326) to Web Mercator (EPSG:3857) and indexed in a packed Hilbert R-Tree.
+- **Per tile request** Martin queries the R-Tree for geometries overlapping the tile bbox, clips them (with a configurable `buffer`), transforms into tile coordinate space and encodes MVT, all on the fly. The tile `extent` and `buffer` are configurable.
+
+Because it's file-backed, GeoJSON sources **hot-reload**: point Martin at a directory and it watches for `.geojson`/`.json` changes via filesystem events, adding, updating and removing sources without a restart, just like PMTiles and COG.
+
+Great for smaller datasets and quick prototyping.
+Done in [#2538](https://github.com/maplibre/martin/pull/2538), [#2925](https://github.com/maplibre/martin/pull/2925) by [@thomfuhrmann](https://github.com/thomfuhrmann).
+
+### Static map overlays
+
+Building on the static rendering core from the last release, we added an endpoint to render a static map image with overlays drawn on top:
+
+```
+POST /style/{id}/static/{camera}/{wxh.fmt}
+```
+
+The camera can be a center point, a bounding box, or auto-fit to the overlays you pass in.
+Overlays support fills, lines and circles with configurable color/opacity.
+See the [documentation](https://maplibre.org/martin/sources-styles.html) for the full field list and examples.
+Done in [#2794](https://github.com/maplibre/martin/pull/2794), [#2922](https://github.com/maplibre/martin/pull/2922).
+
+### `mbtiles pack` and `mbtiles unpack`
+
+The `mbtiles` CLI gained two subcommands for converting between an MBTiles archive and a `{z}/{x}/{y}.{ext}` directory tree.
+`unpack` extracts an archive into a directory (handy for inspecting individual tiles or serving them with any static HTTP server), and `pack` does the inverse.
+Done in [#2199](https://github.com/maplibre/martin/pull/2199) by [@JakeLow](https://github.com/JakeLow).
+
+### Passthrough sources
+
+Martin can now proxy tiles from an upstream HTTP tile server.
+It fetches each tile from the configured upstream and serves the bytes verbatim, while the rest of Martin's pipeline (caching, headers, MVT↔MLT conversion) applies on top.
+Use it to put Martin's cache in front of an existing tile server, hide an upstream API key from browsers, or spread requests across mirrors.
+
+```yaml
+passthrough:
+  sources:
+    osm: https://tile.openstreetmap.org/{z}/{x}/{y}.png
+    secure:
+      url: https://api.example.com/{z}/{x}/{y}
+      headers:
+        Authorization: ${API_TOKEN}
+      timeout: 30s
+```
+
+An upstream can be a `{z}/{x}/{y}` template, a TileJSON document URL, a list of mirror templates, or the detailed object form above.
+See the [documentation](https://maplibre.org/martin/sources-passthrough.html) for the full field list.
+Done in [#2913](https://github.com/maplibre/martin/pull/2913), [#2908](https://github.com/maplibre/martin/pull/2908), [#2924](https://github.com/maplibre/martin/pull/2924).
+
+### More capable config parsing
+
+We reworked how config files are parsed by migrating YAML handling to `serde-saphyr` (dropping `serde_yaml`).
+YAML anchors and aliases now work, and the `${VAR:default}` (with all the docker-compose shorthands now also supported) environment-variable substitution syntax is still supported.
+Done in [#2943](https://github.com/maplibre/martin/pull/2943), [#2877](https://github.com/maplibre/martin/pull/2877), [#2870](https://github.com/maplibre/martin/pull/2870), [#2921](https://github.com/maplibre/martin/pull/2921).
+
+### ☀️ GSoC spotlight: duckdb GeoParquet sources
+
+**GeoParquet** (via DuckDB) config parsing and resolver wiring landed as a building block, continuing our GSoC DuckDB work.
+Top-level config/lifecycle wiring is planned for a follow-up.
+Done in [#2931](https://github.com/maplibre/martin/pull/2931), [#2902](https://github.com/maplibre/martin/pull/2902) by [@manbhav234](https://github.com/manbhav234).
 
 ### Fixed
 
-- *(deps)* update npm dependencies ([#2955](https://github.com/maplibre/martin/pull/2955))
-- *(config)* accept legacy ${VAR:default} substitution syntax ([#2943](https://github.com/maplibre/martin/pull/2943))
-- *(ci)* stop compiling bundled DuckDB in non-duckdb test builds and other CI stability fixes ([#2920](https://github.com/maplibre/martin/pull/2920))
-- gate idr lint expectations on absence of consuming backends ([#2916](https://github.com/maplibre/martin/pull/2916))
-- *(postgres)* redact password in BadConnectionString error ([#2944](https://github.com/maplibre/martin/pull/2944))
+- *(pg)* Redact the password in the `BadConnectionString` error so it can't leak into logs ([#2944](https://github.com/maplibre/martin/pull/2944)).
+- Improve logging when a requested zoom is out of range ([#2893](https://github.com/maplibre/martin/pull/2893)).
 
 ### Other
 
-- *(deps)* autoupdate pre-commit ([#2966](https://github.com/maplibre/martin/pull/2966))
-- disable uv CI cache and drop unused image/utoipa-actix-web deps ([#2963](https://github.com/maplibre/martin/pull/2963))
-- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2940](https://github.com/maplibre/martin/pull/2940))
-- better yaml parsing for configs, e.g. anchors, ... (config-6) ([#2870](https://github.com/maplibre/martin/pull/2870))
-- *(deps)* Bump js-yaml from 4.1.1 to 4.2.0 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2933](https://github.com/maplibre/martin/pull/2933))
-- *(deps)* autoupdate pre-commit ([#2932](https://github.com/maplibre/martin/pull/2932))
-- *(martin-core)* derive font extensions from FontFormat via strum ([#2921](https://github.com/maplibre/martin/pull/2921))
-- Fold unicode arrows to ASCII in pre-commit ([#2909](https://github.com/maplibre/martin/pull/2909))
-- duckdb bounds refactor and sql utils ([#2902](https://github.com/maplibre/martin/pull/2902))
-- *(deps)* update mlt-core ([#2906](https://github.com/maplibre/martin/pull/2906))
-- fmt imports ([#2903](https://github.com/maplibre/martin/pull/2903))
-- migrate YAML serialization to serde-saphyr, drop serde_yaml (config-5) ([#2877](https://github.com/maplibre/martin/pull/2877))
-- *(deps-dev)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2900](https://github.com/maplibre/martin/pull/2900))
+- Documented the new passthrough and GeoJSON sources, plus assorted docs fixes ([#2965](https://github.com/maplibre/martin/pull/2965)).
+- Migrated dependency automation from Dependabot to Renovate ([#2947](https://github.com/maplibre/martin/pull/2947), [#2949](https://github.com/maplibre/martin/pull/2949), [#2951](https://github.com/maplibre/martin/pull/2951), [#2952](https://github.com/maplibre/martin/pull/2952), [#2960](https://github.com/maplibre/martin/pull/2960), [#2962](https://github.com/maplibre/martin/pull/2962), [#2967](https://github.com/maplibre/martin/pull/2967), [#2969](https://github.com/maplibre/martin/pull/2969)).
+- Numerous CI stability fixes ([#2920](https://github.com/maplibre/martin/pull/2920), [#2916](https://github.com/maplibre/martin/pull/2916), [#2963](https://github.com/maplibre/martin/pull/2963), [#2903](https://github.com/maplibre/martin/pull/2903), [#2909](https://github.com/maplibre/martin/pull/2909))
+- various dependency bumps ([#2899](https://github.com/maplibre/martin/pull/2899), [#2955](https://github.com/maplibre/martin/pull/2955),  [#2966](https://github.com/maplibre/martin/pull/2966), [#2906](https://github.com/maplibre/martin/pull/2906), [#2933](https://github.com/maplibre/martin/pull/2933), [#2932](https://github.com/maplibre/martin/pull/2932), [#2940](https://github.com/maplibre/martin/pull/2940), [#2900](https://github.com/maplibre/martin/pull/2900))
 
 ## [1.11.0](https://github.com/maplibre/martin/compare/martin-v1.10.1...martin-v1.11.0) - 2026-06-16
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.11.0"
+version = "1.12.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.17",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1](https://github.com/maplibre/martin/compare/mbtiles-v0.18.0...mbtiles-v0.18.1) - 2026-07-07
+
+### Added
+
+- Add `mbtiles pack` and `mbtiles unpack` subcommands ([#2199](https://github.com/maplibre/martin/pull/2199))
+- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
+- *(tile-utils)* make tile_bbox public ([#2924](https://github.com/maplibre/martin/pull/2924))
+
+### Other
+
+- migrate YAML serialization to serde-saphyr, drop serde_yaml (config-5) ([#2877](https://github.com/maplibre/martin/pull/2877))
+
 ## [0.18.0](https://github.com/maplibre/martin/compare/mbtiles-v0.17.6...mbtiles-v0.18.0) - 2026-06-16
 
 ### Other

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.11.0"
+    "version": "1.12.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.7.4 -> 0.7.5 (✓ API compatible changes)
* `mbtiles`: 0.18.0 -> 0.18.1 (✓ API compatible changes)
* `martin-core`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `martin`: 1.11.0 -> 1.12.0

### ⚠ `martin-core` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature duckdb in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.18.1](https://github.com/maplibre/martin/compare/mbtiles-v0.18.0...mbtiles-v0.18.1) - 2026-07-07

### Added

- Add `mbtiles pack` and `mbtiles unpack` subcommands ([#2199](https://github.com/maplibre/martin/pull/2199))
- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
- *(tile-utils)* make tile_bbox public ([#2924](https://github.com/maplibre/martin/pull/2924))

### Other

- migrate YAML serialization to serde-saphyr, drop serde_yaml (config-5) ([#2877](https://github.com/maplibre/martin/pull/2877))
</blockquote>

## `martin-core`

<blockquote>

## [0.9.0](https://github.com/maplibre/martin/compare/martin-core-v0.8.0...martin-core-v0.9.0) - 2026-07-07

### Added

- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
- *(geojson)* add GeoJSON tile source to martin-core ([#2925](https://github.com/maplibre/martin/pull/2925))
- *(martin-core)* add static map overlay rendering engine ([#2922](https://github.com/maplibre/martin/pull/2922))
- *(martin-core)* add Transport::from_string_headers ([#2913](https://github.com/maplibre/martin/pull/2913))
- *(martin-core)* passthrough tile source ([#2908](https://github.com/maplibre/martin/pull/2908))

### Fixed

- *(postgres)* redact password in BadConnectionString error ([#2944](https://github.com/maplibre/martin/pull/2944))

### Other

- disable uv CI cache and drop unused image/utoipa-actix-web deps ([#2963](https://github.com/maplibre/martin/pull/2963))
- *(martin-core)* derive font extensions from FontFormat via strum ([#2921](https://github.com/maplibre/martin/pull/2921))
- duckdb bounds refactor and sql utils ([#2902](https://github.com/maplibre/martin/pull/2902))
- fmt imports ([#2903](https://github.com/maplibre/martin/pull/2903))
</blockquote>

## `martin`

<blockquote>

## [1.12.0](https://github.com/maplibre/martin/compare/martin-v1.11.0...martin-v1.12.0) - 2026-07-07

### Added

- *(geojson)* serve MVT tiles from a GeoJSON file ([#2538](https://github.com/maplibre/martin/pull/2538))
- *(rendering)* add static map overlay endpoint ([#2794](https://github.com/maplibre/martin/pull/2794))
- geoparquet config and resolver wiring  ([#2931](https://github.com/maplibre/martin/pull/2931))
- update to mlt-core 0.11.1 ([#2899](https://github.com/maplibre/martin/pull/2899))
- *(geojson)* add GeoJSON tile source to martin-core ([#2925](https://github.com/maplibre/martin/pull/2925))
- *(martin-core)* add static map overlay rendering engine ([#2922](https://github.com/maplibre/martin/pull/2922))
- *(martin-core)* add Transport::from_string_headers ([#2913](https://github.com/maplibre/martin/pull/2913))
- *(martin-core)* passthrough tile source ([#2908](https://github.com/maplibre/martin/pull/2908))
- *(tile-utils)* make tile_bbox public ([#2924](https://github.com/maplibre/martin/pull/2924))
- Add `mbtiles pack` and `mbtiles unpack` subcommands ([#2199](https://github.com/maplibre/martin/pull/2199))

### Fixed

- *(deps)* update npm dependencies ([#2955](https://github.com/maplibre/martin/pull/2955))
- *(config)* accept legacy ${VAR:default} substitution syntax ([#2943](https://github.com/maplibre/martin/pull/2943))
- *(ci)* stop compiling bundled DuckDB in non-duckdb test builds and other CI stability fixes ([#2920](https://github.com/maplibre/martin/pull/2920))
- gate idr lint expectations on absence of consuming backends ([#2916](https://github.com/maplibre/martin/pull/2916))
- *(postgres)* redact password in BadConnectionString error ([#2944](https://github.com/maplibre/martin/pull/2944))

### Other

- *(deps)* autoupdate pre-commit ([#2966](https://github.com/maplibre/martin/pull/2966))
- disable uv CI cache and drop unused image/utoipa-actix-web deps ([#2963](https://github.com/maplibre/martin/pull/2963))
- *(deps)* Bump the all-npm-version-updates group across 2 directories with 18 updates ([#2940](https://github.com/maplibre/martin/pull/2940))
- better yaml parsing for configs, e.g. anchors, ... (config-6) ([#2870](https://github.com/maplibre/martin/pull/2870))
- *(deps)* Bump js-yaml from 4.1.1 to 4.2.0 in /martin/martin-ui in the all-npm-security-updates group across 1 directory ([#2933](https://github.com/maplibre/martin/pull/2933))
- *(deps)* autoupdate pre-commit ([#2932](https://github.com/maplibre/martin/pull/2932))
- *(martin-core)* derive font extensions from FontFormat via strum ([#2921](https://github.com/maplibre/martin/pull/2921))
- Fold unicode arrows to ASCII in pre-commit ([#2909](https://github.com/maplibre/martin/pull/2909))
- duckdb bounds refactor and sql utils ([#2902](https://github.com/maplibre/martin/pull/2902))
- *(deps)* update mlt-core ([#2906](https://github.com/maplibre/martin/pull/2906))
- fmt imports ([#2903](https://github.com/maplibre/martin/pull/2903))
- migrate YAML serialization to serde-saphyr, drop serde_yaml (config-5) ([#2877](https://github.com/maplibre/martin/pull/2877))
- *(deps-dev)* Bump the all-npm-security-updates group across 2 directories with 1 update ([#2900](https://github.com/maplibre/martin/pull/2900))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).