### PR TITLE
feat: source-location spans for finalize() validation errors

### DIFF
--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -101,9 +101,12 @@ impl ConfigurationLivecycleHooks for CorsProperties {
 }
 
 impl CorsProperties {
-    pub fn validate(&self) -> ConfigFileResult<()> {
+    pub fn validate(
+        &self,
+        span: Option<Box<crate::config::file::error::ValidationSpan>>,
+    ) -> ConfigFileResult<()> {
         if self.origin.is_empty() {
-            Err(ConfigFileError::CorsNoOriginsConfigured)
+            Err(ConfigFileError::CorsNoOriginsConfigured(span))
         } else {
             Ok(())
         }
@@ -126,10 +129,13 @@ impl CorsConfig {
     }
 
     /// Checks that that if cors is configured explicitly (instead of via `true`/`false`), `origin` is configured
-    pub fn validate(&self) -> MartinResult<()> {
+    pub fn validate(
+        &self,
+        span: Option<Box<crate::config::file::error::ValidationSpan>>,
+    ) -> MartinResult<()> {
         match self {
             Self::SimpleFlag(_) => Ok(()),
-            Self::Properties(properties) => properties.validate().map_err(MartinError::from),
+            Self::Properties(properties) => properties.validate(span).map_err(MartinError::from),
         }
     }
 
@@ -281,7 +287,7 @@ mod tests {
         let default_props = CorsProperties::default();
         assert_eq!(default_props.origin, vec!["*"]);
         assert_eq!(default_props.max_age, None);
-        default_props.validate().unwrap();
+        default_props.validate(None).unwrap();
     }
 
     #[test]
@@ -340,8 +346,8 @@ mod tests {
         if let CorsConfig::Properties(settings) = config {
             // This should fail validation
             assert!(matches!(
-                settings.validate(),
-                Err(ConfigFileError::CorsNoOriginsConfigured)
+                settings.validate(None),
+                Err(ConfigFileError::CorsNoOriginsConfigured(_))
             ));
         } else {
             panic!("Expected Properties variant");
@@ -356,7 +362,7 @@ mod tests {
         let CorsConfig::Properties(settings) = config else {
             panic!("Expected Properties variant");
         };
-        settings.validate().unwrap();
+        settings.validate(None).unwrap();
     }
 
     #[test]
@@ -368,8 +374,8 @@ mod tests {
         };
 
         assert!(matches!(
-            properties.validate(),
-            Err(ConfigFileError::CorsNoOriginsConfigured)
+            properties.validate(None),
+            Err(ConfigFileError::CorsNoOriginsConfigured(_))
         ));
     }
 
@@ -380,7 +386,7 @@ mod tests {
             max_age: Some(3600),
             unrecognized: UnrecognizedValues::default(),
         };
-        properties.validate().unwrap();
+        properties.validate(None).unwrap();
 
         let config = CorsConfig::Properties(properties);
         let middleware = config.make_cors_middleware();
@@ -391,7 +397,7 @@ mod tests {
     fn test_cors_with_wildcard_origin() {
         let properties = CorsProperties::default();
         assert_eq!(properties.origin, vec!["*".to_string()]);
-        properties.validate().unwrap();
+        properties.validate(None).unwrap();
 
         let middleware = CorsConfig::Properties(properties).make_cors_middleware();
         assert!(middleware.is_some());

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -137,14 +137,12 @@ impl ConfigFileError {
                     span: span.clone(),
                 }))
             }
-            Self::BasePathInvalid(_, Some(span)) => {
-                Some(miette::Report::new(ValidationReport {
-                    message: self.to_string(),
-                    code: "martin::config::base_path",
-                    help: "The path must start with '/' and be a valid URI path, e.g. `/tiles` or `/api/v1`.",
-                    span: span.clone(),
-                }))
-            }
+            Self::BasePathInvalid(_, Some(span)) => Some(miette::Report::new(ValidationReport {
+                message: self.to_string(),
+                code: "martin::config::base_path",
+                help: "The path must start with '/' and be a valid URI path, e.g. `/tiles` or `/api/v1`.",
+                span: span.clone(),
+            })),
             _ => None,
         }
     }

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -8,6 +8,14 @@ use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode};
 
 pub type ConfigFileResult<T> = Result<T, ConfigFileError>;
 
+/// Source location info for validation errors that occur after deserialization.
+#[derive(Clone, Debug)]
+pub struct ValidationSpan {
+    pub named_source: NamedSource<String>,
+    pub span: miette::SourceSpan,
+    pub label: &'static str,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigFileError {
     #[error("IO error {0}: {1}")]
@@ -39,7 +47,10 @@ pub enum ConfigFileError {
     InvalidSourceFilePath(String, PathBuf),
 
     #[error("At least one 'origin' must be specified in the 'cors' configuration")]
-    CorsNoOriginsConfigured,
+    CorsNoOriginsConfigured(Option<Box<ValidationSpan>>),
+
+    #[error("Base path must begin with '/' and be a valid URL path, but got '{0}'")]
+    BasePathInvalid(String, Option<Box<ValidationSpan>>),
 
     #[cfg(feature = "styles")]
     #[error("Walk directory error {0}: {1}")]
@@ -82,6 +93,18 @@ pub struct YamlParseDetails {
 }
 
 impl ConfigFileError {
+    /// Construct a `CorsNoOriginsConfigured` error without source location info.
+    #[must_use]
+    pub fn cors_no_origins() -> Self {
+        Self::CorsNoOriginsConfigured(None)
+    }
+
+    /// Construct a `BasePathInvalid` error without source location info.
+    #[must_use]
+    pub fn base_path_invalid(path: String) -> Self {
+        Self::BasePathInvalid(path, None)
+    }
+
     /// Construct a YAML parse error with the originating source text and file path.
     ///
     /// The source text is retained so miette diagnostics can render the offending snippet.
@@ -105,6 +128,22 @@ impl ConfigFileError {
                 );
                 let kind = YamlReportKind::for_error(&details.error);
                 Some(miette::Report::new(YamlParseReport { inner, kind }))
+            }
+            Self::CorsNoOriginsConfigured(Some(span)) => {
+                Some(miette::Report::new(ValidationReport {
+                    message: self.to_string(),
+                    code: "martin::config::cors::no_origins",
+                    help: "Either set `cors: true` (allow all origins) or provide at least one entry in `origin` under the cors block.",
+                    span: span.clone(),
+                }))
+            }
+            Self::BasePathInvalid(_, Some(span)) => {
+                Some(miette::Report::new(ValidationReport {
+                    message: self.to_string(),
+                    code: "martin::config::base_path",
+                    help: "The path must start with '/' and be a valid URI path, e.g. `/tiles` or `/api/v1`.",
+                    span: span.clone(),
+                }))
             }
             _ => None,
         }
@@ -217,6 +256,48 @@ impl Diagnostic for YamlParseReport {
     }
 }
 
+/// Owned wrapper for rendering a validation error (with source span) as a miette diagnostic.
+#[derive(Debug)]
+struct ValidationReport {
+    message: String,
+    code: &'static str,
+    help: &'static str,
+    span: Box<ValidationSpan>,
+}
+
+impl std::fmt::Display for ValidationReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ValidationReport {}
+
+impl Diagnostic for ValidationReport {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(self.code))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(self.help))
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new("https://maplibre.org/martin/config-file/"))
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        Some(&self.span.named_source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(LabeledSpan::new_with_span(
+            Some(self.span.label.to_string()),
+            self.span.span,
+        ))))
+    }
+}
+
 impl Diagnostic for ConfigFileError {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         let code: &'static str = match self {
@@ -229,7 +310,8 @@ impl Diagnostic for ConfigFileError {
             Self::InvalidSourceUrl(..) => "martin::config::invalid_source_url",
             Self::PathNotConvertibleToUrl(_) => "martin::config::path_not_url",
             Self::InvalidSourceFilePath(..) => "martin::config::invalid_source_file_path",
-            Self::CorsNoOriginsConfigured => "martin::config::cors::no_origins",
+            Self::CorsNoOriginsConfigured(_) => "martin::config::cors::no_origins",
+            Self::BasePathInvalid(..) => "martin::config::base_path",
             #[cfg(feature = "styles")]
             Self::DirectoryWalking(..) => "martin::config::styles::walk",
             #[cfg(feature = "postgres")]
@@ -255,8 +337,11 @@ impl Diagnostic for ConfigFileError {
             Self::NoSources => {
                 "Provide tile sources via --connection, environment variables (e.g. DATABASE_URL), or a config file passed with --config."
             }
-            Self::CorsNoOriginsConfigured => {
+            Self::CorsNoOriginsConfigured(_) => {
                 "Either set `cors: true` (allow all origins) or provide at least one entry in `origin` under the cors block."
+            }
+            Self::BasePathInvalid(..) => {
+                "The path must start with '/' and be a valid URI path, e.g. `/tiles` or `/api/v1`."
             }
             Self::YamlParseError { .. } => {
                 "Check the highlighted token in your YAML. The error usually indicates a mismatched type or an unexpected shape."

--- a/martin/src/config/file/main/config.rs
+++ b/martin/src/config/file/main/config.rs
@@ -7,6 +7,7 @@ use martin_core::tiles::BoxedSource;
 use serde::{Deserialize, Serialize};
 use tracing::{error, instrument, warn};
 
+use super::parse::SourceInfo;
 #[cfg(any(
     feature = "pmtiles",
     feature = "mbtiles",
@@ -37,7 +38,6 @@ use crate::config::file::srv::SrvConfig;
 #[cfg(feature = "styles")]
 use crate::config::file::styles::StyleConfig;
 use crate::config::file::{GlobalCacheConfig, UnrecognizedValues};
-use super::parse::SourceInfo;
 #[cfg(feature = "postgres")]
 use crate::config::primitives::OptOneMany;
 #[cfg(feature = "_tiles")]

--- a/martin/src/config/file/main/config.rs
+++ b/martin/src/config/file/main/config.rs
@@ -37,6 +37,7 @@ use crate::config::file::srv::SrvConfig;
 #[cfg(feature = "styles")]
 use crate::config::file::styles::StyleConfig;
 use crate::config::file::{GlobalCacheConfig, UnrecognizedValues};
+use super::parse::SourceInfo;
 #[cfg(feature = "postgres")]
 use crate::config::primitives::OptOneMany;
 #[cfg(feature = "_tiles")]
@@ -176,6 +177,11 @@ pub struct Config {
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
+
+    /// Source text and span information from the YAML file, populated after parsing.
+    /// Used to produce miette diagnostics pointing at the offending value in `finalize()` errors.
+    #[serde(skip)]
+    pub source_info: SourceInfo,
 }
 
 /// Describes the action to take during startup when configuration is found to be invalid

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -18,7 +18,6 @@ use martin_core::tiles::pmtiles::PmtCache;
 use tracing::{info, instrument, warn};
 
 use super::{Config, ServerState, init_aws_lc_tls, parse_base_path};
-use crate::config::file::error::ValidationSpan;
 #[cfg(feature = "_tiles")]
 use super::{ResolutionResult, TileSourceWarning};
 use crate::MartinResult;
@@ -33,6 +32,7 @@ use crate::config::file::FileConfigEnum;
 use crate::config::file::FileConfigSrc;
 #[cfg(any(feature = "_tiles", feature = "sprites", feature = "fonts"))]
 use crate::config::file::cache::{CacheConfig, SubCacheSetting};
+use crate::config::file::error::ValidationSpan;
 #[cfg(feature = "_tiles")]
 use crate::config::file::process::ProcessConfig;
 #[cfg(all(feature = "postgres", feature = "mlt"))]
@@ -117,10 +117,12 @@ impl Config {
             }
         }
         if let Some(cors) = &self.srv.cors {
-            cors.validate(self.make_validation_span(
-                self.source_info.spans.cors_origin,
-                "origin list is empty",
-            ))?;
+            cors.validate(
+                self.make_validation_span(
+                    self.source_info.spans.cors_origin,
+                    "origin list is empty",
+                ),
+            )?;
         }
         #[cfg(feature = "postgres")]
         {

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -18,6 +18,7 @@ use martin_core::tiles::pmtiles::PmtCache;
 use tracing::{info, instrument, warn};
 
 use super::{Config, ServerState, init_aws_lc_tls, parse_base_path};
+use crate::config::file::error::ValidationSpan;
 #[cfg(feature = "_tiles")]
 use super::{ResolutionResult, TileSourceWarning};
 use crate::MartinResult;
@@ -78,16 +79,48 @@ impl Config {
         }
 
         if let Some(path) = &self.srv.route_prefix {
-            let normalized = parse_base_path(path)?;
-            // For route_prefix, an empty normalized path (from "/") means no prefix
-            self.srv.route_prefix = if normalized.is_empty() {
-                None
-            } else {
-                Some(normalized)
-            };
+            match parse_base_path(path) {
+                Ok(normalized) => {
+                    self.srv.route_prefix = if normalized.is_empty() {
+                        None
+                    } else {
+                        Some(normalized)
+                    };
+                }
+                Err(_) => {
+                    return Err(ConfigFileError::BasePathInvalid(
+                        path.clone(),
+                        self.make_validation_span(
+                            self.source_info.spans.route_prefix,
+                            "invalid route_prefix",
+                        ),
+                    )
+                    .into());
+                }
+            }
         }
         if let Some(path) = &self.srv.base_path {
-            self.srv.base_path = Some(parse_base_path(path)?);
+            match parse_base_path(path) {
+                Ok(normalized) => {
+                    self.srv.base_path = Some(normalized);
+                }
+                Err(_) => {
+                    return Err(ConfigFileError::BasePathInvalid(
+                        path.clone(),
+                        self.make_validation_span(
+                            self.source_info.spans.base_path,
+                            "invalid base_path",
+                        ),
+                    )
+                    .into());
+                }
+            }
+        }
+        if let Some(cors) = &self.srv.cors {
+            cors.validate(self.make_validation_span(
+                self.source_info.spans.cors_origin,
+                "origin list is empty",
+            ))?;
         }
         #[cfg(feature = "postgres")]
         {
@@ -187,6 +220,20 @@ impl Config {
         } else {
             Ok(res)
         }
+    }
+
+    fn make_validation_span(
+        &self,
+        span: Option<miette::SourceSpan>,
+        label: &'static str,
+    ) -> Option<Box<ValidationSpan>> {
+        let source_span = span?;
+        let named_source = self.source_info.named_source.as_ref()?.clone();
+        Some(Box::new(ValidationSpan {
+            named_source,
+            span: source_span,
+            label,
+        }))
     }
 
     #[instrument(skip_all, err(Debug))]

--- a/martin/src/config/file/main/parse.rs
+++ b/martin/src/config/file/main/parse.rs
@@ -181,19 +181,19 @@ fn extract_source_info(source_text: &str, file_name: &Path) -> SourceInfo {
     let spans = serde_saphyr::from_str_with_options::<SpanProbe>(source_text, opts)
         .ok()
         .map(|probe| {
-            let route_prefix = probe.route_prefix.as_ref().and_then(|s| {
-                location_to_source_span(&s.referenced, s.referenced.span().len())
-            });
-            let base_path = probe.base_path.as_ref().and_then(|s| {
-                location_to_source_span(&s.referenced, s.referenced.span().len())
-            });
+            let route_prefix = probe
+                .route_prefix
+                .as_ref()
+                .and_then(|s| location_to_source_span(&s.referenced, s.referenced.span().len()));
+            let base_path = probe
+                .base_path
+                .as_ref()
+                .and_then(|s| location_to_source_span(&s.referenced, s.referenced.span().len()));
             let cors_origin = probe
                 .cors
                 .as_ref()
                 .and_then(|c| c.origin.as_ref())
-                .and_then(|s| {
-                    location_to_source_span(&s.referenced, s.referenced.span().len())
-                });
+                .and_then(|s| location_to_source_span(&s.referenced, s.referenced.span().len()));
             ConfigSpans {
                 route_prefix,
                 base_path,
@@ -370,7 +370,9 @@ mod tests {
     use crate::config::file::{CachePolicy, Config, GlobalCacheConfig};
     #[cfg(feature = "postgres")]
     use crate::config::primitives::OptOneMany;
-    use crate::config::test_helpers::{render_failure, render_failure_json, render_finalize_failure};
+    use crate::config::test_helpers::{
+        render_failure, render_failure_json, render_finalize_failure,
+    };
 
     fn parse_yaml(yaml: &str) -> Config {
         parse_config(

--- a/martin/src/config/file/main/parse.rs
+++ b/martin/src/config/file/main/parse.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 
+use miette::NamedSource;
+use serde::Deserialize;
+use serde_saphyr::Spanned;
 use tracing::warn;
 
 use super::Config;
@@ -114,8 +117,95 @@ pub fn parse_config(
     }
     .with_properties(properties.clone());
 
-    serde_saphyr::from_str_with_options::<Config>(&migrated, options)
-        .map_err(|e| ConfigFileError::yaml_parse(e, migrated, file_name))
+    let mut config = serde_saphyr::from_str_with_options::<Config>(&migrated, options)
+        .map_err(|e| ConfigFileError::yaml_parse(e, migrated.clone(), file_name))?;
+
+    config.source_info = extract_source_info(&migrated, file_name);
+    Ok(config)
+}
+
+/// Source text and file path retained after parsing so that `finalize()` errors can render
+/// miette diagnostics pointing at the offending YAML.
+#[derive(Clone, Debug, Default)]
+pub struct SourceInfo {
+    pub named_source: Option<NamedSource<String>>,
+    pub spans: ConfigSpans,
+}
+
+impl PartialEq for SourceInfo {
+    fn eq(&self, _: &Self) -> bool {
+        true // spans are metadata, not semantically meaningful
+    }
+}
+
+/// Byte-offset spans for config fields that are validated after deserialization.
+/// Extracted via a second lightweight saphyr parse of only the fields we need.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ConfigSpans {
+    pub route_prefix: Option<miette::SourceSpan>,
+    pub base_path: Option<miette::SourceSpan>,
+    pub cors_origin: Option<miette::SourceSpan>,
+}
+
+/// Throwaway struct used only to extract `Spanned` locations from the YAML source.
+/// Field names must match the top-level config keys (SrvConfig is flattened).
+#[derive(Deserialize)]
+struct SpanProbe {
+    #[serde(default)]
+    route_prefix: Option<Spanned<serde::de::IgnoredAny>>,
+    #[serde(default)]
+    base_path: Option<Spanned<serde::de::IgnoredAny>>,
+    #[serde(default)]
+    cors: Option<CorsSpanProbe>,
+}
+
+#[derive(Deserialize)]
+struct CorsSpanProbe {
+    #[serde(default)]
+    origin: Option<Spanned<serde::de::IgnoredAny>>,
+}
+
+fn location_to_source_span(loc: &serde_saphyr::Location, len: u64) -> Option<miette::SourceSpan> {
+    let offset = loc.span().byte_offset()?;
+    let byte_len = loc.span().byte_len().unwrap_or(len);
+    Some(miette::SourceSpan::new(
+        miette::SourceOffset::from(offset as usize),
+        byte_len as usize,
+    ))
+}
+
+fn extract_source_info(source_text: &str, file_name: &Path) -> SourceInfo {
+    let named_source = NamedSource::new(file_name.display().to_string(), source_text.to_string());
+
+    let opts = serde_saphyr::options! { with_snippet: false };
+    let spans = serde_saphyr::from_str_with_options::<SpanProbe>(source_text, opts)
+        .ok()
+        .map(|probe| {
+            let route_prefix = probe.route_prefix.as_ref().and_then(|s| {
+                location_to_source_span(&s.referenced, s.referenced.span().len())
+            });
+            let base_path = probe.base_path.as_ref().and_then(|s| {
+                location_to_source_span(&s.referenced, s.referenced.span().len())
+            });
+            let cors_origin = probe
+                .cors
+                .as_ref()
+                .and_then(|c| c.origin.as_ref())
+                .and_then(|s| {
+                    location_to_source_span(&s.referenced, s.referenced.span().len())
+                });
+            ConfigSpans {
+                route_prefix,
+                base_path,
+                cors_origin,
+            }
+        })
+        .unwrap_or_default();
+
+    SourceInfo {
+        named_source: Some(named_source),
+        spans,
+    }
 }
 
 /// Rewrites the legacy single-colon default `${VAR:default}` to serde-saphyr's `${VAR:-default}`,
@@ -280,7 +370,7 @@ mod tests {
     use crate::config::file::{CachePolicy, Config, GlobalCacheConfig};
     #[cfg(feature = "postgres")]
     use crate::config::primitives::OptOneMany;
-    use crate::config::test_helpers::{render_failure, render_failure_json};
+    use crate::config::test_helpers::{render_failure, render_failure_json, render_finalize_failure};
 
     fn parse_yaml(yaml: &str) -> Config {
         parse_config(
@@ -742,5 +832,80 @@ mod tests {
                 "expected no hit in {s:?}"
             );
         }
+    }
+
+    // ----- Finalize validation diagnostics: errors that occur after successful parsing -----
+
+    #[test]
+    fn finalize_base_path_must_start_with_slash() {
+        insta::assert_snapshot!(
+            render_finalize_failure(indoc::indoc! {"
+                pmtiles: /tmp
+                base_path: not-a-path
+            "}),
+            @r"
+        martin::config::base_path (https://maplibre.org/martin/config-file/)
+
+          × Base path must begin with '/' and be a valid URL path, but got 'not-a-
+          │ path'
+           ╭─[config.yaml:2:12]
+         1 │ pmtiles: /tmp
+         2 │ base_path: not-a-path
+           ·            ─────┬────
+           ·                 ╰── invalid base_path
+           ╰────
+          help: The path must start with '/' and be a valid URI path, e.g. `/tiles` or
+                `/api/v1`.
+        "
+        );
+    }
+
+    #[test]
+    fn finalize_route_prefix_must_start_with_slash() {
+        insta::assert_snapshot!(
+            render_finalize_failure(indoc::indoc! {"
+                pmtiles: /tmp
+                route_prefix: oops
+            "}),
+            @r"
+        martin::config::base_path (https://maplibre.org/martin/config-file/)
+
+          × Base path must begin with '/' and be a valid URL path, but got 'oops'
+           ╭─[config.yaml:2:15]
+         1 │ pmtiles: /tmp
+         2 │ route_prefix: oops
+           ·               ──┬─
+           ·                 ╰── invalid route_prefix
+           ╰────
+          help: The path must start with '/' and be a valid URI path, e.g. `/tiles` or
+                `/api/v1`.
+        "
+        );
+    }
+
+    #[test]
+    fn finalize_cors_empty_origin() {
+        insta::assert_snapshot!(
+            render_finalize_failure(indoc::indoc! {"
+                pmtiles: /tmp
+                cors:
+                  origin: []
+                  max_age: 3600
+            "}),
+            @r"
+        martin::config::cors::no_origins (https://maplibre.org/martin/config-file/)
+
+          × At least one 'origin' must be specified in the 'cors' configuration
+           ╭─[config.yaml:3:11]
+         2 │ cors:
+         3 │   origin: []
+           ·           ┬
+           ·           ╰── origin list is empty
+         4 │   max_age: 3600
+           ╰────
+          help: Either set `cors: true` (allow all origins) or provide at least one
+                entry in `origin` under the cors block.
+        "
+        );
     }
 }

--- a/martin/src/config/file/mod.rs
+++ b/martin/src/config/file/mod.rs
@@ -7,7 +7,7 @@ pub mod cache;
 pub mod cors;
 pub mod srv;
 
-mod error;
+pub(crate) mod error;
 pub use error::{ConfigFileError, ConfigFileResult};
 
 pub mod process;

--- a/martin/src/config/test_helpers.rs
+++ b/martin/src/config/test_helpers.rs
@@ -63,6 +63,37 @@ pub(crate) fn render_failure(yaml: &str) -> String {
     buf
 }
 
+/// Parse `yaml` through [`parse_config`], then run [`Config::finalize`] and expect a failure.
+/// Returns the rendered miette diagnostic at a fixed terminal width.
+///
+/// Use for validations that run *after* successful deserialization (e.g. `route_prefix`
+/// must start with `/`, CORS `origin` must be non-empty).
+pub(crate) fn render_finalize_failure(yaml: &str) -> String {
+    let env: HashMap<String, String> = HashMap::new();
+    let mut config = parse_config(yaml, &env, Path::new("config.yaml"))
+        .unwrap_or_else(|e| panic!("expected config to parse successfully:\n{e}"));
+    let err = config
+        .finalize()
+        .err()
+        .unwrap_or_else(|| panic!("expected finalize to fail for:\n{yaml}"));
+    render_martin_error(&err)
+}
+
+fn render_martin_error(err: &MartinError) -> String {
+    if let MartinError::ConfigFileError(cfg_err) = err
+        && let Some(report) = cfg_err.to_miette_report()
+    {
+        let mut buf = String::new();
+        GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor())
+            .with_width(SNAPSHOT_WIDTH)
+            .with_links(false)
+            .render_report(&mut buf, report.as_ref())
+            .expect("rendering into a String is infallible");
+        return buf;
+    }
+    panic!("expected a miette-renderable ConfigFileError, got: {err}");
+}
+
 /// Same as [`render_failure`] but routes through `MartinError::render_diagnostic_with` in
 /// JSON mode, mirroring what the binary emits when `RUST_LOG_FORMAT=json` is set.
 ///

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -223,7 +223,7 @@ pub fn new_server(
         .unwrap_or_else(|| DEFAULT_LISTEN_ADDRESSES.to_string());
 
     let cors_config = config.cors.clone().unwrap_or_default();
-    cors_config.validate()?;
+    cors_config.validate(None)?;
     cors_config.log_current_configuration();
 
     let factory = move || {


### PR DESCRIPTION
Makes sure that more of the validation errors that occur *after* YAML parsing (during `Config::finalize()`) include source location info, so miette renders a snippet pointing at the offending value in the config file:

```
martin::config::base_path

  × Base path must begin with '/' and be a valid URL path, but got 'not-a-path'
   ╭─[config.yaml:2:12]
 1 │ pmtiles: /tmp
 2 │ base_path: not-a-path
   ·            ─────┬────
   ·                 ╰── invalid base_path
   ╰────
  help: The path must start with '/' and be a valid URI path, e.g. `/tiles` or `/api/v1`.
```
