### PR TITLE
chore(deps): Update hotpath and instrument decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,15 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "902f40dea4993d99db66732fddd9143e92657f1d47a642395f92b339b1375659"
 dependencies = [
+ "hotpath-macros 0.21.5",
+]
+
+[[package]]
+name = "hotpath"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66750a77f4f6b408a148be5102ef1f3ba7172def7ee92b1cfc75d9f7a3870453"
+dependencies = [
  "arc-swap",
  "axum",
  "cfg-if",
@@ -3879,7 +3888,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hdrhistogram",
- "hotpath-macros",
+ "hotpath-macros 0.22.0",
  "hotpath-meta",
  "libc",
  "pin-project-lite",
@@ -3902,6 +3911,12 @@ name = "hotpath-macros"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "191f6e3b11c1f817e5c3737158812bc8d3a383e9d9d89526703ea6dc1e9fe647"
+
+[[package]]
+name = "hotpath-macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe0e1900d2dbe2e2df8e9522b97ebd7a5598ba18478f57e247957022dffedbe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3910,15 +3925,15 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros-meta"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604e1929e4e069ce456916d2bb267ddd2b7d680bfb5b89abca06a9b6d3fe50a7"
+checksum = "21f2f70b29b6f42311acd2fb0b2f91a34d9a573c76fb8a7f51970670a1673a49"
 
 [[package]]
 name = "hotpath-meta"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c1f5d817c1a70efc3aa66d27909e86878ea22991c0b6fc5f36d6dbd26856a3"
+checksum = "8b771f77b2f409086bb40ff029f850ce99d17118d4e207df0f28cb32bd7568c7"
 dependencies = [
  "hotpath-macros-meta",
 ]
@@ -5123,7 +5138,7 @@ dependencies = [
  "enum-display",
  "futures",
  "geojson",
- "hotpath",
+ "hotpath 0.22.0",
  "humantime-serde",
  "image",
  "image-compare",
@@ -5208,7 +5223,7 @@ dependencies = [
  "geo-index",
  "geo-types",
  "geojson",
- "hotpath",
+ "hotpath 0.22.0",
  "image",
  "image-compare",
  "insta",
@@ -5277,6 +5292,7 @@ dependencies = [
  "approx",
  "brotli 8.0.4",
  "flate2",
+ "hotpath 0.22.0",
  "rstest",
  "serde",
  "serde_json",
@@ -5322,7 +5338,7 @@ dependencies = [
  "flate2",
  "flume",
  "futures",
- "hotpath",
+ "hotpath 0.22.0",
  "insta",
  "itertools 0.15.0",
  "martin-tile-utils",
@@ -5488,7 +5504,7 @@ dependencies = [
  "geo-types",
  "hex",
  "hilbert_2d",
- "hotpath",
+ "hotpath 0.21.5",
  "integer-encoding",
  "num-traits",
  "num_enum",
@@ -8812,7 +8828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ geo = "0.33.1"
 geo-index = { version = "0.3.3", features = ["rayon"] }
 geo-types = "0.7.18"
 geojson = { version = "1", features = ["geo-types"] }
-hotpath = "0.21"
+hotpath = "0.22"
 humantime-serde = "1.1.1"
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "webp"] }
 image-compare = "0.5"

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -18,6 +18,7 @@ homepage.workspace = true
 [dependencies]
 brotli.workspace = true
 flate2.workspace = true
+hotpath.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -1,56 +1,74 @@
-use std::io::{Read as _, Write as _};
+use std::io::Read as _;
 
-use flate2::read::{MultiGzDecoder, ZlibDecoder};
-use flate2::write::GzEncoder;
+use flate2::read::{GzEncoder, MultiGzDecoder, ZlibDecoder, ZlibEncoder};
 
 pub fn decode_gzip(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut decoder = MultiGzDecoder::new(data);
+    let mut decoder = hotpath::io!(MultiGzDecoder::new(data), label = "decode_gzip");
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     Ok(decompressed)
 }
 
 pub fn encode_zlib(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-    encoder.write_all(data)?;
-    encoder.finish()
+    let mut encoder = hotpath::io!(
+        ZlibEncoder::new(data, flate2::Compression::default()),
+        label = "encode_zlib"
+    );
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed)?;
+    Ok(compressed)
 }
 
 pub fn decode_zlib(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut decoder = ZlibDecoder::new(data);
+    let mut decoder = hotpath::io!(ZlibDecoder::new(data), label = "decode_zlib");
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     Ok(decompressed)
 }
 
 pub fn encode_gzip(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
-    encoder.write_all(data)?;
-    encoder.finish()
+    let mut encoder = hotpath::io!(
+        GzEncoder::new(data, flate2::Compression::default()),
+        label = "encode_gzip"
+    );
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed)?;
+    Ok(compressed)
 }
 
 pub fn decode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut decoder = brotli::Decompressor::new(data, 4096);
+    let mut decoder = hotpath::io!(
+        brotli::Decompressor::new(data, 4096),
+        label = "decode_brotli"
+    );
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     Ok(decompressed)
 }
 
 pub fn encode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut encoder = brotli::CompressorWriter::new(Vec::new(), 4096, 11, 22);
-    encoder.write_all(data)?;
-    Ok(encoder.into_inner())
+    let mut encoder = hotpath::io!(
+        brotli::CompressorReader::new(data, 4096, 11, 22),
+        label = "encode_brotli"
+    );
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed)?;
+    Ok(compressed)
 }
 
 pub fn decode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut decoder = zstd::Decoder::new(data)?;
+    let mut decoder = hotpath::io!(zstd::Decoder::new(data)?, label = "decode_zstd");
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     Ok(decompressed)
 }
 
 pub fn encode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    let mut encoder = zstd::Encoder::new(Vec::new(), 0)?;
-    encoder.write_all(data)?;
-    encoder.finish()
+    let mut encoder = hotpath::io!(
+        zstd::stream::read::Encoder::new(data, 0)?,
+        label = "encode_zstd"
+    );
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed)?;
+    Ok(compressed)
 }


### PR DESCRIPTION
Hi, I just published a new https://hotpath.rs/ release with IO instrumentation. 

It allows wrapping any IO stream, to collect metrics like bytes read/write, rate, perf percentiles etc. with minimal overhead.

I tested with:

```
oha -n 100000 -H 'Accept-Encoding: br'       http://localhost:3000/world_cities/0/0/0
```

and noticed that brotli compression is significantly slower.

Before:

<img width="485" height="256" alt="before-oha" src="https://github.com/user-attachments/assets/8bffdcd4-d983-4ea2-ba9c-28e2b2c03d03" />
<img width="1140" height="194" alt="before-rate" src="https://github.com/user-attachments/assets/ecc1c693-3e82-4827-a239-c718604211d0" />

After switching to compression level 4: 

<img width="488" height="252" alt="after-oha" src="https://github.com/user-attachments/assets/3bb8ec6b-242b-4963-8e98-64e979851f5d" />
<img width="1143" height="203" alt="after-rate" src="https://github.com/user-attachments/assets/f159cc61-a91c-4658-a4e3-e0950c89fe6b" />

~30x encoding and response time speedup. Brotli codec rate: `27.9kb/s -> 1.6 MB/s`

Not sure if this change makes sense for your project i.e. response speed vs compression ratio tradeoff. But maybe you'll find the new I/O instrumentation useful in other places. It should work for TCP, TLS, files I/O basically any types using `Read`, `Write`, `AsyncRead`, `AsyncWrite` traits.

I had to reorganize encoders usage, so that all data is captured, but final result should be identical.

As always feedback welcome!