### PR TITLE
docs: split file sources into MBTiles and PMTiles subpages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ Martin optimizes for speed and heavy traffic, and is written in [Rust](https://g
   * [PostGIS](https://github.com/postgis/postgis) databases, automatically discovering compatible tables and functions
   * [PMTile](https://protomaps.com/blog/pmtiles-v3-whats-new), both local files and over HTTP
   * [MBTile](https://github.com/mapbox/mbtiles-spec) files
-  * [GeoJSON](https://maplibre.org/martin/sources-geojson.html) files, converted to vector tiles on the fly
-* [Passthrough](https://maplibre.org/martin/sources-passthrough.html) tiles from an upstream HTTP tile server
-* [Combine](https://maplibre.org/martin/sources-composite.html) multiple tile sources into one
-* Serve [styles](https://maplibre.org/martin/sources-styles.html) and generate [sprites](https://maplibre.org/martin/sources-sprites.html) or [font glyphs](https://maplibre.org/martin/sources-fonts.html) on the fly
-* Generate tiles in bulk from any Martin-supported sources into an `MBTiles` file with [martin-cp](https://maplibre.org/martin/martin-cp.html) tool
-* Examine, copy, validate, compare, and apply diffs between `MBTiles` files with [mbtiles](https://maplibre.org/martin/tools.html#mbtiles) tool
+  * [GeoJSON](https://maplibre.org/martin/sources-geojson/) files, converted to vector tiles on the fly
+* [Passthrough](https://maplibre.org/martin/sources-passthrough/) tiles from an upstream HTTP tile server
+* [Combine](https://maplibre.org/martin/sources-composite/) multiple tile sources into one
+* Serve [styles](https://maplibre.org/martin/sources-styles/) and generate [sprites](https://maplibre.org/martin/sources-sprites/) or [font glyphs](https://maplibre.org/martin/sources-fonts/) on the fly
+* Generate tiles in bulk from any Martin-supported sources into an `MBTiles` file with [martin-cp](https://maplibre.org/martin/martin-cp/) tool
+* Examine, copy, validate, compare, and apply diffs between `MBTiles` files with [mbtiles](https://maplibre.org/martin/tools/#mbtiles) tool
 
 ## Documentation
 
-* [Quick Start](https://maplibre.org/martin/quick-start.html)
-* [Installation](https://maplibre.org/martin/installation.html)
-* Running with [CLI](https://maplibre.org/martin/run-with-cli.html)
-  or [configuration file](https://maplibre.org/martin/config-file.html)
-* [Usage and API](https://maplibre.org/martin/using.html)
+* [Quick Start](https://maplibre.org/martin/quick-start/)
+* [Installation](https://maplibre.org/martin/installation/)
+* Running with [CLI](https://maplibre.org/martin/run-with-cli/)
+  or [configuration file](https://maplibre.org/martin/config-file/)
+* [Usage and API](https://maplibre.org/martin/using/)
 
 ## Getting Involved
 
@@ -43,7 +43,7 @@ Join the `#maplibre-martin` slack channel at OSMUS -- automatic invite is at <ht
 
 Like any open source project, Martin welcomes contributions from anyone who wants to help improve it.
 
-* See [Development Guide](https://maplibre.org/martin/development.html) for setup
+* See [Development Guide](https://maplibre.org/martin/development/) for setup
 * Use `just help` for common commands
 * Check [help wanted](https://github.com/maplibre/martin/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issues
 

--- a/docs/content/recipe-basemap-postgis.md
+++ b/docs/content/recipe-basemap-postgis.md
@@ -107,7 +107,7 @@ docker exec some-postgis psql --dbname postgres --username postgres --command \
 
 ## Serving tiles with Martin
 
-Now we will serve the content of [mbtiles](sources-files.md) and the [postgis database](pg-connections/index.md).
+Now we will serve the content of [mbtiles](sources-mbtiles.md) and the [postgis database](pg-connections/index.md).
 
 If you want more precise options what things are published how, please see the [configuration file](config-file/index.md) or [cli documentation](run-with-cli.md).
 By default, we will share every servable postgres [table, view](sources-pg-tables.md) and [function](sources-pg-functions.md).

--- a/docs/content/run/index.md
+++ b/docs/content/run/index.md
@@ -4,7 +4,7 @@ icon: material/play-circle
 
 # Usage
 
-Martin requires at least one PostgreSQL [connection string](../pg-connections/index.md) or a [tile source file](../sources-files.md)
+Martin requires at least one PostgreSQL [connection string](../pg-connections/index.md) or a [tile source file](../sources-files/index.md)
 as a command-line argument.
 A PG connection string can also be passed via the `DATABASE_URL` environment variable.
 

--- a/docs/content/sources-files/index.md
+++ b/docs/content/sources-files/index.md
@@ -1,0 +1,89 @@
+---
+icon: material/database
+tags:
+  - mbtiles
+  - pmtiles
+  - tile-sources
+  - configuration
+  - aws
+  - azure
+  - google-cloud
+---
+
+# MBTiles and PMTiles File Sources
+
+Martin can serve any type of tiles from [PMTile](https://protomaps.com/blog/pmtiles-v3-whats-new)
+and [MBTile](https://github.com/mapbox/mbtiles-spec) files.
+To serve a file from CLI, simply put the path to the file or the directory with `*.mbtiles` or `*.pmtiles` files.
+A path to PMTiles file may be a URL.
+For example:
+
+```bash
+martin  /path/to/mbtiles/file.mbtiles  /path/to/directory   https://example.org/path/tiles.pmtiles
+```
+
+You may also want to generate a [config file](../config-file/index.md) using the `--save-config my-config.yaml`, and later edit
+it and use it with `--config my-config.yaml` option.
+
+!!! tip
+    See [our tile sources explanation](../sources-tiles/index.md) for a more detailed explanation on the difference between our available data sources.
+
+Both formats have their own dedicated page describing how to configure them:
+
+- [MBTiles File Sources](../sources-mbtiles.md) - local SQLite archives.
+- [PMTiles File Sources](../sources-pmtiles.md) - local or remote (HTTP range / object storage) archives.
+
+## MBTiles vs PMTiles
+
+MBTiles and PMTiles are both formats for storing tiled geospatial data, but they differ in architecture, deployment, and operational characteristics.
+
+### Key Differences
+
+- **Deployment model**
+  **MBTiles** archives must be stored locally on the same machine as the tile server.
+  **PMTiles** archives can be accessed either locally or remotely via HTTP range requests, e.g. from an object storage like S3.
+  **PMTiles** allows simpler production deployment with Kubernetes, as it allows the large data file to reside in S3 and shared by multiple pods, but restricted from direct user access.
+- **Performance**
+  **MBTiles** typically provide slightly lower latency due to local access and SQLite indexing.
+  **PMTiles** may introduce additional latency when accessed remotely, but this is usually mitigated by HTTP caching and CDN usage.
+- **Storage efficiency**
+  **PMTiles** archives are generally more space-efficient, typically ~10-15% smaller than equivalent **MBTiles** archives.
+- **Memory usage**
+  **MBTiles** relies on SQLite, which maintains an internal page cache and may increase memory usage under load.
+  **PMTiles** can, in some cases, operate with lower memory overhead, depending on access patterns and caching configuration.
+
+The choice between MBTiles and PMTiles depends on system requirements:
+
+- Use **MBTiles** for local, self-contained deployments with minimal external dependencies.
+- Use **PMTiles** for cloud-native or distributed setups where remote access, CDN integration, or object storage is preferred.
+
+## Postprocessing
+
+MBTiles and PMTiles sources support `convert_to_mlt` and `convert_to_mvt` keys to control tile postprocessing.
+This can be set for all sources of a type or for an individual source.
+See [Configuration File](../config-file/index.md#postprocessing) for details.
+
+```yaml
+pmtiles:
+  sources:
+    basemap:
+      path: /data/basemap.pmtiles
+      convert_to_mlt: auto    # convert MVT -> MLT when client requests it
+      convert_to_mvt: auto    # convert MLT -> MVT when client requests it
+    mlt_archive:
+      path: /data/mlt_tiles.pmtiles
+      convert_to_mvt: disable # disabllow any on the the fly conversion
+      convert_to_mlt: disable
+```
+
+## Autodiscovery
+
+For mbtiles or local pmtiles files, we support auto discovering at startup.
+This means that the following will discover all mbtiles and pmtiles files in the directory:
+
+```bash
+martin  /path/to/directory
+```
+
+For remote PMTiles, individual file URLs work as expected.
+Remote object-storage *prefixes* (e.g. `s3://bucket/tiles/`) are also supported via periodic listing - see [PMTiles Hot Reload](../sources-pmtiles.md#pmtiles-hot-reload).

--- a/docs/content/sources-files/index.md
+++ b/docs/content/sources-files/index.md
@@ -5,9 +5,6 @@ tags:
   - pmtiles
   - tile-sources
   - configuration
-  - aws
-  - azure
-  - google-cloud
 ---
 
 # MBTiles and PMTiles File Sources

--- a/docs/content/sources-geojson.md
+++ b/docs/content/sources-geojson.md
@@ -22,7 +22,7 @@ You may also want to generate a [config file](config-file/index.md) using `--sav
 The config file can then be used via the `--config my-config.yaml` option.
 
 !!! warning
-    Serving these files is less efficient compared to pre-calculated [PMTiles or MBTiles](sources-files.md).
+    Serving these files is less efficient compared to pre-calculated [PMTiles or MBTiles](sources-files/index.md).
     This is because to serve GeoJSON, martin needs to:
 
     - parse JSON
@@ -31,7 +31,7 @@ The config file can then be used via the `--config my-config.yaml` option.
     - encode them as MVT
 
     To improve performance, we currently assume that each file fits into RAM.
-    If you want to want and can convert your geojson files to [mbtiles/ pmtiles](sources-files.md), we recomend tooling like [`tippecanoe`](https://github.com/felt/tippecanoe).
+    If you want to want and can convert your geojson files to [mbtiles/ pmtiles](sources-files/index.md), we recomend tooling like [`tippecanoe`](https://github.com/felt/tippecanoe).
 
 ## Run Martin with configuration file
 

--- a/docs/content/sources-mbtiles.md
+++ b/docs/content/sources-mbtiles.md
@@ -1,0 +1,52 @@
+---
+icon: material/database
+tags:
+  - mbtiles
+  - tile-sources
+  - configuration
+---
+
+# MBTiles File Sources
+
+Martin can serve any type of tiles from [MBTile](https://github.com/mapbox/mbtiles-spec) files.
+MBTiles archives are local SQLite databases and must reside on the same machine as the tile server.
+To serve a file from CLI, simply put the path to the file or the directory with `*.mbtiles` files.
+For example:
+
+```bash
+martin  /path/to/mbtiles/file.mbtiles  /path/to/directory
+```
+
+You may also want to generate a [config file](config-file/index.md) using the `--save-config my-config.yaml`, and later edit
+it and use it with `--config my-config.yaml` option.
+
+!!! tip
+    See [MBTiles vs PMTiles](sources-files/index.md#mbtiles-vs-pmtiles) for a comparison of the two file formats.
+
+## MBTiles Hot Reload
+
+Martin watches directories configured under `mbtiles` for changes at runtime.
+When `.mbtiles` files are added, modified, or removed from a watched directory, Martin automatically updates the tile catalog - no restart required.
+
+```bash
+# Martin will watch this directory and reflect any *.mbtiles changes live
+martin  /path/to/mbtiles/directory
+```
+
+Or via config file:
+
+```yaml
+mbtiles:
+  paths:
+    - /path/to/mbtiles/directory
+```
+
+The following events are handled automatically:
+
+- **File added** - the new source appears in the catalog.
+- **File modified** - the source is reloaded and its tile cache is invalidated.
+  Not avaliable on windows due to OS-limtations (SQLite not allowing `FILE_SHARE_DELETE`).
+- **File removed** - the source is removed from the catalog.
+
+!!! note
+    Hot reload applies to directories configured under `mbtiles.paths` (or passed on the CLI). Named sources listed under `mbtiles.sources` are snapshotted at startup and are not watched for changes.

--- a/docs/content/sources-pmtiles.md
+++ b/docs/content/sources-pmtiles.md
@@ -1,7 +1,6 @@
 ---
 icon: material/database
 tags:
-  - mbtiles
   - pmtiles
   - tile-sources
   - configuration
@@ -10,86 +9,26 @@ tags:
   - google-cloud
 ---
 
-# MBTiles and PMTiles File Sources
+# PMTiles File Sources
 
-Martin can serve any type of tiles from [PMTile](https://protomaps.com/blog/pmtiles-v3-whats-new)
-and [MBTile](https://github.com/mapbox/mbtiles-spec) files.
-To serve a file from CLI, simply put the path to the file or the directory with `*.mbtiles` or `*.pmtiles` files.
-A path to PMTiles file may be a URL.
+Martin can serve any type of tiles from [PMTile](https://protomaps.com/blog/pmtiles-v3-whats-new) files.
+A PMTiles archive can be accessed either locally or remotely via HTTP range requests, e.g. from an object storage like S3.
+A path to a PMTiles file may be a URL.
 For example:
 
 ```bash
-martin  /path/to/mbtiles/file.mbtiles  /path/to/directory   https://example.org/path/tiles.pmtiles
+martin  /path/to/directory   https://example.org/path/tiles.pmtiles
 ```
 
 You may also want to generate a [config file](config-file/index.md) using the `--save-config my-config.yaml`, and later edit
 it and use it with `--config my-config.yaml` option.
 
 !!! tip
-    See [our tile sources explanation](sources-tiles/index.md) for a more detailed explanation on the difference between our available data sources.
+    See [MBTiles vs PMTiles](sources-files/index.md#mbtiles-vs-pmtiles) for a comparison of the two file formats.
 
-### Postprocessing
+## PMTiles Hot Reload
 
-MBTiles and PMTiles sources support `convert_to_mlt` and `convert_to_mvt` keys to control tile postprocessing.
-This can be set for all sources of a type or for an individual source.
-See [Configuration File](config-file/index.md#postprocessing) for details.
-
-```yaml
-pmtiles:
-  sources:
-    basemap:
-      path: /data/basemap.pmtiles
-      convert_to_mlt: auto    # convert MVT -> MLT when client requests it
-      convert_to_mvt: auto    # convert MLT -> MVT when client requests it
-    mlt_archive:
-      path: /data/mlt_tiles.pmtiles
-      convert_to_mvt: disable # disabllow any on the the fly conversion
-      convert_to_mlt: disable
-```
-
-### Autodiscovery
-
-For mbtiles or local pmtiles files, we support auto discovering at startup.
-This means that the following will discover all mbtiles and pmtiles files in the directory:
-
-```bash
-martin  /path/to/directory
-```
-
-For remote PMTiles, individual file URLs work as expected.
-Remote object-storage *prefixes* (e.g. `s3://bucket/tiles/`) are also supported via periodic listing - see [PMTiles Hot Reload](#pmtiles-hot-reload) below.
-
-### MBTiles Hot Reload
-
-Martin watches directories configured under `mbtiles` for changes at runtime.
-When `.mbtiles` files are added, modified, or removed from a watched directory, Martin automatically updates the tile catalog - no restart required.
-
-```bash
-# Martin will watch this directory and reflect any *.mbtiles changes live
-martin  /path/to/mbtiles/directory
-```
-
-Or via config file:
-
-```yaml
-mbtiles:
-  paths:
-    - /path/to/mbtiles/directory
-```
-
-The following events are handled automatically:
-
-- **File added** - the new source appears in the catalog.
-- **File modified** - the source is reloaded and its tile cache is invalidated.
-  Not avaliable on windows due to OS-limtations (SQLite not allowing `FILE_SHARE_DELETE`).
-- **File removed** - the source is removed from the catalog.
-
-!!! note
-    Hot reload applies to directories configured under `mbtiles.paths` (or passed on the CLI). Named sources listed under `mbtiles.sources` are snapshotted at startup and are not watched for changes.
-
-### PMTiles Hot Reload
-
-Martin watches local directories configured under `pmtiles` for `.pmtiles` files using filesystem events, with the same add/modify/remove semantics described for MBTiles above.
+Martin watches local directories configured under `pmtiles` for `.pmtiles` files using filesystem events, with the same add/modify/remove semantics described for [MBTiles](sources-mbtiles.md#mbtiles-hot-reload).
 
 ```yaml
 pmtiles:
@@ -113,26 +52,7 @@ pmtiles:
     Hot reload applies to directories and remote prefixes configured under `pmtiles.paths` (or passed on the CLI).
     Named sources listed under `pmtiles.sources` and individual remote-file URLs are snapshotted at startup and are not watched for changes.
 
-## MBTiles vs PMTiles
-
-MBTiles and PMTiles are both formats for storing tiled geospatial data, but they differ in architecture, deployment, and operational characteristics.
-
-### Key Differences
-
-- **Deployment model**
-  **MBTiles** archives must be stored locally on the same machine as the tile server.
-  **PMTiles** archives can be accessed either locally or remotely via HTTP range requests, e.g. from an object storage like S3.
-  **PMTiles** allows simpler production deployment with Kubernetes, as it allows the large data file to reside in S3 and shared by multiple pods, but restricted from direct user access.
-- **Performance**
-  **MBTiles** typically provide slightly lower latency due to local access and SQLite indexing.
-  **PMTiles** may introduce additional latency when accessed remotely, but this is usually mitigated by HTTP caching and CDN usage.
-- **Storage efficiency**
-  **PMTiles** archives are generally more space-efficient, typically ~10-15% smaller than equivalent **MBTiles** archives.
-- **Memory usage**
-  **MBTiles** relies on SQLite, which maintains an internal page cache and may increase memory usage under load.
-  **PMTiles** can, in some cases, operate with lower memory overhead, depending on access patterns and caching configuration.
-
-### Serving PMTiles without a Tile Server
+## Serving PMTiles without a Tile Server
 
 PMTiles archives can be served directly from HTTP range-capable storage without a dedicated tile server.
 This approach has several limitations:
@@ -148,12 +68,7 @@ This approach has several limitations:
 - **Caching behavior**
   Cache efficiency may be reduced compared to setups with a dedicated tile server that can optimize request patterns.
 
-The choice between MBTiles and PMTiles depends on system requirements:
-
-- Use **MBTiles** for local, self-contained deployments with minimal external dependencies.
-- Use **PMTiles** for cloud-native or distributed setups where remote access, CDN integration, or object storage is preferred.
-
-### Serving PMTiles from local file systems, http or Object Storage
+## Serving PMTiles from local file systems, http or Object Storage
 
 The settings available for a PMTiles source depend on the backend:
 

--- a/docs/content/sources-tiles/index.md
+++ b/docs/content/sources-tiles/index.md
@@ -8,14 +8,14 @@ tags:
 
 Martin supports multiple tile sources
 
-- [MBTiles Sources](../sources-files.md) Local Sqlite database containing pre-generated vector or raster tiles.
-- [PMTiles Sources](../sources-files.md) A local file or a web-accessible HTTP source with the pre-generated raster or vector tiles.
+- [MBTiles Sources](../sources-mbtiles.md) Local Sqlite database containing pre-generated vector or raster tiles.
+- [PMTiles Sources](../sources-pmtiles.md) A local file or a web-accessible HTTP source with the pre-generated raster or vector tiles.
 - [GeoJSON Sources](../sources-geojson.md) A local file with geodata that we can convert to vector tiles.
 - [PostgreSQL Connections](../pg-connections/index.md) with
   - [Table Sources](../sources-pg-tables.md)
   - [Function Sources](../sources-pg-functions.md)
 
-The difference between tile archives (*[MBTiles/PMTiles](../sources-files.md)*), semi-static data (*[GeoJSON](../sources-geojson.md)*) and a database ([PG-Table](../sources-pg-tables.md)/[PG-Function](../sources-pg-functions.md)) is that
+The difference between tile archives (*[MBTiles/PMTiles](../sources-files/index.md)*), semi-static data (*[GeoJSON](../sources-geojson.md)*) and a database ([PG-Table](../sources-pg-tables.md)/[PG-Function](../sources-pg-functions.md)) is that
 
 - **database** are more flexible and may (depending on how you fill it) be updated in **real-time**.
 - **Tile archives** on the other hand may (depending on the data) be more **compact, memory efficient and exhibit better performance** for tile-serving.

--- a/docs/content/sources-tiles/index.md
+++ b/docs/content/sources-tiles/index.md
@@ -8,8 +8,9 @@ tags:
 
 Martin supports multiple tile sources
 
-- [MBTiles Sources](../sources-mbtiles.md) Local Sqlite database containing pre-generated vector or raster tiles.
-- [PMTiles Sources](../sources-pmtiles.md) A local file or a web-accessible HTTP source with the pre-generated raster or vector tiles.
+- [Tile Archive files](../sources-files/index.md)
+  - [MBTiles Sources](../sources-mbtiles.md) Local Sqlite database containing pre-generated vector or raster tiles.
+  - [PMTiles Sources](../sources-pmtiles.md) A local file or a web-accessible HTTP source with the pre-generated raster or vector tiles.
 - [GeoJSON Sources](../sources-geojson.md) A local file with geodata that we can convert to vector tiles.
 - [PostgreSQL Connections](../pg-connections/index.md) with
   - [Table Sources](../sources-pg-tables.md)

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -45,7 +45,7 @@ Done in [#2199](https://github.com/maplibre/martin/pull/2199) by [@JakeLow](http
 ### Passthrough sources
 
 Martin can now proxy tiles from an upstream HTTP tile server.
-It fetches each tile from the configured upstream and serves the bytes verbatim, while the rest of Martin's pipeline (caching, headers, MVT↔MLT conversion) applies on top.
+It fetches each tile from the configured upstream and serves the bytes verbatim, while the rest of Martin's pipeline (caching, headers, MVT<->MLT conversion) applies on top.
 Use it to put Martin's cache in front of an existing tile server, hide an upstream API key from browsers, or spread requests across mirrors.
 
 ```yaml

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,7 +54,11 @@ nav = [
     "config-file/index.md",
     {"Tile sources" = [
         "sources-tiles/index.md",
-        {"MBTiles and PMTiles File Sources" = "sources-files.md"},
+        {"MBTiles and PMTiles File Sources" = [
+            "sources-files/index.md",
+            {"MBTiles File Sources" = "sources-mbtiles.md"},
+            {"PMTiles File Sources" = "sources-pmtiles.md"}
+        ]},
         {"PostgreSQL Connections" = [
             "pg-connections/index.md",
             {"PostgreSQL Table Sources" = "sources-pg-tables.md"},


### PR DESCRIPTION
Splits the single file-sources page into an overview plus per-format subpages, mirroring the PostgreSQL Connections structure: `sources-files/index.md` explains MBTiles vs PMTiles and links to `sources-mbtiles.md` and `sources-pmtiles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HuFwiDUdrMcNCzAh77zps