### PR TITLE
fix(ci): pin maplibre_native to 0.8.3 (0.8.4 deadlocks headless rendering, hangs CI 6h)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,9 +4691,9 @@ dependencies = [
 
 [[package]]
 name = "maplibre_native"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe6b3a0924076ea2e6d52fb9239fd0f55efe50825f18c96c2c851a198ea4a3c"
+checksum = "7f254585f671f8bbad7dbaf711f03325922d2040fc4e7ad12ea92946e354206f"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,11 @@ itertools = "0.15"
 json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
-maplibre_native = "0.8.3"
+# Pinned: 0.8.4 deadlocks server-side style rendering on headless Linux (software
+# Vulkan/lavapipe) - the map render future never resolves and the HTTP request hangs
+# until the 6h CI ceiling. Backtrace: map thread's libuv run loop waits forever while a
+# libvulkan_lvp worker is parked on a condvar. Unpin once maplibre-native fixes this.
+maplibre_native = "=0.8.3"
 martin-core = { path = "./martin-core", version = "0.9.0", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.5" }
 mbtiles = { path = "./mbtiles", version = "0.18.1" }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -61,7 +61,10 @@ if [[ -z "${CURL_BIN:-}" ]]; then
   echo 'On macOS, install it with: brew install curl'
   exit 1
 fi
-CURL="${CURL:-$CURL_BIN --silent --show-error --fail --compressed}"
+# --connect-timeout keeps the wait_for retry loop snappy when the server is not up yet;
+# --max-time caps a wedged response so a single hung request fails the job in minutes
+# instead of running into the 6h CI ceiling (see the maplibre-native render-deadlock).
+CURL="${CURL:-$CURL_BIN --silent --show-error --fail --compressed --connect-timeout 10 --max-time 120}"
 
 function wait_for {
     # Seems the --retry-all-errors option is not available on older curl versions, but maybe in the future we can just use this:


### PR DESCRIPTION
## Summary

Every `main` (release) CI run since #2961 has hung for **6 hours** at
`Testing metrics_1` and been force-cancelled. The metrics endpoint is a red
herring — that's just the last line `tests/test.sh` echoes before a **silent
style-render probe**. The real wedge is the first server-side render request
(`GET /style/maplibre/0/0/0.png`), and it's caused by **`maplibre_native` 0.8.3 → 0.8.4**,
which was pulled in by the #2961 lock-file maintenance bump.

## Root cause (backtrace-confirmed)

On the headless CI runner maplibre renders via software Vulkan (lavapipe). Under
0.8.4 the render **deadlocks** — all threads at 0% CPU blocked on futexes:

- `render-tile-0` sits forever in maplibre's libuv run loop (`uv_run` → `epoll_pwait`, `timeout=-1`)
- a `libvulkan_lvp.so` render worker is parked on a `pthread_cond_wait` that never fires
- maplibre `Worker`/`AssetFileSource` scheduler threads idle on condvars

So the render future never resolves → the HTTP response never completes → `curl`
(which had **no timeout**) blocks until the 6h job ceiling.

Why only `main`: release builds ship/exercise this path; PR (debug) builds happened to render fine.

## Fix

- **Pin `maplibre_native = "=0.8.3"`** until upstream fixes 0.8.4. Verified green on CI:
  with 0.8.3 the render probe returns `rc=0` and "Style rendering smoke tests passed (PNG + JPEG)".
- **Add `--connect-timeout 10 --max-time 120` to `$CURL`** so a future wedged request fails
  the job in minutes instead of 6h (defense-in-depth; the missing timeout is what turned a
  render bug into a week of red `main`).

## Evidence

- `metrics_1.txt` came back with 37 KB of valid content → metrics passed.
- Bisected the hang to the #2961 `Cargo.lock`-only commit; 0.8.4 was the only rendering-relevant bump.
- A parallel CI run with `maplibre_native` pinned to 0.8.3 passed the full suite.

A follow-up upstream issue should be filed against maplibre-native for the 0.8.4 headless-Vulkan render deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)