### PR TITLE
refactor: make UnrecognizedValues a newtype

### DIFF
--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -472,6 +472,7 @@ mod tests {
         pmtiles: "../tests/fixtures/"
         mbtiles: "../tests/fixtures/"
         cog: "../tests/fixtures/"
+        geojson: "../tests/fixtures/"
         "#);
     }
 

--- a/martin/src/config/file/collect_unrecognized.rs
+++ b/martin/src/config/file/collect_unrecognized.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use std::collections::hash_map::IntoIter as HashMapIntoIter;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration keys that were present in a config section but not recognized by any known field.
+///
+/// Populated by `#[serde(flatten)]` capture on config structs and surfaced to the user as
+/// warnings during finalization.
+/// A newtype (rather than a bare `HashMap`) so it can carry its own `CollectUnrecognizedKeys`
+/// behavior without overlapping the generic map impl.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct UnrecognizedValues(HashMap<String, serde_json::Value>);
+
+impl UnrecognizedValues {
+    /// Iterates over the unrecognized keys.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.0.keys()
+    }
+
+    /// Returns `true` if the given key was captured as unrecognized.
+    pub fn contains_key(&self, key: impl AsRef<str>) -> bool {
+        self.0.contains_key(key.as_ref())
+    }
+
+    /// Inserts an unrecognized key/value, returning the previous value if the key was present.
+    pub fn insert(
+        &mut self,
+        key: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        self.0.insert(key.into(), value)
+    }
+
+    /// Removes and returns the value for the given key, if present.
+    pub fn remove(&mut self, key: impl AsRef<str>) -> Option<serde_json::Value> {
+        self.0.remove(key.as_ref())
+    }
+}
+
+impl From<HashMap<String, serde_json::Value>> for UnrecognizedValues {
+    fn from(values: HashMap<String, serde_json::Value>) -> Self {
+        Self(values)
+    }
+}
+
+impl<K: Into<String>> FromIterator<(K, serde_json::Value)> for UnrecognizedValues {
+    fn from_iter<I: IntoIterator<Item = (K, serde_json::Value)>>(iter: I) -> Self {
+        Self(iter.into_iter().map(|(k, v)| (k.into(), v)).collect())
+    }
+}
+
+impl IntoIterator for UnrecognizedValues {
+    type Item = (String, serde_json::Value);
+    type IntoIter = HashMapIntoIter<String, serde_json::Value>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/martin/src/config/file/collect_unrecognized.rs
+++ b/martin/src/config/file/collect_unrecognized.rs
@@ -4,11 +4,6 @@ use std::collections::hash_map::IntoIter as HashMapIntoIter;
 use serde::{Deserialize, Serialize};
 
 /// Configuration keys that were present in a config section but not recognized by any known field.
-///
-/// Populated by `#[serde(flatten)]` capture on config structs and surfaced to the user as
-/// warnings during finalization.
-/// A newtype (rather than a bare `HashMap`) so it can carry its own `CollectUnrecognizedKeys`
-/// behavior without overlapping the generic map impl.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -18,7 +18,7 @@ use tracing::{info, warn};
 #[cfg(feature = "_tiles")]
 use url::Url;
 
-use crate::config::file::{ConfigFileError, ConfigFileResult};
+use crate::config::file::{ConfigFileError, ConfigFileResult, UnrecognizedValues};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
 #[cfg(feature = "_tiles")]
@@ -1138,7 +1138,6 @@ impl<'de> Deserialize<'de> for CacheSizeConfig {
     }
 }
 
-pub type UnrecognizedValues = HashMap<String, serde_json::Value>;
 pub type UnrecognizedKeys = HashSet<String>;
 
 pub fn copy_unrecognized_keys_from_config(

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::mem;

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
+#[cfg(feature = "_tiles")]
+use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::mem;

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, HashSet};
 #[cfg(feature = "_tiles")]
 use std::collections::HashMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::mem;

--- a/martin/src/config/file/mod.rs
+++ b/martin/src/config/file/mod.rs
@@ -1,6 +1,9 @@
 mod file_config;
 pub use file_config::*;
 
+mod collect_unrecognized;
+pub use collect_unrecognized::*;
+
 mod main;
 pub use main::*;
 pub mod cache;

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -197,7 +197,9 @@ sources:
                         ),
                         tables: None,
                         macros: None,
-                        unrecognized: {},
+                        unrecognized: UnrecognizedValues(
+                            {},
+                        ),
                     },
                 ),
                 GeoParquet(
@@ -232,11 +234,15 @@ sources:
                             memory_limit_mb: None,
                             auto_bounds: None,
                         },
-                        unrecognized: {},
+                        unrecognized: UnrecognizedValues(
+                            {},
+                        ),
                     },
                 ),
             ],
-            unrecognized: {},
+            unrecognized: UnrecognizedValues(
+                {},
+            ),
         }
         "#);
     }
@@ -294,11 +300,15 @@ sources:
                                 Skip,
                             ),
                         },
-                        unrecognized: {},
+                        unrecognized: UnrecognizedValues(
+                            {},
+                        ),
                     },
                 ),
             ],
-            unrecognized: {},
+            unrecognized: UnrecognizedValues(
+                {},
+            ),
         }
         "#);
     }
@@ -331,13 +341,17 @@ sources:
                         auto_publish: None,
                         tables: None,
                         macros: None,
-                        unrecognized: {
-                            "geoparquet": String("/data/buildings.parquet"),
-                        },
+                        unrecognized: UnrecognizedValues(
+                            {
+                                "geoparquet": String("/data/buildings.parquet"),
+                            },
+                        ),
                     },
                 ),
             ],
-            unrecognized: {},
+            unrecognized: UnrecognizedValues(
+                {},
+            ),
         }
         "#);
     }

--- a/tests/expected/process/proc_mlt_table_source.mlt.dump.txt
+++ b/tests/expected/process/proc_mlt_table_source.mlt.dump.txt
@@ -73,9 +73,7 @@ Tag01(
                 U32(
                     RawScalar {
                         name: "gid",
-                        presence: RawPresence(
-                            None,
-                        ),
+                        presence: AllPresent,
                         data: RawStream {
                             meta: StreamMeta {
                                 stream_type: Data(None),


### PR DESCRIPTION
Replaces the bare `HashMap` alias for `UnrecognizedValues` with a newtype so it can carry its own unrecognized-key collection behavior in the follow-up PR.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>