### PR TITLE
fix(martin-ui): center tile inspect map on tileset bounds, not 0/0/0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { toolchain: nightly, tools: 'cargo-shear,just', rendering: true }
+        with: { toolchain: nightly-2026-07-12, tools: 'cargo-shear,just', rendering: true }
       - run: just shear
   build-aarch64-unknown-linux-musl:
     uses: ./.github/workflows/build-binary.yml

--- a/martin/martin-ui/__tests__/components/dialogs/tile-inspect-map.test.tsx
+++ b/martin/martin-ui/__tests__/components/dialogs/tile-inspect-map.test.tsx
@@ -1,0 +1,189 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TileInspectDialogMap } from '@/components/dialogs/tile-inspect-map';
+import { martinClient } from '@/lib/martin-client';
+import type { Catalog } from '@/lib/types.gen';
+
+// A single mock MapLibre instance whose methods we assert against. Hoisted so
+// the vi.mock factory below (also hoisted) can reference it.
+const { mapSpies } = vi.hoisted(() => ({
+  mapSpies: {
+    addControl: vi.fn(),
+    addLayer: vi.fn(),
+    addSource: vi.fn(),
+    fitBounds: vi.fn(),
+    getLayer: vi.fn(),
+    getSource: vi.fn(),
+    getStyle: vi.fn(),
+    isStyleLoaded: vi.fn(),
+    jumpTo: vi.fn(),
+    on: vi.fn(),
+    removeControl: vi.fn(),
+    removeLayer: vi.fn(),
+    removeSource: vi.fn(),
+    setCenter: vi.fn(),
+    setMaxBounds: vi.fn(),
+    setMaxZoom: vi.fn(),
+    setMinZoom: vi.fn(),
+  },
+}));
+
+// Override the global @vis.gl/react-maplibre mock with one that exposes a ref
+// (getMap) and fires onLoad on mount, so configureMap() actually runs.
+vi.mock('@vis.gl/react-maplibre', () => {
+  const React = require('react');
+  return {
+    Layer: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'maplibre-layer' }, children),
+    Map: React.forwardRef(
+      (
+        { children, onLoad }: { children?: React.ReactNode; onLoad?: () => void },
+        ref: React.Ref<unknown>,
+      ) => {
+        React.useImperativeHandle(ref, () => ({ getMap: () => mapSpies }));
+        React.useEffect(() => {
+          onLoad?.();
+        }, []);
+        return React.createElement('div', { 'data-testid': 'maplibre-map' }, children);
+      },
+    ),
+    Source: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'maplibre-source' }, children),
+  };
+});
+
+// The component does `new Popup(...)` / `new MaplibreInspect(...)` inside the
+// onLoad path. The global setup mocks these as arrow functions, which are not
+// constructable; provide constructable stubs for this file.
+vi.mock('maplibre-gl', () => ({
+  Popup: class {
+    addTo() {
+      return this;
+    }
+    remove() {
+      return this;
+    }
+    setHTML() {
+      return this;
+    }
+    setLngLat() {
+      return this;
+    }
+  },
+}));
+
+vi.mock('@maplibre/maplibre-gl-inspect', () => ({
+  default: class {
+    onAdd() {
+      return document.createElement('div');
+    }
+    onRemove() {}
+  },
+}));
+
+// Feed a controllable TileJSON through the martin client.
+vi.mock('@/lib/martin-client', () => ({
+  martinClient: { GET: vi.fn() },
+}));
+
+// Keep the underlay out of the way; findProvider(undefined) short-circuits.
+vi.mock('@/hooks/use-underlay-preference', () => ({
+  useUnderlayPreference: () => [undefined, vi.fn()],
+}));
+
+const mockedGet = vi.mocked(martinClient.GET);
+
+const setTileJson = (tileJson: unknown) => {
+  mockedGet.mockResolvedValue({
+    data: tileJson,
+    response: { statusText: 'OK' } as Response,
+    // openapi-fetch returns extra fields we don't use in this component.
+  } as never);
+};
+
+const source: Catalog['tiles'][string] = {
+  attribution: '',
+  content_encoding: 'gzip',
+  content_type: 'application/x-protobuf',
+  description: '',
+  layer_count: 1,
+  name: 'workshop',
+} as Catalog['tiles'][string];
+
+describe('TileInspectDialogMap initial view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mapSpies.getStyle.mockReturnValue({ layers: [] });
+    mapSpies.getSource.mockReturnValue(undefined);
+    mapSpies.getLayer.mockReturnValue(undefined);
+    mapSpies.isStyleLoaded.mockReturnValue(true);
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('fits the map to the tileset bounds and honors a zero minzoom', async () => {
+    setTileJson({
+      bounds: [-89.85918, 42.71594, -88.69675, 43.37933],
+      center: [-89.27797, 43.04763, 9],
+      maxzoom: 14,
+      minzoom: 0,
+    });
+
+    render(<TileInspectDialogMap name="workshop" source={source} />);
+
+    await waitFor(() => expect(mapSpies.fitBounds).toHaveBeenCalled());
+
+    // Regression: a falsy-zero minzoom used to be skipped entirely.
+    expect(mapSpies.setMinZoom).toHaveBeenCalledWith(0);
+    expect(mapSpies.setMaxZoom).toHaveBeenCalledWith(14);
+    expect(mapSpies.setMaxBounds).toHaveBeenCalledWith([
+      [-89.85918, 42.71594],
+      [-88.69675, 43.37933],
+    ]);
+    expect(mapSpies.fitBounds).toHaveBeenCalledWith(
+      [
+        [-89.85918, 42.71594],
+        [-88.69675, 43.37933],
+      ],
+      expect.objectContaining({ animate: false }),
+    );
+  });
+
+  it('jumps to center (with its zoom) for a world-extent tileset', async () => {
+    setTileJson({
+      bounds: [-180, -85, 180, 85],
+      center: [10, 20, 4],
+      maxzoom: 6,
+      minzoom: 0,
+    });
+
+    render(<TileInspectDialogMap name="workshop" source={source} />);
+
+    await waitFor(() => expect(mapSpies.jumpTo).toHaveBeenCalled());
+
+    // World extent: no maxBounds clamp, and center[2] drives the zoom.
+    expect(mapSpies.setMaxBounds).not.toHaveBeenCalled();
+    expect(mapSpies.fitBounds).not.toHaveBeenCalled();
+    expect(mapSpies.jumpTo).toHaveBeenCalledWith({ center: [10, 20], zoom: 4 });
+  });
+
+  it('respects an explicit #map deep link and does not reposition', async () => {
+    window.location.hash = '#map=12/43.07/-89.4';
+    setTileJson({
+      bounds: [-89.85918, 42.71594, -88.69675, 43.37933],
+      center: [-89.27797, 43.04763, 9],
+      maxzoom: 14,
+      minzoom: 0,
+    });
+
+    render(<TileInspectDialogMap name="workshop" source={source} />);
+
+    // Constraints still apply, but the view is left to the URL hash.
+    await waitFor(() => expect(mapSpies.setMinZoom).toHaveBeenCalledWith(0));
+    expect(mapSpies.fitBounds).not.toHaveBeenCalled();
+    expect(mapSpies.jumpTo).not.toHaveBeenCalled();
+  });
+});

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -121,6 +121,17 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
     }
   }, [selectedUnderlay]);
 
