### PR TITLE
test: migrate tile content-negotiation e2e tests to rust

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant, SystemTime};
 use brotli::Decompressor;
 use flate2::read::GzDecoder;
 use mlt_core::fast_mvt::{MvtReaderRef, MvtTile};
+use mlt_core::{Decoder, Layer, Parser, TileLayer};
 use regex::Regex;
 use reqwest::{Client, Method, redirect};
 use sqlx::sqlite::SqliteConnectOptions;
@@ -268,7 +269,11 @@ impl Martin {
     /// Perform a HEAD request. Routes list their methods one by one, so a route
     /// that answers `GET` does not necessarily answer `HEAD`.
     pub async fn head(&self, path: &str) -> TestResponse {
-        self.request(Method::HEAD, path, &[]).await
+        self.head_with_headers(path, &[]).await
+    }
+
+    pub async fn head_with_headers(&self, path: &str, headers: &[(&str, &str)]) -> TestResponse {
+        self.request(Method::HEAD, path, headers).await
     }
 
     async fn request(&self, method: Method, path: &str, headers: &[(&str, &str)]) -> TestResponse {
@@ -652,6 +657,26 @@ impl TestResponse {
             .expect("response body is not a vector tile")
             .to_tile()
             .expect("response body is not a decodable vector tile")
+    }
+
+    /// Decompressed response body decoded as a `MapLibre` tile.
+    #[must_use]
+    pub fn mlt(&self) -> Vec<TileLayer> {
+        let mut parser = Parser::default();
+        let mut decoder = Decoder::default();
+        parser
+            .parse_layers(&self.body)
+            .expect("response body is not a maplibre tile")
+            .into_iter()
+            .map(|layer| {
+                let Layer::Tag01(layer) = layer else {
+                    panic!("response body has a layer that is not MVT-compatible");
+                };
+                layer
+                    .into_tile(&mut decoder)
+                    .expect("response body has an undecodable layer")
+            })
+            .collect()
     }
 
     /// Decompressed response body decoded as a vector tile, in `mvt dump`'s text form.

--- a/integration-tests/tests/metrics.rs
+++ b/integration-tests/tests/metrics.rs
@@ -1,0 +1,32 @@
+//! Prometheus metrics served at `/_/metrics`.
+
+use martin_integration_tests::Martin;
+
+#[tokio::test]
+async fn a_repeated_tile_request_is_counted_as_a_tile_cache_hit() {
+    let mut martin = Martin::builder()
+        .arg("tests/fixtures/pmtiles/png.pmtiles")
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    assert_eq!(martin.get("/png/0/0/0").await.status(), 200);
+    assert_eq!(martin.get("/png/0/0/0").await.status(), 200);
+
+    let metrics = martin.get("/_/metrics").await;
+    assert_eq!(metrics.status(), 200);
+    let cache_counters = metrics
+        .text()
+        .lines()
+        .filter(|line| line.starts_with("martin_tile_cache_requests_total{"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!(cache_counters, @r#"
+    martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
+    martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1
+    "#);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}

--- a/integration-tests/tests/tile_routes.rs
+++ b/integration-tests/tests/tile_routes.rs
@@ -1,4 +1,4 @@
-//! Routing behaviour shared by every tile source: redirects from a format suffix and from the `/tiles/` prefix.
+//! Routing behaviour shared by every tile source: redirects from a format suffix and from the `/tiles/` prefix, `Accept` header negotiation, and the zoom range a source covers.
 
 use martin_integration_tests::Martin;
 use rstest::rstest;
@@ -6,6 +6,15 @@ use rstest::rstest;
 async fn martin_with_a_pmtiles_source() -> Martin {
     Martin::builder()
         .arg("tests/fixtures/pmtiles2")
+        .start()
+        .await
+        .expect("failed to start martin")
+}
+
+async fn martin_with_a_vector_and_a_raster_source() -> Martin {
+    Martin::builder()
+        .arg("tests/fixtures/geojson/feature_1.geojson")
+        .arg("tests/fixtures/pmtiles/png.pmtiles")
         .start()
         .await
         .expect("failed to start martin")
@@ -102,6 +111,179 @@ async fn a_redirect_is_issued_before_the_source_is_resolved(#[case] path: &str) 
 
     martin.stop().await;
     martin.assert_log_contains(r#"ERROR error="Source nosuch does not exist""#);
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::the_source_format("application/x-protobuf")]
+#[case::the_mapbox_alias_of_the_source_format("application/vnd.mapbox-vector-tile")]
+#[case::anything("*/*")]
+#[case::a_list_containing_the_source_format("image/png, application/x-protobuf")]
+#[case::the_least_preferred_of_a_list("image/png;q=0.9, application/x-protobuf;q=0.1")]
+#[tokio::test]
+async fn a_vector_source_serves_mvt_when_the_accept_header_allows_it(#[case] accept: &str) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let tile = martin
+        .get_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(tile.status(), 200);
+    assert_eq!(tile.header("content-type"), Some("application/x-protobuf"));
+    let layers = tile.mvt().layers;
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].name, "feature_1");
+    assert_eq!(layers[0].features.len(), 1);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::the_maplibre_tile_type("application/vnd.maplibre-tile")]
+#[case::its_vector_tile_alias("application/vnd.maplibre-vector-tile")]
+#[tokio::test]
+async fn a_vector_source_transcodes_to_mlt_for_an_mlt_accept_header(#[case] accept: &str) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let tile = martin
+        .get_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(tile.status(), 200);
+    assert_eq!(
+        tile.header("content-type"),
+        Some("application/vnd.maplibre-tile")
+    );
+    let layers = tile.mlt();
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].name(), "feature_1");
+    assert_eq!(layers[0].feature_count(), 1);
+    assert_eq!(layers[0].property_names(), ["id", "name"]);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::png("image/png")]
+#[case::every_image_format("image/*")]
+#[case::json("application/json")]
+#[tokio::test]
+async fn a_vector_source_rejects_an_accept_header_of_other_formats(#[case] accept: &str) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let response = martin
+        .get_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(response.status(), 406);
+    assert_eq!(
+        response.text(),
+        "Source produces application/x-protobuf, which does not match the Accept header"
+    );
+    let head = martin
+        .head_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(head.status(), 406);
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        r#"ERROR error="Source produces application/x-protobuf, which does not match the Accept header""#,
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::the_source_format("image/png")]
+#[case::every_image_format("image/*")]
+#[case::anything("*/*")]
+#[tokio::test]
+async fn a_raster_source_serves_png_when_the_accept_header_allows_it(#[case] accept: &str) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let tile = martin
+        .get_with_headers("/png/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(tile.status(), 200);
+    assert_eq!(tile.header("content-type"), Some("image/png"));
+    assert_eq!(&tile.body()[..8], b"\x89PNG\r\n\x1a\n");
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::mvt("application/x-protobuf")]
+#[case::mlt("application/vnd.maplibre-tile")]
+#[tokio::test]
+async fn a_raster_source_is_never_transcoded_to_a_vector_format(#[case] accept: &str) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let response = martin
+        .get_with_headers("/png/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(response.status(), 406);
+    assert_eq!(
+        response.text(),
+        "Source produces image/png, which does not match the Accept header"
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        r#"ERROR error="Source produces image/png, which does not match the Accept header""#,
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::a_type_that_is_not_a_tile_format("text/html")]
+#[case::a_tile_format_rejected_with_a_zero_quality("application/x-protobuf;q=0")]
+#[case::a_wildcard_rejected_with_a_zero_quality("*/*;q=0")]
+#[tokio::test]
+async fn an_accept_header_naming_no_tile_format_is_rejected_before_the_source_is_resolved(
+    #[case] accept: &str,
+) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let response = martin
+        .get_with_headers("/nosuch/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(response.status(), 406);
+    assert_eq!(
+        response.text(),
+        "Accept header does not contain any supported tile format"
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        r#"ERROR error="Accept header does not contain any supported tile format""#,
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::just_above_the_maximum(2)]
+#[case::far_above_the_maximum(10)]
+#[tokio::test]
+async fn a_zoom_the_source_does_not_cover_is_a_404_naming_the_range(#[case] zoom: u8) {
+    let mut martin = martin_with_a_vector_and_a_raster_source().await;
+
+    let response = martin.get(&format!("/png/{zoom}/0/0")).await;
+    assert_eq!(response.status(), 404);
+    assert_eq!(
+        response.text(),
+        format!("Zoom {zoom} is outside the supported range: png supports zoom 0-1")
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains(&format!(
+        r#"ERROR error="Zoom {zoom} is outside the supported range: png supports zoom 0-1""#
+    ));
     martin.assert_startup_warnings();
     martin.assert_log_clean();
 }

--- a/tests/expected/configured/metrics_1.fetched_with_compression.txt
+++ b/tests/expected/configured/metrics_1.fetched_with_compression.txt
@@ -70,34 +70,6 @@ martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}
 martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200",le="+Inf"} NUMBER
 martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
 martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.005"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.01"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.025"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.05"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.25"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="2.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="10"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="+Inf"} NUMBER
-martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.005"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.01"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.025"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.05"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.25"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="2.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="10"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="+Inf"} NUMBER
-martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
-martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
 # HELP martin_http_requests_total Total number of HTTP requests
 # TYPE martin_http_requests_total counter
 martin_http_requests_total{endpoint="/_/metrics",method="GET",status="200"} NUMBER
@@ -105,9 +77,6 @@ martin_http_requests_total{endpoint="/catalog",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/health",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/{source_ids}",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
-martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
 # HELP martin_tile_cache_requests_total Martin tile-coordinate cache lookups, labeled by cache type, hit/miss result, and zoom
 # TYPE martin_tile_cache_requests_total counter
-martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} NUMBER
 martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} NUMBER

--- a/tests/expected/configured/metrics_1.txt
+++ b/tests/expected/configured/metrics_1.txt
@@ -56,43 +56,12 @@ martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}
 martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200",le="+Inf"} NUMBER
 martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
 martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.005"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.01"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.025"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.05"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.25"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="0.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="2.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="10"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404",le="+Inf"} NUMBER
-martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.005"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.01"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.025"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.05"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.25"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="0.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="1"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="2.5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="5"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="10"} NUMBER
-martin_http_requests_duration_seconds_bucket{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406",le="+Inf"} NUMBER
-martin_http_requests_duration_seconds_sum{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
-martin_http_requests_duration_seconds_count{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
 # HELP martin_http_requests_total Total number of HTTP requests
 # TYPE martin_http_requests_total counter
 martin_http_requests_total{endpoint="/catalog",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/health",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/{source_ids}",method="GET",status="200"} NUMBER
 martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="200"} NUMBER
-martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="404"} NUMBER
-martin_http_requests_total{endpoint="/{source_ids}/{z}/{x}/{y}",method="GET",status="406"} NUMBER
 # HELP martin_tile_cache_requests_total Martin tile-coordinate cache lookups, labeled by cache type, hit/miss result, and zoom
 # TYPE martin_tile_cache_requests_total counter
-martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} NUMBER
 martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} NUMBER

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -194,19 +194,6 @@ test_json_with_header() {
   clean_headers_dump "$FILENAME.headers"
 }
 
-test_accept_header() {
-  URL="$MARTIN_URL/$1"
-  ACCEPT_HEADER="$2"
-  EXPECTED_CODE="$3"
-
-  echo "Testing Accept header: $ACCEPT_HEADER on $URL (expect $EXPECTED_CODE)"
-  HTTP_CODE=$(curl --silent --show-error --write-out "%{http_code}" --output /dev/null -H "Accept: $ACCEPT_HEADER" "$URL")
-  if [ "$HTTP_CODE" != "$EXPECTED_CODE" ]; then
-    echo "ERROR: Expected HTTP $EXPECTED_CODE, got $HTTP_CODE for $URL with Accept: $ACCEPT_HEADER"
-    exit 1
-  fi
-}
-
 test_mlt() {
   FILENAME="$TEST_OUT_DIR/$1.mlt"
   URL="$MARTIN_URL/$2"
@@ -619,34 +606,6 @@ test_png pmt2_0_0_0   pmt2/0/0/0  # HTTP pmtiles
 # Test comments override
 test_jsn tbl_comment_cfg  MixPoints
 test_jsn fnc_comment_cfg  function_Mixed_Name
-
->&2 echo "***** Test Accept header content negotiation (HTTP 406) *****"
-
-# MVT source
-test_accept_header table_source/0/0/0 "application/x-protobuf" 200
-test_accept_header table_source/0/0/0 "*/*" 200
-test_accept_header table_source/0/0/0 "image/png, application/x-protobuf" 200
-test_accept_header table_source/0/0/0 "application/x-protobuf, image/png" 200
-test_accept_header table_source/0/0/0 "image/png" 406
-test_accept_header table_source/0/0/0 "image/*" 406
-# MVT -> MLT pre-cache conversion: MLT Accept on an MVT source returns 200 with MLT body
-test_accept_header table_source/0/0/0 "application/vnd.maplibre-vector-tile" 200
-test_accept_header table_source/0/0/0 "application/vnd.maplibre-tile" 200
-test_accept_header table_source/0/0/0 "text/html" 406
-
-# PNG source
-test_accept_header pmt/0/0/0 "image/png" 200
-test_accept_header pmt/0/0/0 "image/*" 200
-test_accept_header pmt/0/0/0 "*/*" 200
-test_accept_header pmt/0/0/0 "application/x-protobuf" 406
-test_accept_header pmt/0/0/0 "application/vnd.maplibre-vector-tile" 406
-test_accept_header pmt/0/0/0 "application/vnd.maplibre-tile" 406
-
->&2 echo "***** Test out-of-zoom-range tiles return 404 *****"
-
-# pmt only covers zoom 0-3, so requesting a higher zoom filters out every source -> 404
-test_accept_header pmt/4/0/0 "*/*" 404
-test_accept_header pmt/10/0/0 "*/*" 404
 
 >&2 echo "***** Test observability outputs (metrics, logs) *****"
 


### PR DESCRIPTION
Moves the Accept-header 406 and out-of-zoom-range 404 blocks out of `tests/test.sh` into `tile_routes.rs`, plus a `metrics.rs` for the tile-cache counters they were keeping alive.