### PR TITLE
docs: sync pmtiles object_store keys with 0.14.1

### DIFF
--- a/docs/snippets/pmtiles/aws.md
+++ b/docs/snippets/pmtiles/aws.md
@@ -38,8 +38,8 @@
 
 | configuration             | description                                                                                                         | example                                                      |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `checksum`                | Checksum algorithm for uploads                                                                                      | `SHA256`                                                     |
-| `server_side_encryption`  | Type of server-side encryption:<br>`AES256` (SSE-S3)<br>`aws:kms` (SSE-KMS)<br>`aws:kms:dsse` (DSSE-KMS)<br>`sse-c` | `AES256`                                                     |
-| `kms_key_id`              | KMS Key ID for SSE-KMS or DSSE-KMS                                                                                  | `arn:aws:kms:us-east-1:123456789012:key/abcd-1234-efgh-5678` |
-| `bucket_key_enabled`      | Use bucket's default KMS key (`true`/`false`)                                                                       | `true`                                                       |
-| `customer_encryption_key` | Base64-encoded 256-bit key for SSE-C                                                                                | `MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=`               |
+| `checksum_algorithm`       | Checksum algorithm for uploads                                                                                     | `SHA256`                                                     |
+| `server_side_encryption`   | Type of server-side encryption:<br>`AES256` (SSE-S3)<br>`aws:kms` (SSE-KMS)<br>`aws:kms:dsse` (DSSE-KMS)<br>`sse-c` | `AES256`                                                     |
+| `sse_kms_key_id`           | KMS Key ID for SSE-KMS or DSSE-KMS                                                                                 | `arn:aws:kms:us-east-1:123456789012:key/abcd-1234-efgh-5678` |
+| `sse_bucket_key_enabled`   | Use bucket's default KMS key (`true`/`false`)                                                                      | `true`                                                       |
+| `sse_customer_key_base64`  | Base64-encoded 256-bit key for SSE-C                                                                               | `MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=`               |

--- a/docs/snippets/pmtiles/client.md
+++ b/docs/snippets/pmtiles/client.md
@@ -13,6 +13,7 @@
 | `user_agent`                  | User-Agent header to be used by this client                                                                        | `martin 1.0.0` |
 | `randomize_addresses`         | Randomize order addresses that the DNS resolution yields.<br>This will spread the connections across more servers. | `true`         |
 | `connect_timeout`             | Timeout for only the connect phase of a Client                                                                     | `5s`           |
+| `read_timeout`                | Timeout for each read operation, reset after every successful read.<br>Useful for detecting stalled connections when the response size is unknown.<br>Disabled by default; timeout errors are retried | `30s`          |
 | `timeout`                     | The timeout is applied from when the request starts connecting until the response body has finished                | `10s`          |
 | `pool_idle_timeout`           | The pool max idle timeout                                                                                          | `5m`           |
 | `pool_max_idle_per_host`      | maximum number of idle connections per host                                                                        | `10`           |


### PR DESCRIPTION
The `object_store` bump to 0.14.1 (#3028 and prior) left the `docs/snippets/pmtiles/` reference tables out of date.

## Changes

- **`client.md`**: add the new `read_timeout` connection option exposed in object_store 0.14.1 ([arrow-rs-object-store #681](https://github.com/apache/arrow-rs-object-store/pull/681)).
- **`aws.md`**: fix four AWS encryption/integrity key names that object_store actually rejects. Martin forwards these keys straight to `AmazonS3ConfigKey::from_str`, whose match arms only accept:
  - `checksum_algorithm` (was documented as `checksum`)
  - `sse_kms_key_id` (was `kms_key_id`)
  - `sse_bucket_key_enabled` (was `bucket_key_enabled`)
  - `sse_customer_key_base64` (was `customer_encryption_key`)

I cross-checked every key in `aws.md`, `azure.md`, `google.md`, and `client.md` against the current `AmazonS3ConfigKey` / `AzureConfigKey` / `GoogleConfigKey` / `ClientConfigKey` parsers; `read_timeout` was the only newly-added key in the 0.13.2→0.14.1 range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)