+  // The map's onLoad can fire before the TileJSON fetch resolves, in which case
+  // configureMap() early-returns and the view/constraints are never applied.
+  // Re-run it once the TileJSON arrives (and the map has loaded) so the inspect
+  // map opens centered on the tileset instead of the default 0/0/0 world view.
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+    if (map?.isStyleLoaded() && tileJsonOperation.data) {
+      configureMap();
+    }
+  }, [tileJsonOperation.data]);
+
   const configureMap = () => {
     if (!mapRef.current) {
       console.error('Map not found despite being initialized, this cannot happen');
@@ -136,9 +147,11 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
       return;
     }
     const tileJson: TileJson = tileJsonOperation.data;
+
+    let isWorld = false;
     if (tileJson.bounds) {
       const [west, south, east, north] = tileJson.bounds;
-      const isWorld = west <= -179 && east >= 179;
+      isWorld = west <= -179 && east >= 179;
       if (!isWorld) {
         map.setMaxBounds([
           [west, south],
@@ -146,15 +159,39 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
         ]);
       }
     }
-    if (tileJson.minzoom) {
+    // Use `!== undefined` rather than a truthy check: a valid minzoom/maxzoom
+    // of 0 is falsy, so `if (tileJson.minzoom)` would silently skip world-min
+    // tilesets (e.g. OpenMapTiles, minzoom 0).
+    if (tileJson.minzoom !== undefined) {
       map.setMinZoom(tileJson.minzoom);
-      map.setZoom(tileJson.minzoom);
     }
-    if (tileJson.maxzoom) {
+    if (tileJson.maxzoom !== undefined) {
       map.setMaxZoom(tileJson.maxzoom);
     }
-    if (tileJson.center) {
-      map.setCenter([tileJson.center[0], tileJson.center[1]]);
+
+    // Apply the initial view from the TileJSON, unless the URL already pins one
+    // (a shared deep link such as #map=9/43.1/-89.2). The `hash="map"` prop
+    // writes a default "#map=0/0/0" on first render, which we treat as "unset".
+    const hash = window.location.hash;
+    const hasExplicitView = hash.startsWith('#map=') && hash !== '#map=0/0/0';
+    if (!hasExplicitView) {
+      if (tileJson.bounds && !isWorld) {
+        // Derive both center and zoom from the data extent. This also sidesteps
+        // the previous bug where center[2] (the recommended zoom) was dropped.
+        const [west, south, east, north] = tileJson.bounds;
+        map.fitBounds(
+          [
+            [west, south],
+            [east, north],
+          ],
+          { animate: false, padding: 20 },
+        );
+      } else if (tileJson.center) {
+        map.jumpTo({
+          center: [tileJson.center[0], tileJson.center[1]],
+          zoom: tileJson.center[2] ?? tileJson.minzoom ?? 0,
+        });
+      }
     }
   };
 


### PR DESCRIPTION
- Fixes #3001.

The tile inspect map ignored the TileJSON `center`/`bounds` and always opened at `#map=0/0/0`. As detailed in the issue, three things combined to cause this: `configureMap()` ran only from the map `onLoad` handler and lost the race against the TileJSON fetch, `if (tileJson.minzoom)` skipped a valid `minzoom` of 0, and `setCenter` dropped `center[2]`.

Changes:

* Re-apply the view once the TileJSON arrives, via a `useEffect` keyed on the fetched data, so it no longer depends on which of the fetch or the map load wins.
* Use `!== undefined` checks for `minzoom`/`maxzoom`.
* Derive center and zoom from the extent with `fitBounds`, falling back to `jumpTo` with `center` (including `center[2]`) for world-extent sets.
* Respect an explicit `#map=z/lat/lng` deep link, treating the default `#map=0/0/0` as unset.

Added unit tests for the three cases (bounds fit with zero minzoom, world-extent jumpTo, deep-link respected).

One note: the shared mocks in `vitest.setup.tsx` stub `Popup` and `MaplibreInspect` as arrow functions, which are not constructable, so no existing test exercised the `onLoad` path; the new test file provides constructable stubs locally, and fixing the shared mocks could be a good follow-up.
