### PR TITLE
chore: reuse .sql schema files in code

### DIFF
--- a/docs/content/files/init-metadata.sql
+++ b/docs/content/files/init-metadata.sql
@@ -1,0 +1,1 @@
+../../../mbtiles/sql/init-metadata.sql

--- a/docs/content/files/init-normalized-with-hash.sql
+++ b/docs/content/files/init-normalized-with-hash.sql
@@ -1,0 +1,1 @@
+../../../mbtiles/sql/init-normalized-with-hash.sql

--- a/docs/content/mbtiles-schema.md
+++ b/docs/content/mbtiles-schema.md
@@ -9,6 +9,14 @@ tags:
 
 The `mbtiles` tool builds on top of the original [MBTiles specification](https://github.com/mapbox/mbtiles-spec#readme) by specifying three different kinds of schema for `tiles` data: `flat`, `flat-with-hash`, and `normalized`. The `mbtiles` tool can convert between these schemas, and can also generate a diff between two files of any schemas, as well as merge multiple schema files into one file.
 
+## metadata
+
+Every schema includes a shared `metadata` table that stores key/value pairs such as the tileset name, format, and bounds.
+
+```sql
+--8<-- "files/init-metadata.sql"
+```
+
 ## flat
 
 Flat schema is the closest to the original MBTiles specification.
@@ -36,14 +44,14 @@ The `map` table contains a `tile_id` column that is a foreign key to the `images
 The `tile_id` column is a hash of the `tile_data` column, making it possible to both validate each individual tile like in the `flat-with-hash` schema, and also to optimize storage by storing each unique tile only once.
 
 ```sql
---8<-- "files/init-normalized.sql:0:28"
+--8<-- "files/init-normalized.sql"
 ```
 
 Optionally, `.mbtiles` files with `normalized` schema can include a `tiles_with_hash` view.
 All `normalized` files created by the `mbtiles` tool will contain this view.
 
 ```sql
---8<-- "files/init-normalized.sql:30:39"
+--8<-- "files/init-normalized-with-hash.sql"
 ```
 
 ### Alternative normalized schema (dedup-id)

--- a/martin-core/src/resources/fonts/cache.rs
+++ b/martin-core/src/resources/fonts/cache.rs
@@ -41,10 +41,6 @@ impl CacheKey for FontCacheKey {
         crate::metrics::CACHE_REQUESTS_TOTAL
             .with_label_values(&[Self::CACHE_NAME, crate::cache::hit_miss_label(hit)])
             .inc();
-        #[expect(
-            clippy::if_same_then_else,
-            reason = "hotpath::gauge! requires a literal name argument"
-        )]
         if hit {
             hotpath::gauge!("font_cache_hits").inc(1.0);
         } else {

--- a/martin-core/src/resources/sprites/cache.rs
+++ b/martin-core/src/resources/sprites/cache.rs
@@ -47,10 +47,6 @@ impl CacheKey for SpriteCacheKey {
         crate::metrics::CACHE_REQUESTS_TOTAL
             .with_label_values(&[Self::CACHE_NAME, crate::cache::hit_miss_label(hit)])
             .inc();
-        #[expect(
-            clippy::if_same_then_else,
-            reason = "hotpath::gauge! requires a literal name argument"
-        )]
         if hit {
             hotpath::gauge!("sprite_cache_hits").inc(1.0);
         } else {

--- a/martin-core/src/tiles/cache.rs
+++ b/martin-core/src/tiles/cache.rs
@@ -61,10 +61,6 @@ impl CacheKey for TileCacheKey {
                 crate::metrics::ZOOM_LABELS[self.xyz.z as usize],
             ])
             .inc();
-        #[expect(
-            clippy::if_same_then_else,
-            reason = "hotpath::gauge! requires a literal name argument"
-        )]
         if hit {
             hotpath::gauge!("tile_cache_hits").inc(1.0);
         } else {

--- a/mbtiles/sql/init-flat-with-hash.sql
+++ b/mbtiles/sql/init-flat-with-hash.sql
@@ -3,17 +3,10 @@ CREATE TABLE tiles_with_hash (
     tile_column INTEGER NOT NULL,
     tile_row INTEGER NOT NULL,
     tile_data BLOB,
-    tile_hash TEXT
-);
-
-CREATE UNIQUE INDEX tiles_with_hash_index ON tiles_with_hash (
-    zoom_level, tile_column, tile_row
+    tile_hash TEXT,
+    PRIMARY KEY (zoom_level, tile_column, tile_row)
 );
 
 CREATE VIEW tiles AS
-SELECT
-    zoom_level,
-    tile_column,
-    tile_row,
-    tile_data
+SELECT zoom_level, tile_column, tile_row, tile_data
 FROM tiles_with_hash;

--- a/mbtiles/sql/init-flat-with-hash.sql
+++ b/mbtiles/sql/init-flat-with-hash.sql
@@ -8,5 +8,9 @@ CREATE TABLE tiles_with_hash (
 );
 
 CREATE VIEW tiles AS
-SELECT zoom_level, tile_column, tile_row, tile_data
+SELECT
+    zoom_level,
+    tile_column,
+    tile_row,
+    tile_data
 FROM tiles_with_hash;

--- a/mbtiles/sql/init-flat.sql
+++ b/mbtiles/sql/init-flat.sql
@@ -1,10 +1,7 @@
 CREATE TABLE tiles (
-    zoom_level INTEGER,
-    tile_column INTEGER,
-    tile_row INTEGER,
-    tile_data BLOB
-);
-
-CREATE UNIQUE INDEX tile_index ON tiles (
-    zoom_level, tile_column, tile_row
+    zoom_level INTEGER NOT NULL,
+    tile_column INTEGER NOT NULL,
+    tile_row INTEGER NOT NULL,
+    tile_data BLOB,
+    PRIMARY KEY (zoom_level, tile_column, tile_row)
 );

--- a/mbtiles/sql/init-metadata.sql
+++ b/mbtiles/sql/init-metadata.sql
@@ -1,0 +1,4 @@
+CREATE TABLE metadata (
+    name TEXT NOT NULL PRIMARY KEY,
+    value TEXT
+);

--- a/mbtiles/sql/init-normalized-with-hash.sql
+++ b/mbtiles/sql/init-normalized-with-hash.sql
@@ -1,9 +1,9 @@
 CREATE VIEW tiles_with_hash AS
 SELECT
-    map.zoom_level AS zoom_level,
-    map.tile_column AS tile_column,
-    map.tile_row AS tile_row,
-    images.tile_data AS tile_data,
+    map.zoom_level,
+    map.tile_column,
+    map.tile_row,
+    images.tile_data,
     images.tile_id AS tile_hash
 FROM map
-JOIN images ON images.tile_id = map.tile_id;
+INNER JOIN images ON map.tile_id = images.tile_id;

--- a/mbtiles/sql/init-normalized-with-hash.sql
+++ b/mbtiles/sql/init-normalized-with-hash.sql
@@ -1,0 +1,9 @@
+CREATE VIEW tiles_with_hash AS
+SELECT
+    map.zoom_level AS zoom_level,
+    map.tile_column AS tile_column,
+    map.tile_row AS tile_row,
+    images.tile_data AS tile_data,
+    images.tile_id AS tile_hash
+FROM map
+JOIN images ON images.tile_id = map.tile_id;

--- a/mbtiles/sql/init-normalized.sql
+++ b/mbtiles/sql/init-normalized.sql
@@ -13,9 +13,9 @@ CREATE TABLE images (
 
 CREATE VIEW tiles AS
 SELECT
-    map.zoom_level AS zoom_level,
-    map.tile_column AS tile_column,
-    map.tile_row AS tile_row,
-    images.tile_data AS tile_data
+    map.zoom_level,
+    map.tile_column,
+    map.tile_row,
+    images.tile_data
 FROM map
-JOIN images ON images.tile_id = map.tile_id;
+INNER JOIN images ON map.tile_id = images.tile_id;

--- a/mbtiles/sql/init-normalized.sql
+++ b/mbtiles/sql/init-normalized.sql
@@ -1,39 +1,21 @@
 CREATE TABLE map (
-    zoom_level INTEGER,
-    tile_column INTEGER,
-    tile_row INTEGER,
-    tile_id TEXT
+    zoom_level INTEGER NOT NULL,
+    tile_column INTEGER NOT NULL,
+    tile_row INTEGER NOT NULL,
+    tile_id TEXT,
+    PRIMARY KEY (zoom_level, tile_column, tile_row)
 );
 
 CREATE TABLE images (
-    tile_id TEXT,
+    tile_id TEXT NOT NULL PRIMARY KEY,
     tile_data BLOB
-);
-
-CREATE UNIQUE INDEX map_index ON map (
-    zoom_level, tile_column, tile_row
-);
-CREATE UNIQUE INDEX images_id ON images (
-    tile_id
 );
 
 CREATE VIEW tiles AS
 SELECT
-    map.zoom_level,
-    map.tile_column,
-    map.tile_row,
-    images.tile_data
-FROM
-    map INNER JOIN images
-    ON map.tile_id = images.tile_id;
-
-CREATE VIEW tiles_with_hash AS
-SELECT
-    map.zoom_level,
-    map.tile_column,
-    map.tile_row,
-    images.tile_data,
-    images.tile_id AS tile_hash
-FROM
-    map INNER JOIN images
-    ON map.tile_id = images.tile_id;
+    map.zoom_level AS zoom_level,
+    map.tile_column AS tile_column,
+    map.tile_row AS tile_row,
+    images.tile_data AS tile_data
+FROM map
+JOIN images ON images.tile_id = map.tile_id;

--- a/mbtiles/src/queries.rs
+++ b/mbtiles/src/queries.rs
@@ -21,20 +21,38 @@ where
         .is_none())
 }
 
+/// Execute a schema-init `.sql` script, decorating each statement to match the runtime DDL:
+/// every `CREATE TABLE`/`CREATE VIEW` becomes `... IF NOT EXISTS ...` (idempotent; `SQLite` strips
+/// `IF NOT EXISTS` from the stored DDL), and each `CREATE TABLE` gets a ` STRICT` suffix when `strict`.
+///
+/// The scripts live in `mbtiles/sql/` and are the single source of truth shared with the docs. Splitting
+/// on `;` is safe because these files are ours and contain no embedded semicolons.
+pub(crate) async fn create_schema<T>(conn: &mut T, sql: &str, strict: bool) -> MbtResult<()>
+where
+    for<'e> &'e mut T: SqliteExecutor<'e>,
+{
+    for stmt in sql.split(';') {
+        let stmt = stmt.trim();
+        if stmt.is_empty() {
+            continue;
+        }
+        let mut stmt = stmt
+            .replacen("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ", 1)
+            .replacen("CREATE VIEW ", "CREATE VIEW IF NOT EXISTS ", 1);
+        if strict && stmt.to_ascii_uppercase().starts_with("CREATE TABLE") {
+            stmt.push_str(" STRICT");
+        }
+        conn.execute(AssertSqlSafe(stmt)).await?;
+    }
+    Ok(())
+}
+
 pub async fn create_metadata_table<T>(conn: &mut T, strict: bool) -> MbtResult<()>
 where
     for<'e> &'e mut T: SqliteExecutor<'e>,
 {
     debug!("Creating metadata table if it doesn't already exist");
-    let s = if strict { " STRICT" } else { "" };
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS metadata (
-             name text NOT NULL PRIMARY KEY,
-             value text){s};"
-    );
-    conn.execute(AssertSqlSafe(sql)).await?;
-
-    Ok(())
+    create_schema(conn, include_str!("../sql/init-metadata.sql"), strict).await
 }
 
 pub async fn reset_db_settings<T>(conn: &mut T) -> MbtResult<()>

--- a/mbtiles/src/schemas/flat.rs
+++ b/mbtiles/src/schemas/flat.rs
@@ -1,9 +1,10 @@
 //! The `flat` `MBTiles` schema: a single `tiles(zoom_level, tile_column, tile_row, tile_data)` table.
 
-use sqlx::{AssertSqlSafe, Executor as _, SqliteExecutor, query};
+use sqlx::{SqliteExecutor, query};
 use tracing::debug;
 
 use crate::errors::MbtResult;
+use crate::queries::create_schema;
 
 pub async fn is_flat_tables_type<T>(conn: &mut T) -> MbtResult<bool>
 where
@@ -39,18 +40,7 @@ where
     for<'e> &'e mut T: SqliteExecutor<'e>,
 {
     debug!("Creating if needed flat table: tiles(z,x,y,data)");
-    let s = if strict { " STRICT" } else { "" };
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS tiles (
-             zoom_level integer NOT NULL,
-             tile_column integer NOT NULL,
-             tile_row integer NOT NULL,
-             tile_data blob,
-             PRIMARY KEY(zoom_level, tile_column, tile_row)){s};"
-    );
-    conn.execute(AssertSqlSafe(sql)).await?;
-
-    Ok(())
+    create_schema(conn, include_str!("../../sql/init-flat.sql"), strict).await
 }
 
 #[cfg(test)]

--- a/mbtiles/src/schemas/flat_with_hash.rs
+++ b/mbtiles/src/schemas/flat_with_hash.rs
@@ -1,10 +1,11 @@
 //! The `flat-with-hash` `MBTiles` schema: a `tiles_with_hash` table that adds a `tile_hash`
 //! column to the flat schema, plus a `tiles` view for compatibility.
 
-use sqlx::{AssertSqlSafe, Executor as _, SqliteExecutor, query};
+use sqlx::{SqliteExecutor, query};
 use tracing::debug;
 
 use crate::errors::MbtResult;
+use crate::queries::create_schema;
 
 /// Check if `MBTiles` has a table or a view named `tiles_with_hash` with needed fields
 pub async fn has_tiles_with_hash<T>(conn: &mut T) -> MbtResult<bool>
@@ -54,27 +55,15 @@ pub async fn create_flat_with_hash_tables<T>(conn: &mut T, strict: bool) -> MbtR
 where
     for<'e> &'e mut T: SqliteExecutor<'e>,
 {
-    debug!("Creating if needed flat-with-hash table: tiles_with_hash(z,x,y,data,hash)");
-    let s = if strict { " STRICT" } else { "" };
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS tiles_with_hash (
-             zoom_level integer NOT NULL,
-             tile_column integer NOT NULL,
-             tile_row integer NOT NULL,
-             tile_data blob,
-             tile_hash text,
-             PRIMARY KEY(zoom_level, tile_column, tile_row)){s};"
+    debug!(
+        "Creating if needed flat-with-hash table and tiles view: tiles_with_hash(z,x,y,data,hash)"
     );
-    conn.execute(AssertSqlSafe(sql)).await?;
-
-    debug!("Creating if needed tiles view for flat-with-hash");
-    conn.execute(
-        "CREATE VIEW IF NOT EXISTS tiles AS
-             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash;",
+    create_schema(
+        conn,
+        include_str!("../../sql/init-flat-with-hash.sql"),
+        strict,
     )
-    .await?;
-
-    Ok(())
+    .await
 }
 
 #[cfg(test)]

--- a/mbtiles/src/schemas/normalized.rs
+++ b/mbtiles/src/schemas/normalized.rs
@@ -3,10 +3,11 @@
 //! `tiles_with_hash` view exposes the `tile_id` as a hash, and an alternative
 //! `tiles_shallow` + `tiles_data` variant uses an integer `tile_data_id`.
 
-use sqlx::{AssertSqlSafe, Executor as _, Row as _, SqliteExecutor, query};
+use sqlx::{Row as _, SqliteExecutor, query};
 use tracing::debug;
 
 use crate::errors::MbtResult;
+use crate::queries::create_schema;
 
 pub async fn is_normalized_tables_type<T>(conn: &mut T) -> MbtResult<bool>
 where
@@ -107,39 +108,8 @@ pub async fn create_normalized_tables<T>(conn: &mut T, strict: bool) -> MbtResul
 where
     for<'e> &'e mut T: SqliteExecutor<'e>,
 {
-    debug!("Creating if needed normalized table: map(z,x,y,id)");
-    let s = if strict { " STRICT" } else { "" };
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS map (
-             zoom_level integer NOT NULL,
-             tile_column integer NOT NULL,
-             tile_row integer NOT NULL,
-             tile_id text,
-             PRIMARY KEY(zoom_level, tile_column, tile_row)){s};"
-    );
-    conn.execute(AssertSqlSafe(sql)).await?;
-
-    debug!("Creating if needed normalized table: images(id,data)");
-    let sql = format!(
-        "CREATE TABLE IF NOT EXISTS images (
-             tile_id text NOT NULL PRIMARY KEY,
-             tile_data blob){s};"
-    );
-    conn.execute(AssertSqlSafe(sql)).await?;
-
-    debug!("Creating if needed tiles view for normalized map+images structure");
-    conn.execute(
-        "CREATE VIEW IF NOT EXISTS tiles AS
-             SELECT map.zoom_level AS zoom_level,
-                    map.tile_column AS tile_column,
-                    map.tile_row AS tile_row,
-                    images.tile_data AS tile_data
-             FROM map
-             JOIN images ON images.tile_id = map.tile_id;",
-    )
-    .await?;
-
-    Ok(())
+    debug!("Creating if needed normalized tables and tiles view: map(z,x,y,id) + images(id,data)");
+    create_schema(conn, include_str!("../../sql/init-normalized.sql"), strict).await
 }
 
 pub async fn create_tiles_with_hash_view<T>(conn: &mut T) -> MbtResult<()>
@@ -147,20 +117,12 @@ where
     for<'e> &'e mut T: SqliteExecutor<'e>,
 {
     debug!("Creating if needed tiles_with_hash view for normalized map+images structure");
-    conn.execute(
-        "CREATE VIEW IF NOT EXISTS tiles_with_hash AS
-             SELECT
-                 map.zoom_level AS zoom_level,
-                 map.tile_column AS tile_column,
-                 map.tile_row AS tile_row,
-                 images.tile_data AS tile_data,
-                 images.tile_id AS tile_hash
-             FROM map
-             JOIN images ON images.tile_id = map.tile_id",
+    create_schema(
+        conn,
+        include_str!("../../sql/init-normalized-with-hash.sql"),
+        false,
     )
-    .await?;
-
-    Ok(())
+    .await
 }
 
 #[cfg(test)]

--- a/mbtiles/tests/snapshots/copy__convert@v1__bbox__flat.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__bbox__flat.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"012434681F0EBF296906D6608C54D632\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, blob(edit-v1)  )"
     - "(  5, 1, 2, blob()  )"

--- a/mbtiles/tests/snapshots/copy__convert@v1__bbox__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__bbox__hash.snap
@@ -28,5 +28,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__bbox__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__bbox__hash.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"012434681F0EBF296906D6608C54D632\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, blob(edit-v1), \"EFE0AE5FD114DE99855BC2838BE97E1D\"  )"
     - "(  5, 1, 2, blob(), \"D41D8CD98F00B204E9800998ECF8427E\"  )"
@@ -28,5 +28,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__bbox__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__bbox__norm.snap
@@ -39,9 +39,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__bbox__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__bbox__norm.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0F6969D7052DA9261E31DDB6E88C136E\", blob(remove)  )"
     - "(  \"D41D8CD98F00B204E9800998ECF8427E\", blob()  )"
     - "(  \"EFE0AE5FD114DE99855BC2838BE97E1D\", blob(edit-v1)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, \"EFE0AE5FD114DE99855BC2838BE97E1D\"  )"
     - "(  5, 1, 2, \"D41D8CD98F00B204E9800998ECF8427E\"  )"
@@ -19,7 +19,7 @@ expression: actual_value
     - "(  6, 1, 4, \"EFE0AE5FD114DE99855BC2838BE97E1D\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"012434681F0EBF296906D6608C54D632\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -39,9 +39,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__meta__flat.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__meta__flat.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata

--- a/mbtiles/tests/snapshots/copy__convert@v1__meta__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__meta__hash.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata
@@ -24,5 +24,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__meta__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__meta__hash.snap
@@ -24,5 +24,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__meta__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__meta__norm.snap
@@ -32,9 +32,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__meta__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__meta__norm.snap
@@ -4,15 +4,15 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values: []
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -32,9 +32,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__tiles__flat.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__tiles__flat.snap
@@ -4,12 +4,12 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root)  )"
     - "(  5, 0, 0, blob(same)  )"

--- a/mbtiles/tests/snapshots/copy__convert@v1__tiles__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__tiles__hash.snap
@@ -33,5 +33,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__tiles__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__tiles__hash.snap
@@ -4,12 +4,12 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root), \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, blob(same), \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -33,5 +33,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__tiles__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__tiles__norm.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0F6969D7052DA9261E31DDB6E88C136E\", blob(remove)  )"
     - "(  \"51037A4A37730F52C8732586D3AAA316\", blob(same)  )"
@@ -15,7 +15,7 @@ expression: actual_value
     - "(  \"EFE0AE5FD114DE99855BC2838BE97E1D\", blob(edit-v1)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 2, 6, \"535A5575B48444EDEB926815AB26EC9B\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
 - type: index
@@ -48,9 +48,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__tiles__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__tiles__norm.snap
@@ -48,9 +48,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__z6__flat.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__z6__flat.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"675349A4153AEC0679BE9C0637AEEBCC\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  6, 0, 3, blob(same)  )"
     - "(  6, 0, 5, blob(1-keep-1-rm)  )"

--- a/mbtiles/tests/snapshots/copy__convert@v1__z6__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__z6__hash.snap
@@ -28,5 +28,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__z6__hash.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__z6__hash.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"675349A4153AEC0679BE9C0637AEEBCC\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  6, 0, 3, blob(same), \"51037A4A37730F52C8732586D3AAA316\"  )"
     - "(  6, 0, 5, blob(1-keep-1-rm), \"535A5575B48444EDEB926815AB26EC9B\"  )"
@@ -28,5 +28,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__z6__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__z6__norm.snap
@@ -39,9 +39,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__convert@v1__z6__norm.snap
+++ b/mbtiles/tests/snapshots/copy__convert@v1__z6__norm.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"51037A4A37730F52C8732586D3AAA316\", blob(same)  )"
     - "(  \"535A5575B48444EDEB926815AB26EC9B\", blob(1-keep-1-rm)  )"
     - "(  \"EFE0AE5FD114DE99855BC2838BE97E1D\", blob(edit-v1)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  6, 0, 3, \"51037A4A37730F52C8732586D3AAA316\"  )"
     - "(  6, 0, 5, \"535A5575B48444EDEB926815AB26EC9B\"  )"
@@ -19,7 +19,7 @@ expression: actual_value
     - "(  6, 2, 6, \"535A5575B48444EDEB926815AB26EC9B\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"675349A4153AEC0679BE9C0637AEEBCC\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -39,9 +39,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@flat__bdr.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__bdr.snap
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  6, 1, 4, blob(1B1F00F8077163E37063303653B324A12804E8010450E0ED01), 808518166405267028  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"585A88FEEC740448FF1EB4F96088FFE3\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
@@ -22,7 +22,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 2, 2, NULL  )"
     - "(  5, 2, 3, NULL  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__bdz.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__bdz.snap
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  6, 1, 4, blob(1B1F00F8077163E37063303653B324A12804E8010450E0ED01), 808518166405267028  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9AFEC3326B465CB939664C47A572D4C6\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"A18D0C39730FB52E5A547F096F5C60E8\"  )"
@@ -22,7 +22,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 2, 2, NULL  )"
     - "(  5, 2, 3, NULL  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__dif.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__dif.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"B86122579EDCDD4C51F3910894FCC1A1\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
@@ -14,7 +14,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, blob(edit-v2)  )"
     - "(  5, 1, 2, blob(not-empty)  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__dif_empty.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"agg_tiles_hash_before_apply\", \"9ED9178D7025276336C783C2B54D6258\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata

--- a/mbtiles/tests/snapshots/copy__databases@flat__empty-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__empty-no-hash.snap
@@ -4,11 +4,11 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values: []
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata

--- a/mbtiles/tests/snapshots/copy__databases@flat__empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__empty.snap
@@ -4,12 +4,12 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata

--- a/mbtiles/tests/snapshots/copy__databases@flat__v1-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__v1-no-hash.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"md-edit\", \"value - v1\"  )"
     - "(  \"md-remove\", \"value - remove\"  )"
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root)  )"
     - "(  5, 0, 0, blob(same)  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__v1.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__v1.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root)  )"
     - "(  5, 0, 0, blob(same)  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__v1z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__v1z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"C0CA886B149CE416242AB2AFE8E641AD\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000)  )"
     - "(  5, 0, 0, blob(1F8B08000000000000FF2B4ECC4D050044F150FC04000000)  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__v2.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__v2.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root)  )"
     - "(  5, 0, 0, blob(same)  )"

--- a/mbtiles/tests/snapshots/copy__databases@flat__v2z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@flat__v2z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"A18D0C39730FB52E5A547F096F5C60E8\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000)  )"
     - "(  5, 0, 0, blob(1F8B08000000000000FF2B4ECC4D050044F150FC04000000)  )"

--- a/mbtiles/tests/snapshots/copy__databases@hash__bdr.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__bdr.snap
@@ -43,5 +43,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__bdr.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__bdr.snap
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  6, 1, 4, blob(1B1F00F8077163E37063303653B324A12804E8010450E0ED01), 808518166405267028  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"585A88FEEC740448FF1EB4F96088FFE3\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
@@ -22,7 +22,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 2, 2, NULL, \"\"  )"
     - "(  5, 2, 3, NULL, \"\"  )"
@@ -43,5 +43,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__bdz.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__bdz.snap
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  6, 1, 4, blob(1B1F00F8077163E37063303653B324A12804E8010450E0ED01), 808518166405267028  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9AFEC3326B465CB939664C47A572D4C6\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"A18D0C39730FB52E5A547F096F5C60E8\"  )"
@@ -22,7 +22,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 2, 2, NULL, \"\"  )"
     - "(  5, 2, 3, NULL, \"\"  )"
@@ -43,5 +43,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__bdz.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__bdz.snap
@@ -43,5 +43,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__dif.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__dif.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"B86122579EDCDD4C51F3910894FCC1A1\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
@@ -14,7 +14,7 @@ expression: actual_value
     - "(  \"md-remove\", NULL  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, blob(edit-v2), \"FF76830FF90D79BB335884F256031731\"  )"
     - "(  5, 1, 2, blob(not-empty), \"99DEE0E66806ECF1C20C09F64B2C0A34\"  )"
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__dif.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__dif.snap
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"agg_tiles_hash_before_apply\", \"9ED9178D7025276336C783C2B54D6258\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata
@@ -23,5 +23,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__dif_empty.snap
@@ -23,5 +23,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__empty-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__empty-no-hash.snap
@@ -20,5 +20,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__empty-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__empty-no-hash.snap
@@ -4,11 +4,11 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values: []
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata
@@ -20,5 +20,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__empty.snap
@@ -21,5 +21,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__empty.snap
@@ -4,12 +4,12 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: index
   tbl_name: metadata
@@ -21,5 +21,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1-no-hash.snap
@@ -4,14 +4,14 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"md-edit\", \"value - v1\"  )"
     - "(  \"md-remove\", \"value - remove\"  )"
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root), \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, blob(same), \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1-no-hash.snap
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1.snap
@@ -36,5 +36,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root), \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, blob(same), \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -36,5 +36,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"C0CA886B149CE416242AB2AFE8E641AD\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000), \"0A62AF3A2A3D38C0E8FF098A684C3EC1\"  )"
     - "(  5, 0, 0, blob(1F8B08000000000000FF2B4ECC4D050044F150FC04000000), \"98AD49106F1CE0AA003027C229A70F7E\"  )"
@@ -36,5 +36,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v1z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v1z.snap
@@ -36,5 +36,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v2.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v2.snap
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v2.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v2.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root), \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, blob(same), \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v2z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v2z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"A18D0C39730FB52E5A547F096F5C60E8\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -12,7 +12,7 @@ expression: actual_value
     - "(  \"md-same\", \"value - same\"  )"
 - type: table
   tbl_name: tiles_with_hash
-  sql: "CREATE TABLE tiles_with_hash (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             tile_hash text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles_with_hash (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    tile_hash TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000), \"0A62AF3A2A3D38C0E8FF098A684C3EC1\"  )"
     - "(  5, 0, 0, blob(1F8B08000000000000FF2B4ECC4D050044F150FC04000000), \"98AD49106F1CE0AA003027C229A70F7E\"  )"
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@hash__v2z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@hash__v2z.snap
@@ -35,5 +35,5 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT zoom_level, tile_column, tile_row, tile_data\nFROM tiles_with_hash"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    zoom_level,\n    tile_column,\n    tile_row,\n    tile_data\nFROM tiles_with_hash"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__dif.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__dif.snap
@@ -49,9 +49,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__dif.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__dif.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"\", NULL  )"
     - "(  \"03132BFACDB00CC63D6B7DD98D974DD5\", blob(edit-v2a)  )"
@@ -14,7 +14,7 @@ expression: actual_value
     - "(  \"FF76830FF90D79BB335884F256031731\", blob(edit-v2)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  5, 1, 1, \"FF76830FF90D79BB335884F256031731\"  )"
     - "(  5, 1, 2, \"99DEE0E66806ECF1C20C09F64B2C0A34\"  )"
@@ -27,7 +27,7 @@ expression: actual_value
     - "(  6, 2, 6, \"\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"B86122579EDCDD4C51F3910894FCC1A1\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
@@ -49,9 +49,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
@@ -4,15 +4,15 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values: []
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
     - "(  \"agg_tiles_hash_after_apply\", \"9ED9178D7025276336C783C2B54D6258\"  )"
@@ -31,9 +31,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__dif_empty.snap
@@ -31,9 +31,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__empty-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__empty-no-hash.snap
@@ -28,9 +28,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__empty-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__empty-no-hash.snap
@@ -4,15 +4,15 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values: []
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values: []
 - type: index
   tbl_name: images
@@ -28,9 +28,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__empty.snap
@@ -29,9 +29,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__empty.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__empty.snap
@@ -4,15 +4,15 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values: []
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values: []
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"D41D8CD98F00B204E9800998ECF8427E\"  )"
 - type: index
@@ -29,9 +29,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1-no-hash.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0F6969D7052DA9261E31DDB6E88C136E\", blob(remove)  )"
     - "(  \"51037A4A37730F52C8732586D3AAA316\", blob(same)  )"
@@ -15,7 +15,7 @@ expression: actual_value
     - "(  \"EFE0AE5FD114DE99855BC2838BE97E1D\", blob(edit-v1)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 2, 6, \"535A5575B48444EDEB926815AB26EC9B\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"md-edit\", \"value - v1\"  )"
     - "(  \"md-remove\", \"value - remove\"  )"
@@ -50,9 +50,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1-no-hash.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1-no-hash.snap
@@ -50,9 +50,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0F6969D7052DA9261E31DDB6E88C136E\", blob(remove)  )"
     - "(  \"51037A4A37730F52C8732586D3AAA316\", blob(same)  )"
@@ -15,7 +15,7 @@ expression: actual_value
     - "(  \"EFE0AE5FD114DE99855BC2838BE97E1D\", blob(edit-v1)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 2, 6, \"535A5575B48444EDEB926815AB26EC9B\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"9ED9178D7025276336C783C2B54D6258\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1.snap
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0A62AF3A2A3D38C0E8FF098A684C3EC1\", blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000)  )"
     - "(  \"0D9BABF1C0099632D55F6274FB15419F\", blob(1F8B08000000000000FF2B4ACDCD2F4B0500301D806806000000)  )"
@@ -15,7 +15,7 @@ expression: actual_value
     - "(  \"A4D55DDE3B49D78DD9846688A0786F2D\", blob(1F8B08000000000000FF4B4DC92CD12D3304007ED8D6BF07000000)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"0A62AF3A2A3D38C0E8FF098A684C3EC1\"  )"
     - "(  5, 0, 0, \"98AD49106F1CE0AA003027C229A70F7E\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 2, 6, \"3CD93E79D6812F995906036D24282DBE\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"C0CA886B149CE416242AB2AFE8E641AD\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v1z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v1z.snap
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v2.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v2.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"03132BFACDB00CC63D6B7DD98D974DD5\", blob(edit-v2a)  )"
     - "(  \"22AF645D1859CB5CA6DA0C484F1F37EA\", blob(new)  )"
@@ -16,7 +16,7 @@ expression: actual_value
     - "(  \"FF76830FF90D79BB335884F256031731\", blob(edit-v2)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"63A9F0EA7BB98050796B649E85481845\"  )"
     - "(  5, 0, 0, \"51037A4A37730F52C8732586D3AAA316\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 1, 4, \"03132BFACDB00CC63D6B7DD98D974DD5\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"3BCDEE3F52407FF1315629298CB99133\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v2.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v2.snap
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v2z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v2z.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: images
-  sql: "CREATE TABLE images (\n             tile_id text NOT NULL PRIMARY KEY,\n             tile_data blob)"
+  sql: "CREATE TABLE images (\n    tile_id TEXT NOT NULL PRIMARY KEY,\n    tile_data BLOB\n)"
   values:
     - "(  \"0A62AF3A2A3D38C0E8FF098A684C3EC1\", blob(1F8B08000000000000FF2BCACF2F01005BF9F41604000000)  )"
     - "(  \"163BE0A88C70CA629FD516DBAADAD96A\", blob(1F8B08000000000000FF03000000000000000000)  )"
@@ -16,7 +16,7 @@ expression: actual_value
     - "(  \"E1A151E7B18F8B2C53F94DF4CA201026\", blob(1F8B08000000000000FFCB4B2D07004544E36B03000000)  )"
 - type: table
   tbl_name: map
-  sql: "CREATE TABLE map (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_id text,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE map (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_id TEXT,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, \"0A62AF3A2A3D38C0E8FF098A684C3EC1\"  )"
     - "(  5, 0, 0, \"98AD49106F1CE0AA003027C229A70F7E\"  )"
@@ -31,7 +31,7 @@ expression: actual_value
     - "(  6, 1, 4, \"59A99A65DF08F16CE984BDFA6EBC95CF\"  )"
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"agg_tiles_hash\", \"A18D0C39730FB52E5A547F096F5C60E8\"  )"
     - "(  \"md-edit\", \"value - v2\"  )"
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\n             SELECT map.zoom_level AS zoom_level,\n                    map.tile_column AS tile_column,\n                    map.tile_row AS tile_row,\n                    images.tile_data AS tile_data\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\n             SELECT\n                 map.zoom_level AS zoom_level,\n                 map.tile_column AS tile_column,\n                 map.tile_row AS tile_row,\n                 images.tile_data AS tile_data,\n                 images.tile_id AS tile_hash\n             FROM map\n             JOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__databases@norm__v2z.snap
+++ b/mbtiles/tests/snapshots/copy__databases@norm__v2z.snap
@@ -51,9 +51,9 @@ expression: actual_value
   values: ~
 - type: view
   tbl_name: tiles
-  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~
 - type: view
   tbl_name: tiles_with_hash
-  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level AS zoom_level,\n    map.tile_column AS tile_column,\n    map.tile_row AS tile_row,\n    images.tile_data AS tile_data,\n    images.tile_id AS tile_hash\nFROM map\nJOIN images ON images.tile_id = map.tile_id"
+  sql: "CREATE VIEW tiles_with_hash AS\nSELECT\n    map.zoom_level,\n    map.tile_column,\n    map.tile_row,\n    images.tile_data,\n    images.tile_id AS tile_hash\nFROM map\nINNER JOIN images ON map.tile_id = images.tile_id"
   values: ~

--- a/mbtiles/tests/snapshots/copy__update@update.snap
+++ b/mbtiles/tests/snapshots/copy__update@update.snap
@@ -4,7 +4,7 @@ expression: actual_value
 ---
 - type: table
   tbl_name: metadata
-  sql: "CREATE TABLE metadata (\n             name text NOT NULL PRIMARY KEY,\n             value text)"
+  sql: "CREATE TABLE metadata (\n    name TEXT NOT NULL PRIMARY KEY,\n    value TEXT\n)"
   values:
     - "(  \"maxzoom\", \"6\"  )"
     - "(  \"md-edit\", \"value - v1\"  )"
@@ -13,7 +13,7 @@ expression: actual_value
     - "(  \"minzoom\", \"3\"  )"
 - type: table
   tbl_name: tiles
-  sql: "CREATE TABLE tiles (\n             zoom_level integer NOT NULL,\n             tile_column integer NOT NULL,\n             tile_row integer NOT NULL,\n             tile_data blob,\n             PRIMARY KEY(zoom_level, tile_column, tile_row))"
+  sql: "CREATE TABLE tiles (\n    zoom_level INTEGER NOT NULL,\n    tile_column INTEGER NOT NULL,\n    tile_row INTEGER NOT NULL,\n    tile_data BLOB,\n    PRIMARY KEY (zoom_level, tile_column, tile_row)\n)"
   values:
     - "(  3, 6, 7, blob(root)  )"
     - "(  5, 0, 0, blob(same)  )"


### PR DESCRIPTION
Merge #2989 first

* same .sql files are now used in code and in the docs
* metadata schema is now also documented
* there are some spacing differences, thus updating expected test results