### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,9 @@ lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.8.5"
 martin-config-macros = { path = "./martin-config-macros", version = "0.1.0" }
-martin-core = { path = "./martin-core", version = "0.9.0", default-features = false }
+martin-core = { path = "./martin-core", version = "0.10.0", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.5" }
-mbtiles = { path = "./mbtiles", version = "0.18.1" }
+mbtiles = { path = "./mbtiles", version = "0.19.0" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12.3", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.12.0
+    image: ghcr.io/maplibre/martin:1.13.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.12.0 \
+           ghcr.io/maplibre/martin:1.13.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.12.0
+    image: ghcr.io/maplibre/martin:1.13.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.12.0
+  ghcr.io/maplibre/martin:1.13.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.12.0 \
+  ghcr.io/maplibre/martin:1.13.0 \
   /files
 ```
 
@@ -36,7 +36,7 @@ You can also pass any [CLI flags](run-with-cli.md) after the image name, for exa
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.12.0 \
+  ghcr.io/maplibre/martin:1.13.0 \
   --webui enable-for-all \
   /files
 ```
@@ -53,7 +53,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.12.0
+  ghcr.io/maplibre/martin:1.13.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -64,7 +64,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.12.0
+  ghcr.io/maplibre/martin:1.13.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -75,5 +75,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.12.0
+  ghcr.io/maplibre/martin:1.13.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.12.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.13.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.12.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.13.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -395,7 +395,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.12.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.13.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -11,12 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
 - propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))
 
 ### Fixed
 
