### PR TITLE
feat(mbtiles): read and validate the hash_algorithm metadata key

### DIFF
--- a/mbtiles/src/errors.rs
+++ b/mbtiles/src/errors.rs
@@ -89,7 +89,10 @@ pub enum MbtError {
     #[error(
         "MBTiles file {filepath} declares an unsupported tile hash algorithm `{algorithm}` in its metadata. This build can only validate `md5` hashes."
     )]
-    UnsupportedHashAlgorithm { algorithm: String, filepath: String },
+    UnsupportedHashAlgorithm {
+        algorithm: String,
+        filepath: PathBuf,
+    },
 
     #[error(r#"Filename "{0}" passed to SQLite must be valid UTF-8"#)]
     InvalidFilenameType(PathBuf),

--- a/mbtiles/src/errors.rs
+++ b/mbtiles/src/errors.rs
@@ -86,6 +86,11 @@ pub enum MbtError {
     )]
     AggHashValueNotFound(String),
 
+    #[error(
+        "MBTiles file {filepath} declares an unsupported tile hash algorithm `{algorithm}` in its metadata. This build can only validate `md5` hashes."
+    )]
+    UnsupportedHashAlgorithm { algorithm: String, filepath: String },
+
     #[error(r#"Filename "{0}" passed to SQLite must be valid UTF-8"#)]
     InvalidFilenameType(PathBuf),
 

--- a/mbtiles/src/lib.rs
+++ b/mbtiles/src/lib.rs
@@ -45,7 +45,8 @@ mod validation;
 pub use martin_tile_utils::{Tile, TileCoord};
 pub use validation::{
     AGG_TILES_HASH, AGG_TILES_HASH_AFTER_APPLY, AGG_TILES_HASH_BEFORE_APPLY, AggHashType,
-    IntegrityCheckType, MbtType, NormalizedSchema, calc_agg_tiles_hash,
+    HASH_ALGORITHM, HashAlgorithm, IntegrityCheckType, MbtType, NormalizedSchema,
+    calc_agg_tiles_hash,
 };
 
 /// `MBTiles` uses a TMS (Tile Map Service) scheme for its tile coordinates (inverted along the Y axis).

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -31,34 +31,24 @@ pub const AGG_TILES_HASH_AFTER_APPLY: &str = "agg_tiles_hash_after_apply";
 /// Metadata key for a diff file, describing the expected [`AGG_TILES_HASH`] value of the tileset to which the diff will be applied.
 pub const AGG_TILES_HASH_BEFORE_APPLY: &str = "agg_tiles_hash_before_apply";
 
-/// Metadata key recording the algorithm used to hash tile data and to compute
-/// the [`AGG_TILES_HASH`] value.
+/// metadata key naming the algorithm used to hash tiles and compute [`AGG_TILES_HASH`].
 ///
-/// Historically `mbtiles`/`martin-cp` (and `tilelive-copy`) always used MD5 and
-/// never stored the algorithm. Other tools (e.g. `tippecanoe`) use different
-/// algorithms such as `fnv1a`, which previously surfaced as a confusing
-/// [`AGG_TILES_HASH`] mismatch during validation. When this key is absent, MD5
-/// is assumed for backwards compatibility.
-///
-/// See <https://github.com/maplibre/martin/issues/1086>.
+/// old `mbtiles`/`martin-cp`/`tilelive-copy` always used md5 and never stored this,
+/// so an absent key means md5. other tools like `tippecanoe` use e.g. `fnv1a`, which
+/// used to show up as a confusing [`AGG_TILES_HASH`] mismatch (#1086).
 pub const HASH_ALGORITHM: &str = "hash_algorithm";
 
