### PR TITLE
feat(docs): page through the guide with left/right arrow keys

### DIFF
--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -5,9 +5,7 @@
 // common "prev/next" behavior of left/right paged sites.
 //
 // See https://github.com/maplibre/martin/issues/2788
-(function () {
-  "use strict";
-
+(() => {
   // Don't hijack the arrow keys while the user is typing (e.g. in the search
   // box) or interacting with a form control.
   function isTypingTarget(el) {
@@ -18,13 +16,13 @@
       return true;
     }
     var tag = el.tagName;
-    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   }
 
   // A single document-level listener keeps working across "instant" navigation,
   // where the page body is swapped without a full reload. The footer links are
   // looked up on each key press so they always point at the current page.
-  document.addEventListener("keydown", function (event) {
+  document.addEventListener('keydown', (event) => {
     // Leave modifier combinations alone (e.g. browser back/forward shortcuts).
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
@@ -34,16 +32,16 @@
     }
 
     var selector;
-    if (event.key === "ArrowLeft") {
-      selector = "a.md-footer__link--prev[href]";
-    } else if (event.key === "ArrowRight") {
-      selector = "a.md-footer__link--next[href]";
+    if (event.key === 'ArrowLeft') {
+      selector = 'a.md-footer__link--prev[href]';
+    } else if (event.key === 'ArrowRight') {
+      selector = 'a.md-footer__link--next[href]';
     } else {
       return;
     }
 
     var link = document.querySelector(selector);
-    if (link && link.getAttribute("href")) {
+    if (link && link.getAttribute('href')) {
       event.preventDefault();
       // Use click() so "instant" navigation (if enabled) can intercept it.
       link.click();

--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -16,7 +16,7 @@
   // one document-level listener survives "instant" navigation (body swapped, no
   // full reload); re-query the footer links each keypress so they track the current page.
   document.addEventListener('keydown', (event) => {
-    // leave modifier combos alone — e.g. browser back/forward shortcuts
+    // leave modifier combos alone - e.g. browser back/forward shortcuts
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
     }

--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -1,0 +1,52 @@
+// Keyboard navigation for the documentation guide.
+//
+// Left/Right arrow keys page through the guide, following the same
+// previous/next links that are shown in the page footer. This mirrors the
+// common "prev/next" behavior of left/right paged sites.
+//
+// See https://github.com/maplibre/martin/issues/2788
+(function () {
+  "use strict";
+
+  // Don't hijack the arrow keys while the user is typing (e.g. in the search
+  // box) or interacting with a form control.
+  function isTypingTarget(el) {
+    if (!el) {
+      return false;
+    }
+    if (el.isContentEditable) {
+      return true;
+    }
+    var tag = el.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+  }
+
+  // A single document-level listener keeps working across "instant" navigation,
+  // where the page body is swapped without a full reload. The footer links are
+  // looked up on each key press so they always point at the current page.
+  document.addEventListener("keydown", function (event) {
+    // Leave modifier combinations alone (e.g. browser back/forward shortcuts).
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return;
+    }
+    if (isTypingTarget(document.activeElement)) {
+      return;
+    }
+
+    var selector;
+    if (event.key === "ArrowLeft") {
+      selector = "a.md-footer__link--prev[href]";
+    } else if (event.key === "ArrowRight") {
+      selector = "a.md-footer__link--next[href]";
+    } else {
+      return;
+    }
+
+    var link = document.querySelector(selector);
+    if (link && link.getAttribute("href")) {
+      event.preventDefault();
+      // Use click() so "instant" navigation (if enabled) can intercept it.
+      link.click();
+    }
+  });
+})();

--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -19,6 +19,14 @@
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
     }
+    // don't hijack arrows while the search overlay is open: the user is either
+    // typing a query or arrowing through the results, which moves focus onto the
+    // result links (so an activeElement check alone doesn't cover it). `#__search`
+    // is the theme's search toggle checkbox, checked whenever search is open.
+    var searchToggle = document.getElementById('__search');
+    if (searchToggle && searchToggle.checked) {
+      return;
+    }
     if (isTypingTarget(document.activeElement)) {
       return;
     }

--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -1,13 +1,7 @@
-// Keyboard navigation for the documentation guide.
-//
-// Left/Right arrow keys page through the guide, following the same
-// previous/next links that are shown in the page footer. This mirrors the
-// common "prev/next" behavior of left/right paged sites.
-//
-// See https://github.com/maplibre/martin/issues/2788
+// left/right arrow keys page through the docs guide, following the prev/next
+// links shown in the page footer (#2788).
 (() => {
-  // Don't hijack the arrow keys while the user is typing (e.g. in the search
-  // box) or interacting with a form control.
+  // don't hijack arrows while typing in the search box or a form control
   function isTypingTarget(el) {
     if (!el) {
       return false;
@@ -19,11 +13,10 @@
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   }
 
-  // A single document-level listener keeps working across "instant" navigation,
-  // where the page body is swapped without a full reload. The footer links are
-  // looked up on each key press so they always point at the current page.
+  // one document-level listener survives "instant" navigation (body swapped, no
+  // full reload); re-query the footer links each keypress so they track the current page.
   document.addEventListener('keydown', (event) => {
-    // Leave modifier combinations alone (e.g. browser back/forward shortcuts).
+    // leave modifier combos alone — e.g. browser back/forward shortcuts
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
     }
@@ -43,7 +36,7 @@
     var link = document.querySelector(selector);
     if (link && link.getAttribute('href')) {
       event.preventDefault();
-      // Use click() so "instant" navigation (if enabled) can intercept it.
+      // click() so "instant" navigation can intercept it
       link.click();
     }
   });

--- a/docs/content/javascripts/keyboard-nav.js
+++ b/docs/content/javascripts/keyboard-nav.js
@@ -1,5 +1,4 @@
-// left/right arrow keys page through the docs guide, following the prev/next
-// links shown in the page footer (#2788).
+// left/right arrow keys page through the docs guide
 (() => {
   // don't hijack arrows while typing in the search box or a form control
   function isTypingTarget(el) {
@@ -13,8 +12,8 @@
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   }
 
-  // one document-level listener survives "instant" navigation (body swapped, no
-  // full reload); re-query the footer links each keypress so they track the current page.
+  // one document-level listener survives "instant" navigation (body swapped, no full reload)
+  // re-query the footer links each keypress so they track the current page
   document.addEventListener('keydown', (event) => {
     // leave modifier combos alone - e.g. browser back/forward shortcuts
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {

--- a/zensical.toml
+++ b/zensical.toml
@@ -127,7 +127,6 @@ nav = [
 # The path provided should be relative to the "docs_dir".
 #
 # Read more: https://zensical.org/docs/customization/#additional-javascript
-# Enables Left/Right arrow keys to page through the guide (issue #2788).
 extra_javascript = ["javascripts/keyboard-nav.js"]
 
 # ----------------------------------------------------------------------------

--- a/zensical.toml
+++ b/zensical.toml
@@ -127,7 +127,8 @@ nav = [
 # The path provided should be relative to the "docs_dir".
 #
 # Read more: https://zensical.org/docs/customization/#additional-javascript
-#extra_javascript = ["javascripts/extra.js"]
+# Enables Left/Right arrow keys to page through the guide (issue #2788).
+extra_javascript = ["javascripts/keyboard-nav.js"]
 
 # ----------------------------------------------------------------------------
 # Section for configuring theme options


### PR DESCRIPTION
## What

Fixes #2788. Left/Right arrow keys now page through the guide via the footer prev/next links — a common paged-docs convenience.

## How

A single document-level `keydown` listener maps `ArrowLeft`/`ArrowRight` to the existing footer `a.md-footer__link--prev`/`--next` anchors, wired through `extra_javascript`. It survives `navigation.instant`, ignores modifier-key combos, and does nothing when a form field is focused.

## Testing

- `uvx zensical build` → "No issues found"; the script is emitted and referenced in the built HTML.
- Live browser check: from `/installation/`, ArrowRight → `/run/`, ArrowLeft → back to `/installation/`; with an input focused, ArrowRight did not navigate (guard works).
