### PR TITLE
fix(martin-ui): match metric endpoints when a route_prefix is set

### DIFF
--- a/martin/martin-ui/__tests__/lib/prometheus.test.ts
+++ b/martin/martin-ui/__tests__/lib/prometheus.test.ts
@@ -118,6 +118,40 @@ describe('parsePrometheusMetrics', () => {
       expect(result.group2.averageRequestDurationMs).toBe(0);
       expect(result.group2.requestCount).toBe(0);
     });
+
+    it('matches endpoints carrying a route_prefix', () => {
+      // With `route_prefix = /martin`, actix labels endpoints with the prefix,
+      // but ENDPOINT_GROUPS patterns are unprefixed.
+      const sum = {
+        '/martin/{source_ids}': 2,
+        '/martin/{source_ids}/{z}/{x}/{y}': 10,
+      };
+      const count = {
+        '/martin/{source_ids}': 4,
+        '/martin/{source_ids}/{z}/{x}/{y}': 20,
+      };
+      const endpointGroups = {
+        tiles: ['/{source_ids}/{z}/{x}/{y}', '/{source_ids}'],
+      };
+
+      const result = aggregateEndpointGroups(sum, count, endpointGroups);
+
+      // sum = 10+2 = 12, count = 20+4 = 24, avg = (12/24)*1000 = 500
+      expect(result.tiles.requestCount).toBe(24);
+      expect(result.tiles.averageRequestDurationMs).toBeCloseTo(500);
+    });
+
+    it('does not let a shorter pattern double-count a longer endpoint', () => {
+      // `/{source_ids}` must not also match `/martin/{source_ids}/{z}/{x}/{y}`.
+      const sum = { '/martin/{source_ids}/{z}/{x}/{y}': 10 };
+      const count = { '/martin/{source_ids}/{z}/{x}/{y}': 20 };
+      const endpointGroups = {
+        tiles: ['/{source_ids}/{z}/{x}/{y}', '/{source_ids}'],
+      };
+
+      const result = aggregateEndpointGroups(sum, count, endpointGroups);
+      expect(result.tiles.requestCount).toBe(20);
+    });
   });
 
   describe('parsePrometheusHistogram', () => {
@@ -346,6 +380,25 @@ describe('parsePrometheusMetrics', () => {
         expect(result.sprites).toHaveLength(0);
         expect(result.tiles).toBeDefined();
         expect(result.tiles).toHaveLength(0);
+      });
+
+      it('matches prefixed endpoint labels against unprefixed patterns', () => {
+        const histograms = {
+          '/martin/{source_ids}/{z}/{x}/{y}': [
+            { count: 1000, le: 0.005 },
+            { count: 1200, le: 0.01 },
+          ],
+        };
+
+        const endpointGroups = {
+          tiles: ['/{source_ids}/{z}/{x}/{y}', '/{source_ids}'],
+        };
+
+        const result = aggregateHistogramGroups(histograms, endpointGroups);
+
+        expect(result.tiles).toHaveLength(2);
+        expect(result.tiles[0]).toEqual({ count: 1000, le: 0.005 });
+        expect(result.tiles[1]).toEqual({ count: 1200, le: 0.01 });
       });
 
       it('handles partial histogram data (some endpoints missing)', () => {

--- a/martin/martin-ui/src/lib/prometheus.ts
+++ b/martin/martin-ui/src/lib/prometheus.ts
@@ -41,6 +41,24 @@ export function parsePrometheusMetrics(text: string): {
 }
 
 /**
+ * Finds the metric endpoint labels matching a group's route patterns.
+ *
+ * Labels carry the server's `route_prefix` (e.g. `/martin/{source_ids}/{z}/{x}/{y}`),
+ * while the patterns in `ENDPOINT_GROUPS` are unprefixed.
+ * Matching by suffix keeps the grouping correct regardless of the configured prefix.
+ * Patterns start with `/`, so the suffix always lands on a path-segment boundary.
+ */
+function matchingLabels(labels: Iterable<string>, patterns: readonly string[]): Set<string> {
+  const matched = new Set<string>();
+  for (const label of labels) {
+    if (patterns.some((pattern) => label === pattern || label.endsWith(pattern))) {
+      matched.add(label);
+    }
+  }
+  return matched;
+}
+
+/**
  * Aggregates endpoint metrics into logical groups and computes average duration and request count.
  *
  * @param sum - Record of endpoint to sum of durations
@@ -53,11 +71,12 @@ export function aggregateEndpointGroups(
   count: Record<string, number>,
   endpointGroups: Record<string, readonly string[]>,
 ): Record<string, { averageRequestDurationMs: number; requestCount: number }> {
+  const labels = new Set([...Object.keys(sum), ...Object.keys(count)]);
   const result: Record<string, { averageRequestDurationMs: number; requestCount: number }> = {};
   for (const [group, endpoints] of Object.entries(endpointGroups)) {
     let totalSum = 0;
     let totalCount = 0;
-    for (const endpoint of endpoints) {
+    for (const endpoint of matchingLabels(labels, endpoints)) {
       totalSum += sum[endpoint] || 0;
       totalCount += count[endpoint] || 0;
     }
@@ -142,23 +161,19 @@ export function aggregateHistogramGroups(
 ): Record<string, HistogramBucket[]> {
   const result: Record<string, HistogramBucket[]> = {};
 
+  const labels = Object.keys(histograms);
   for (const [group, endpoints] of Object.entries(endpointGroups)) {
-    for (const endpoint of endpoints) {
-      if (!result[group]) {
-        // due to etags, a multiple statuses are relevant.
-        // because they are not merged in previous steps, we have to do this here
-        // => short-circuiting by setting the result to the histogram would be incorrect
-        result[group] = [];
-      }
-      // Check if histogram data exists for this endpoint
-      if (histograms[endpoint]) {
-        for (const bucket of histograms[endpoint]) {
-          const existingBucket = result[group].find((b) => b.le === bucket.le);
-          if (existingBucket) {
-            existingBucket.count += bucket.count;
-          } else {
-            result[group].push(bucket);
-          }
+    // due to etags, multiple statuses are relevant.
+    // because they are not merged in previous steps, we have to do this here
+    // => short-circuiting by setting the result to the histogram would be incorrect
+    result[group] = [];
+    for (const endpoint of matchingLabels(labels, endpoints)) {
+      for (const bucket of histograms[endpoint]) {
+        const existingBucket = result[group].find((b) => b.le === bucket.le);
+        if (existingBucket) {
+          existingBucket.count += bucket.count;
+        } else {
+          result[group].push(bucket);
         }
       }
     }


### PR DESCRIPTION
Fixes the 0/0 for some metrics.

<img width="1909" height="650" alt="image" src="https://github.com/user-attachments/assets/d942db10-655c-4f2a-abae-3975c752fb55" />