-/// Algorithm used to hash tile data in an `MBTiles` file, as recorded in the
-/// [`HASH_ALGORITHM`] metadata key.
+/// tile-hashing algorithm recorded in the [`HASH_ALGORITHM`] metadata key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HashAlgorithm {
-    /// MD5, the algorithm used by `mbtiles`, `martin-cp`, and `tilelive-copy`.
-    ///
-    /// This is the only algorithm this build can currently compute, and the
-    /// default assumed when [`HASH_ALGORITHM`] is not present in the metadata.
+    /// md5 — used by `mbtiles`, `martin-cp`, `tilelive-copy`. the only algorithm this
+    /// build can compute, and the default when [`HASH_ALGORITHM`] is absent.
     #[default]
     Md5,
 }
 
 impl HashAlgorithm {
-    /// Parse a [`HASH_ALGORITHM`] metadata value (case-insensitive).
-    ///
-    /// Returns `None` for an algorithm this build cannot compute.
+    /// parse a [`HASH_ALGORITHM`] value (case-insensitive). `None` if this build can't compute it.
     #[must_use]
     pub fn parse(value: &str) -> Option<Self> {
         match value.to_ascii_lowercase().as_str() {
@@ -260,13 +250,10 @@ impl Mbtiles {
         self.get_metadata_value(&mut *conn, AGG_TILES_HASH).await
     }
 
-    /// Determine the tile-hashing algorithm recorded in the metadata table.
-    ///
-    /// Historically the algorithm was always MD5 and never stored, so a missing
-    /// [`HASH_ALGORITHM`] key is treated as [`HashAlgorithm::Md5`]. An explicit
-    /// but unrecognized value yields [`MbtError::UnsupportedHashAlgorithm`]
-    /// rather than silently comparing hashes computed with a different
-    /// algorithm. See <https://github.com/maplibre/martin/issues/1086>.
+    /// tile-hashing algorithm from the metadata table. a missing [`HASH_ALGORITHM`]
+    /// means [`HashAlgorithm::Md5`] (it was always md5 and never stored); an explicit
+    /// but unknown value gives [`MbtError::UnsupportedHashAlgorithm`] rather than
+    /// silently comparing hashes from a different algorithm (#1086).
     pub async fn get_hash_algorithm<T>(&self, conn: &mut T) -> MbtResult<HashAlgorithm>
     where
         for<'e> &'e mut T: SqliteExecutor<'e>,
@@ -677,9 +664,8 @@ LIMIT 1;"
         let Some(stored) = self.get_agg_tiles_hash(&mut *conn).await? else {
             return Err(AggHashValueNotFound(self.filepath().to_string()));
         };
-        // Make sure the stored hash was produced with an algorithm we can
-        // recompute. Otherwise comparing an md5 against, say, an fnv1a hash
-        // would surface as a confusing `AggHashMismatch`. See issue #1086.
+        // bail if the stored hash used an algorithm we can't recompute — else comparing
+        // md5 against, say, fnv1a shows up as a confusing `AggHashMismatch` (#1086).
         let HashAlgorithm::Md5 = self.get_hash_algorithm(&mut *conn).await?;
         let computed = calc_agg_tiles_hash(&mut *conn).await?;
         if stored != computed {
@@ -1031,8 +1017,7 @@ pub(crate) mod tests {
 
     #[actix_rt::test]
     async fn agg_hash_check_rejects_unsupported_algorithm() {
-        // A file that declares a non-md5 algorithm must fail with a clear
-        // error instead of a confusing agg_tiles_hash mismatch.
+        // declaring a non-md5 algorithm must fail clearly, not as a confusing agg_tiles_hash mismatch.
         let (mbt, mut conn) = anonymous_mbtiles(
             "CREATE TABLE metadata (name text NOT NULL PRIMARY KEY, value text);
              CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -276,7 +276,7 @@ impl Mbtiles {
             Some(value) => {
                 HashAlgorithm::parse(&value).ok_or_else(|| MbtError::UnsupportedHashAlgorithm {
                     algorithm: value,
-                    filepath: self.filepath().to_string(),
+                    filepath: self.filepath().into(),
                 })
             }
         }

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -31,6 +31,43 @@ pub const AGG_TILES_HASH_AFTER_APPLY: &str = "agg_tiles_hash_after_apply";
 /// Metadata key for a diff file, describing the expected [`AGG_TILES_HASH`] value of the tileset to which the diff will be applied.
 pub const AGG_TILES_HASH_BEFORE_APPLY: &str = "agg_tiles_hash_before_apply";
 
+/// Metadata key recording the algorithm used to hash tile data and to compute
+/// the [`AGG_TILES_HASH`] value.
+///
+/// Historically `mbtiles`/`martin-cp` (and `tilelive-copy`) always used MD5 and
+/// never stored the algorithm. Other tools (e.g. `tippecanoe`) use different
+/// algorithms such as `fnv1a`, which previously surfaced as a confusing
+/// [`AGG_TILES_HASH`] mismatch during validation. When this key is absent, MD5
+/// is assumed for backwards compatibility.
+///
+/// See <https://github.com/maplibre/martin/issues/1086>.
+pub const HASH_ALGORITHM: &str = "hash_algorithm";
+
+/// Algorithm used to hash tile data in an `MBTiles` file, as recorded in the
+/// [`HASH_ALGORITHM`] metadata key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HashAlgorithm {
+    /// MD5, the algorithm used by `mbtiles`, `martin-cp`, and `tilelive-copy`.
+    ///
+    /// This is the only algorithm this build can currently compute, and the
+    /// default assumed when [`HASH_ALGORITHM`] is not present in the metadata.
+    #[default]
+    Md5,
+}
+
+impl HashAlgorithm {
+    /// Parse a [`HASH_ALGORITHM`] metadata value (case-insensitive).
+    ///
+    /// Returns `None` for an algorithm this build cannot compute.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "md5" => Some(Self::Md5),
+            _ => None,
+        }
+    }
+}
+
 /// Describes the naming convention used by a normalized `MBTiles` schema.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize)]
 pub enum NormalizedSchema {
@@ -221,6 +258,28 @@ impl Mbtiles {
         for<'e> &'e mut T: SqliteExecutor<'e>,
     {
         self.get_metadata_value(&mut *conn, AGG_TILES_HASH).await
+    }
+
+    /// Determine the tile-hashing algorithm recorded in the metadata table.
+    ///
+    /// Historically the algorithm was always MD5 and never stored, so a missing
+    /// [`HASH_ALGORITHM`] key is treated as [`HashAlgorithm::Md5`]. An explicit
+    /// but unrecognized value yields [`MbtError::UnsupportedHashAlgorithm`]
+    /// rather than silently comparing hashes computed with a different
+    /// algorithm. See <https://github.com/maplibre/martin/issues/1086>.
+    pub async fn get_hash_algorithm<T>(&self, conn: &mut T) -> MbtResult<HashAlgorithm>
+    where
+        for<'e> &'e mut T: SqliteExecutor<'e>,
+    {
+        match self.get_metadata_value(&mut *conn, HASH_ALGORITHM).await? {
+            None => Ok(HashAlgorithm::Md5),
+            Some(value) => {
+                HashAlgorithm::parse(&value).ok_or_else(|| MbtError::UnsupportedHashAlgorithm {
+                    algorithm: value,
+                    filepath: self.filepath().to_string(),
+                })
+            }
+        }
     }
 
     /// Detect tile format and verify that it is consistent across some tiles
@@ -618,6 +677,10 @@ LIMIT 1;"
         let Some(stored) = self.get_agg_tiles_hash(&mut *conn).await? else {
             return Err(AggHashValueNotFound(self.filepath().to_string()));
         };
+        // Make sure the stored hash was produced with an algorithm we can
+        // recompute. Otherwise comparing an md5 against, say, an fnv1a hash
+        // would surface as a confusing `AggHashMismatch`. See issue #1086.
+        let HashAlgorithm::Md5 = self.get_hash_algorithm(&mut *conn).await?;
         let computed = calc_agg_tiles_hash(&mut *conn).await?;
         if stored != computed {
             let file = self.filepath().to_string();
@@ -925,6 +988,64 @@ pub(crate) mod tests {
         let (mbt, mut conn) = anonymous_mbtiles(script).await;
         let result = mbt.check_agg_tiles_hashes(&mut conn).await;
         assert!(matches!(result, Err(AggHashMismatch { .. })));
+    }
+
+    #[actix_rt::test]
+    async fn hash_algorithm_defaults_to_md5_when_absent() {
+        let (mbt, mut conn) = anonymous_mbtiles(
+            "CREATE TABLE metadata (name text NOT NULL PRIMARY KEY, value text);",
+        )
+        .await;
+        assert_eq!(
+            mbt.get_hash_algorithm(&mut conn).await.unwrap(),
+            HashAlgorithm::Md5
+        );
+    }
+
+    #[actix_rt::test]
+    async fn hash_algorithm_reads_md5_case_insensitively() {
+        let (mbt, mut conn) = anonymous_mbtiles(
+            "CREATE TABLE metadata (name text NOT NULL PRIMARY KEY, value text);
+             INSERT INTO metadata VALUES('hash_algorithm', 'MD5');",
+        )
+        .await;
+        assert_eq!(
+            mbt.get_hash_algorithm(&mut conn).await.unwrap(),
+            HashAlgorithm::Md5
+        );
+    }
+
+    #[actix_rt::test]
+    async fn hash_algorithm_rejects_unsupported() {
+        let (mbt, mut conn) = anonymous_mbtiles(
+            "CREATE TABLE metadata (name text NOT NULL PRIMARY KEY, value text);
+             INSERT INTO metadata VALUES('hash_algorithm', 'fnv1a');",
+        )
+        .await;
+        let result = mbt.get_hash_algorithm(&mut conn).await;
+        assert!(
+            matches!(result, Err(MbtError::UnsupportedHashAlgorithm { .. })),
+            "expected UnsupportedHashAlgorithm, got {result:?}"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn agg_hash_check_rejects_unsupported_algorithm() {
+        // A file that declares a non-md5 algorithm must fail with a clear
+        // error instead of a confusing agg_tiles_hash mismatch.
+        let (mbt, mut conn) = anonymous_mbtiles(
+            "CREATE TABLE metadata (name text NOT NULL PRIMARY KEY, value text);
+             CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);
+             INSERT INTO metadata VALUES('agg_tiles_hash', 'DEADBEEF');
+             INSERT INTO metadata VALUES('hash_algorithm', 'fnv1a');
+             INSERT INTO tiles VALUES(0, 0, 0, X'00');",
+        )
+        .await;
+        let result = mbt.check_agg_tiles_hashes(&mut conn).await;
+        assert!(
+            matches!(result, Err(MbtError::UnsupportedHashAlgorithm { .. })),
+            "expected UnsupportedHashAlgorithm, got {result:?}"
+        );
     }
 
     #[actix_rt::test]

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -41,7 +41,7 @@ pub const HASH_ALGORITHM: &str = "hash_algorithm";
 /// tile-hashing algorithm recorded in the [`HASH_ALGORITHM`] metadata key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HashAlgorithm {
-    /// md5 — used by `mbtiles`, `martin-cp`, `tilelive-copy`. the only algorithm this
+    /// md5 - used by `mbtiles`, `martin-cp`, `tilelive-copy`. the only algorithm this
     /// build can compute, and the default when [`HASH_ALGORITHM`] is absent.
     #[default]
     Md5,
@@ -664,7 +664,7 @@ LIMIT 1;"
         let Some(stored) = self.get_agg_tiles_hash(&mut *conn).await? else {
             return Err(AggHashValueNotFound(self.filepath().to_string()));
         };
-        // bail if the stored hash used an algorithm we can't recompute — else comparing
+        // bail if the stored hash used an algorithm we can't recompute - else comparing
         // md5 against, say, fnv1a shows up as a confusing `AggHashMismatch` (#1086).
         let HashAlgorithm::Md5 = self.get_hash_algorithm(&mut *conn).await?;
         let computed = calc_agg_tiles_hash(&mut *conn).await?;


### PR DESCRIPTION
Refs #1086. This is the **read/validation half** of the request (see scope note below).

## What

mbtiles/martin-cp hash tile data with MD5, but other tools (e.g. tippecanoe) use `fnv1a`. Validating such a file recomputed MD5 and reported a misleading `agg_tiles_hash` **mismatch**, giving no hint that the algorithm simply differs.

## How

- Add the `hash_algorithm` metadata key and a `HashAlgorithm` type (currently `Md5`, the only algorithm this build can compute), with case-insensitive parsing.
- `Mbtiles::get_hash_algorithm`: absent key ⇒ `Md5` (backwards compatible), explicit-but-unrecognized value ⇒ a clear new `MbtError::UnsupportedHashAlgorithm` instead of a confusing hash mismatch.
- Wire it into agg-hash validation so an unsupported-algorithm file fails with an actionable message.

## Scope (intentional)

This PR is **purely additive on the read side** — it does not yet *write* `hash_algorithm` on file creation. Doing so changes generated-file output and would churn ~15 integration metadata snapshots (including Postgres-backed `martin-cp` fixtures that need the full Docker/PG stack to regenerate). I kept this slice self-contained and fully unit-tested so it's easy to review; writing the key on creation and adding more algorithms is a natural follow-up. Hence `Refs` rather than `Fixes` — happy to fold in the write-side (with regenerated snapshots) if you'd prefer a single PR.

## Testing

```
cargo test -p mbtiles --lib     # 50 passed (4 new: default-md5, case-insensitive, reject-unsupported, ...)
cargo test -p mbtiles --doc     # 21 passed
cargo clippy -p mbtiles --all-targets -- -D warnings   # clean
```
