### PR TITLE
docs: note CLI flags (--webui) in docker usage

### DIFF
--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -30,6 +30,17 @@ docker run \
   /files
 ```
 
+You can also pass any [CLI flags](run-with-cli.md) after the image name, for example `--webui enable-for-all` to serve the built-in web UI (disabled by default):
+
+```bash
+docker run \
+  -p 3000:3000 \
+  -v /path/to/local/files:/files \
+  ghcr.io/maplibre/martin:1.12.0 \
+  --webui enable-for-all \
+  /files
+```
+
 ### Accessing Local PostgreSQL on Linux
 
 If you are running PostgreSQL instance on `localhost`, you have to change network settings to allow the Docker container


### PR DESCRIPTION
Add a small nod in the Docker docs that CLI flags can be passed after the image name, using `--webui enable-for-all` as the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)