-- connect to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
+- Allow connecting to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
 - *(postgres)* honor sslmode=verify-ca by skipping only the hostname check ([#2987](https://github.com/maplibre/martin/pull/2987))
 
 ### Other

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/maplibre/martin/compare/martin-core-v0.9.0...martin-core-v0.10.0) - 2026-07-25
+
+### Added
+
+- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
+- propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))
+
+### Fixed
+
+- connect to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
+- *(postgres)* honor sslmode=verify-ca by skipping only the hostname check ([#2987](https://github.com/maplibre/martin/pull/2987))
+
+### Other
+
+- use re-exported mvt from mlt ([#3037](https://github.com/maplibre/martin/pull/3037))
+- update fast-mvt and other deps ([#3028](https://github.com/maplibre/martin/pull/3028))
+- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
+- address feedback from fast-mvt migration ([#2993](https://github.com/maplibre/martin/pull/2993))
+- migrate geozero to fast-mvt, make duckdb non-dflt ([#2991](https://github.com/maplibre/martin/pull/2991))
+- fix clippy lints for 1.97 release ([#2989](https://github.com/maplibre/martin/pull/2989))
+- run `just fmt` ([#2981](https://github.com/maplibre/martin/pull/2981))
+
 ## [0.9.0](https://github.com/maplibre/martin/compare/martin-core-v0.8.0...martin-core-v0.9.0) - 2026-07-07
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,12 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25
 
+### Passthrough sources: config-file wiring
+
+`1.12.0` introduced passthrough sources at the `martin-core` level; this release finishes the job by wiring them into `martin`'s config file.
+This adds a dedicated typed config section, clearer errors for unrecognized keys, and correct etag-suffixing so cached passthrough tiles don't collide with tiles from other sources.
+Done in [#2910](https://github.com/maplibre/martin/pull/2910).
+
+### New `cache` MBTiles schema
+
+MBTiles files can now use a `cache` schema: like `flat`, but with `fetched`, `expires` and `etag` columns stored alongside each tile, so a `.mbtiles` file can double as a persistent, inspectable web-tile cache.
+It still exposes a spec-compatible `tiles` view, so any standard MBTiles reader (including `martin` itself) can serve a cache file unmodified.
+The `mbtiles` CLI gained a matching `cache-purge <file> [--max-size <MB>]` subcommand to evict expired (and, if needed, soonest-expiring) entries and reclaim space.
+Done in [#3009](https://github.com/maplibre/martin/pull/3009).
+
+### `martin-cp` now responds to Ctrl+C when copying from PostgreSQL
+
+Previously, interrupting a `martin-cp` run against PostgreSQL could hang instead of exiting.
+In-flight Postgres queries are now tracked and cancelled on interrupt, and the copier drains already-queued tiles instead of getting stuck.
+Done in [#2901](https://github.com/maplibre/martin/pull/2901).
+
 ### Added
 
-- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
-- *(mbtiles)* add a new cache schema ([#3009](https://github.com/maplibre/martin/pull/3009))
-- propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))
-- *(mbtiles)* read and validate the hash_algorithm metadata key ([#2985](https://github.com/maplibre/martin/pull/2985))
+- *(mbtiles)* read and validate the `hash_algorithm` metadata key, so files hashed with an algorithm other than MD5 (e.g. by `tippecanoe`) report a clear "unsupported algorithm" error instead of a misleading hash mismatch during validation ([#2985](https://github.com/maplibre/martin/pull/2985))
 
 ### Fixed
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25
+
+### Added
+
+- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
+- *(mbtiles)* add a new cache schema ([#3009](https://github.com/maplibre/martin/pull/3009))
+- propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))
+- *(mbtiles)* read and validate the hash_algorithm metadata key ([#2985](https://github.com/maplibre/martin/pull/2985))
+
+### Fixed
+
+- *(pmtiles)* restore AWS profile support ([#3029](https://github.com/maplibre/martin/pull/3029))
+- *(deps)* update npm dependencies ([#3012](https://github.com/maplibre/martin/pull/3012))
+- *(martin-ui)* center tile inspect map on tileset bounds, not 0/0/0 ([#3002](https://github.com/maplibre/martin/pull/3002))
+- *(postgres)* clearer error when a source schema exists but has no tile sources ([#2979](https://github.com/maplibre/martin/pull/2979))
+- *(martin-ui)* match metric endpoints when a route_prefix is set ([#2986](https://github.com/maplibre/martin/pull/2986))
+- connect to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
+- *(postgres)* honor sslmode=verify-ca by skipping only the hostname check ([#2987](https://github.com/maplibre/martin/pull/2987))
+- *(mbtiles)* validate min/max zoom metadata against actual tiles ([#2983](https://github.com/maplibre/martin/pull/2983))
+
+### Other
+
+- *(deps)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3045](https://github.com/maplibre/martin/pull/3045))
+- *(deps)* update dependency postcss to v8.5.18 [security] ([#3044](https://github.com/maplibre/martin/pull/3044))
+- *(deps)* autoupdate pre-commit ([#3040](https://github.com/maplibre/martin/pull/3040))
+- use re-exported mvt from mlt ([#3037](https://github.com/maplibre/martin/pull/3037))
+- derive CollectUnrecognizedKeys instead of hand-written impls ([#3031](https://github.com/maplibre/martin/pull/3031))
+- make UnrecognizedValues a newtype ([#3030](https://github.com/maplibre/martin/pull/3030))
+- *(deps)* update cargo dependencies ([#3011](https://github.com/maplibre/martin/pull/3011))
+- *(deps)* update dependency pbf to v5.1.1 ([#3020](https://github.com/maplibre/martin/pull/3020))
+- *(deps)* update dependency @types/node to v26.1.1 ([#3019](https://github.com/maplibre/martin/pull/3019))
+- add render_finalize_failure helper and snapshot tests ([#3000](https://github.com/maplibre/martin/pull/3000))
+- *(deps)* autoupdate pre-commit ([#2998](https://github.com/maplibre/martin/pull/2998))
+- *(postgres)* use NonZeroUsize for pool_size ([#2996](https://github.com/maplibre/martin/pull/2996))
+- run `just fmt` ([#2981](https://github.com/maplibre/martin/pull/2981))
+- *(deps)* lock file maintenance ([#2961](https://github.com/maplibre/martin/pull/2961))
+- split file sources into MBTiles and PMTiles subpages ([#2978](https://github.com/maplibre/martin/pull/2978))
+- update fast-mvt and other deps ([#3028](https://github.com/maplibre/martin/pull/3028))
+- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
+- address feedback from fast-mvt migration ([#2993](https://github.com/maplibre/martin/pull/2993))
+- migrate geozero to fast-mvt, make duckdb non-dflt ([#2991](https://github.com/maplibre/martin/pull/2991))
+- fix clippy lints for 1.97 release ([#2989](https://github.com/maplibre/martin/pull/2989))
+- more sqlx precompiled stmts ([#3010](https://github.com/maplibre/martin/pull/3010))
+- cleanup normalized-dedup sql ([#2990](https://github.com/maplibre/martin/pull/2990))
+- reuse .sql schema files in code ([#2988](https://github.com/maplibre/martin/pull/2988))
+- *(mbtiles)* refactor schemas to individual files ([#2982](https://github.com/maplibre/martin/pull/2982))
+
 ## [1.12.0](https://github.com/maplibre/martin/compare/martin-v1.11.0...martin-v1.12.0) - 2026-07-07
 
 ### GeoJSON tile source

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.12.0"
+version = "1.13.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.19",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.12.0"
+  "version": "1.13.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/maplibre/martin/compare/mbtiles-v0.18.1...mbtiles-v0.19.0) - 2026-07-25
+
+### Added
+
+- *(mbtiles)* add a new cache schema ([#3009](https://github.com/maplibre/martin/pull/3009))
+- *(mbtiles)* read and validate the hash_algorithm metadata key ([#2985](https://github.com/maplibre/martin/pull/2985))
+
+### Fixed
+
+- *(mbtiles)* validate min/max zoom metadata against actual tiles ([#2983](https://github.com/maplibre/martin/pull/2983))
+
+### Other
+
+- more sqlx precompiled stmts ([#3010](https://github.com/maplibre/martin/pull/3010))
+- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
+- cleanup normalized-dedup sql ([#2990](https://github.com/maplibre/martin/pull/2990))
+- reuse .sql schema files in code ([#2988](https://github.com/maplibre/martin/pull/2988))
+- *(mbtiles)* refactor schemas to individual files ([#2982](https://github.com/maplibre/martin/pull/2982))
+
 ## [0.18.1](https://github.com/maplibre/martin/compare/mbtiles-v0.18.0...mbtiles-v0.18.1) - 2026-07-07
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.18.1 -> 0.19.0 (⚠ API breaking changes)
* `martin-core`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `martin`: 1.12.0 -> 1.13.0

### ⚠ `mbtiles` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant MbtTypeCli:Cache in /tmp/.tmpJq9TMs/martin/mbtiles/src/mbtiles.rs:30
  variant MbtType:Cache in /tmp/.tmpJq9TMs/martin/mbtiles/src/validation.rs:160

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function mbtiles::get_bsdiff_tbl_name, previously in file /tmp/.tmp7xNBVU/mbtiles/src/queries.rs:253
  function mbtiles::create_bsdiffraw_tables, previously in file /tmp/.tmp7xNBVU/mbtiles/src/queries.rs:260
```

### ⚠ `martin-core` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum martin_core::tiles::duckdb::DuckDBError, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/duckdb/errors.rs:75

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant PostgresError::BadPostgresVersion in /tmp/.tmpJq9TMs/martin/martin-core/src/tiles/postgres/errors.rs:85

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant GeoJsonError::GeozeroError, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/geojson/error.rs:19
  variant MartinCoreError::DuckDBError, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/error.rs:31

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod martin_core::tiles::duckdb, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/duckdb/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct martin_core::tiles::duckdb::DuckDBPool, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/duckdb/pool.rs:20
  struct martin_core::tiles::duckdb::DuckDBSource, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/duckdb/source.rs:14
  struct martin_core::tiles::duckdb::DuckDBSqlInfo, previously in file /tmp/.tmp7xNBVU/martin-core/src/tiles/duckdb/source.rs:105
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.19.0](https://github.com/maplibre/martin/compare/mbtiles-v0.18.1...mbtiles-v0.19.0) - 2026-07-25

### Added

- *(mbtiles)* add a new cache schema ([#3009](https://github.com/maplibre/martin/pull/3009))
- *(mbtiles)* read and validate the hash_algorithm metadata key ([#2985](https://github.com/maplibre/martin/pull/2985))

### Fixed

- *(mbtiles)* validate min/max zoom metadata against actual tiles ([#2983](https://github.com/maplibre/martin/pull/2983))

### Other

- more sqlx precompiled stmts ([#3010](https://github.com/maplibre/martin/pull/3010))
- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
- cleanup normalized-dedup sql ([#2990](https://github.com/maplibre/martin/pull/2990))
- reuse .sql schema files in code ([#2988](https://github.com/maplibre/martin/pull/2988))
- *(mbtiles)* refactor schemas to individual files ([#2982](https://github.com/maplibre/martin/pull/2982))
</blockquote>

## `martin-core`

<blockquote>

## [0.10.0](https://github.com/maplibre/martin/compare/martin-core-v0.9.0...martin-core-v0.10.0) - 2026-07-25

### Added

- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
- propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))

### Fixed

- connect to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
- *(postgres)* honor sslmode=verify-ca by skipping only the hostname check ([#2987](https://github.com/maplibre/martin/pull/2987))

### Other

- use re-exported mvt from mlt ([#3037](https://github.com/maplibre/martin/pull/3037))
- update fast-mvt and other deps ([#3028](https://github.com/maplibre/martin/pull/3028))
- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
- address feedback from fast-mvt migration ([#2993](https://github.com/maplibre/martin/pull/2993))
- migrate geozero to fast-mvt, make duckdb non-dflt ([#2991](https://github.com/maplibre/martin/pull/2991))
- fix clippy lints for 1.97 release ([#2989](https://github.com/maplibre/martin/pull/2989))
- run `just fmt` ([#2981](https://github.com/maplibre/martin/pull/2981))
</blockquote>

## `martin`

<blockquote>

## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25

### Added

- *(martin)* passthrough tile source configuration ([#2910](https://github.com/maplibre/martin/pull/2910))
- *(mbtiles)* add a new cache schema ([#3009](https://github.com/maplibre/martin/pull/3009))
- propagate cancellation to postgres #2646 ([#2901](https://github.com/maplibre/martin/pull/2901))
- *(mbtiles)* read and validate the hash_algorithm metadata key ([#2985](https://github.com/maplibre/martin/pull/2985))

### Fixed

- *(pmtiles)* restore AWS profile support ([#3029](https://github.com/maplibre/martin/pull/3029))
- *(deps)* update npm dependencies ([#3012](https://github.com/maplibre/martin/pull/3012))
- *(martin-ui)* center tile inspect map on tileset bounds, not 0/0/0 ([#3002](https://github.com/maplibre/martin/pull/3002))
- *(postgres)* clearer error when a source schema exists but has no tile sources ([#2979](https://github.com/maplibre/martin/pull/2979))
- *(martin-ui)* match metric endpoints when a route_prefix is set ([#2986](https://github.com/maplibre/martin/pull/2986))
- connect to prerelease PostgreSQL versions ([#3024](https://github.com/maplibre/martin/pull/3024))
- *(postgres)* honor sslmode=verify-ca by skipping only the hostname check ([#2987](https://github.com/maplibre/martin/pull/2987))
- *(mbtiles)* validate min/max zoom metadata against actual tiles ([#2983](https://github.com/maplibre/martin/pull/2983))

### Other

- *(deps)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3045](https://github.com/maplibre/martin/pull/3045))
- *(deps)* update dependency postcss to v8.5.18 [security] ([#3044](https://github.com/maplibre/martin/pull/3044))
- *(deps)* autoupdate pre-commit ([#3040](https://github.com/maplibre/martin/pull/3040))
- use re-exported mvt from mlt ([#3037](https://github.com/maplibre/martin/pull/3037))
- derive CollectUnrecognizedKeys instead of hand-written impls ([#3031](https://github.com/maplibre/martin/pull/3031))
- make UnrecognizedValues a newtype ([#3030](https://github.com/maplibre/martin/pull/3030))
- *(deps)* update cargo dependencies ([#3011](https://github.com/maplibre/martin/pull/3011))
- *(deps)* update dependency pbf to v5.1.1 ([#3020](https://github.com/maplibre/martin/pull/3020))
- *(deps)* update dependency @types/node to v26.1.1 ([#3019](https://github.com/maplibre/martin/pull/3019))
- add render_finalize_failure helper and snapshot tests ([#3000](https://github.com/maplibre/martin/pull/3000))
- *(deps)* autoupdate pre-commit ([#2998](https://github.com/maplibre/martin/pull/2998))
- *(postgres)* use NonZeroUsize for pool_size ([#2996](https://github.com/maplibre/martin/pull/2996))
- run `just fmt` ([#2981](https://github.com/maplibre/martin/pull/2981))
- *(deps)* lock file maintenance ([#2961](https://github.com/maplibre/martin/pull/2961))
- split file sources into MBTiles and PMTiles subpages ([#2978](https://github.com/maplibre/martin/pull/2978))
- update fast-mvt and other deps ([#3028](https://github.com/maplibre/martin/pull/3028))
- update sqlite queries ([#3003](https://github.com/maplibre/martin/pull/3003))
- address feedback from fast-mvt migration ([#2993](https://github.com/maplibre/martin/pull/2993))
- migrate geozero to fast-mvt, make duckdb non-dflt ([#2991](https://github.com/maplibre/martin/pull/2991))
- fix clippy lints for 1.97 release ([#2989](https://github.com/maplibre/martin/pull/2989))
- more sqlx precompiled stmts ([#3010](https://github.com/maplibre/martin/pull/3010))
- cleanup normalized-dedup sql ([#2990](https://github.com/maplibre/martin/pull/2990))
- reuse .sql schema files in code ([#2988](https://github.com/maplibre/martin/pull/2988))
- *(mbtiles)* refactor schemas to individual files ([#2982](https://github.com/maplibre/martin/pull/2982))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).