### PR TITLE
perf: Change dynamic brotli encoding level from 11 to 4

### DIFF
--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -46,9 +46,9 @@ pub fn decode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     Ok(decompressed)
 }
 
-pub fn encode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+pub fn encode_brotli(data: &[u8], quality: u32) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = hotpath::io!(
-        brotli::CompressorReader::new(data, 4096, 11, 22),
+        brotli::CompressorReader::new(data, 4096, quality, 22),
         label = "encode_brotli"
     );
     let mut compressed = Vec::new();

--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -46,9 +46,14 @@ pub fn decode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     Ok(decompressed)
 }
 
-pub fn encode_brotli(data: &[u8], quality: u32) -> Result<Vec<u8>, std::io::Error> {
+pub fn encode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    encode_brotli_with_quality(data, 11)
+}
+
+/// Encodes with the given Brotli quality, clamped to the valid `0..=11` range.
+pub fn encode_brotli_with_quality(data: &[u8], quality: u32) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = hotpath::io!(
-        brotli::CompressorReader::new(data, 4096, quality, 22),
+        brotli::CompressorReader::new(data, 4096, quality.min(11), 22),
         label = "encode_brotli"
     );
     let mut compressed = Vec::new();

--- a/martin-tile-utils/src/decoders.rs
+++ b/martin-tile-utils/src/decoders.rs
@@ -47,14 +47,20 @@ pub fn decode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 }
 
 pub fn encode_brotli(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
-    encode_brotli_with_quality(data, 11)
+    let mut encoder = hotpath::io!(
+        brotli::CompressorReader::new(data, 4096, 11, 22),
+        label = "encode_brotli"
+    );
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed)?;
+    Ok(compressed)
 }
 
 /// Encodes with the given Brotli quality, clamped to the valid `0..=11` range.
 pub fn encode_brotli_with_quality(data: &[u8], quality: u32) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = hotpath::io!(
         brotli::CompressorReader::new(data, 4096, quality.min(11), 22),
-        label = "encode_brotli"
+        label = "encode_brotli_with_quality"
     );
     let mut compressed = Vec::new();
     encoder.read_to_end(&mut compressed)?;

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -651,13 +651,16 @@ impl<'a> DynTileSource<'a> {
     }
 }
 
+/// Brotli quality for on-the-fly response compression; q10+ is orders of magnitude slower.
+const BROTLI_ENCODE_QUALITY: u32 = 4;
+
 #[hotpath::measure]
 fn encode(tile: Tile, enc: ContentEncoding) -> ActixResult<Tile> {
     hotpath::dbg!("encode", enc);
     let etag = tile.etag;
     Ok(match enc {
         ContentEncoding::Brotli => Tile::new_with_etag(
-            encode_brotli(&tile.data)?,
+            encode_brotli(&tile.data, BROTLI_ENCODE_QUALITY)?,
             tile.info.encoding(Encoding::Brotli),
             etag,
         ),
@@ -888,7 +891,7 @@ mod tests {
     fn compress_with(data: &[u8], encoding: Encoding) -> Vec<u8> {
         match encoding {
             Encoding::Gzip => encode_gzip(data).unwrap(),
-            Encoding::Brotli => encode_brotli(data).unwrap(),
+            Encoding::Brotli => encode_brotli(data, BROTLI_ENCODE_QUALITY).unwrap(),
             Encoding::Zlib => encode_zlib(data).unwrap(),
             Encoding::Zstd => encode_zstd(data).unwrap(),
             _ => panic!("compress_with: unsupported encoding {encoding:?}"),

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -651,9 +651,8 @@ impl<'a> DynTileSource<'a> {
     }
 }
 
-/// Brotli quality level for on-the-fly response compression; levels 10 and
-/// above are orders of magnitude slower to encode.
-const BROTLI_ENCODE_QUALITY: u32 = 4;
+/// Brotli quality level for on-the-fly response compression
+const BROTLI_ENCODE_QUALITY: u32 = 6;
 
 #[hotpath::measure]
 fn encode(tile: Tile, enc: ContentEncoding) -> ActixResult<Tile> {

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -651,7 +651,8 @@ impl<'a> DynTileSource<'a> {
     }
 }
 
-/// Brotli quality for on-the-fly response compression; q10+ is orders of magnitude slower.
+/// Brotli quality level for on-the-fly response compression; levels 10 and
+/// above are orders of magnitude slower to encode.
 const BROTLI_ENCODE_QUALITY: u32 = 4;
 
 #[hotpath::measure]

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -13,7 +13,7 @@ use futures::future::try_join_all;
 use martin_core::tiles::{BoxedSource, MartinCoreError, Tile, TileCache, UrlQuery};
 use martin_tile_utils::{
     Encoding, Format, TileCoord, TileInfo, decode_brotli, decode_gzip, decode_zlib, decode_zstd,
-    encode_brotli, encode_gzip, encode_zlib, encode_zstd,
+    encode_brotli_with_quality, encode_gzip, encode_zlib, encode_zstd,
 };
 use serde::Deserialize;
 use tracing::{instrument, warn};
@@ -660,7 +660,7 @@ fn encode(tile: Tile, enc: ContentEncoding) -> ActixResult<Tile> {
     let etag = tile.etag;
     Ok(match enc {
         ContentEncoding::Brotli => Tile::new_with_etag(
-            encode_brotli(&tile.data, BROTLI_ENCODE_QUALITY)?,
+            encode_brotli_with_quality(&tile.data, BROTLI_ENCODE_QUALITY)?,
             tile.info.encoding(Encoding::Brotli),
             etag,
         ),
@@ -891,7 +891,7 @@ mod tests {
     fn compress_with(data: &[u8], encoding: Encoding) -> Vec<u8> {
         match encoding {
             Encoding::Gzip => encode_gzip(data).unwrap(),
-            Encoding::Brotli => encode_brotli(data, BROTLI_ENCODE_QUALITY).unwrap(),
+            Encoding::Brotli => encode_brotli_with_quality(data, BROTLI_ENCODE_QUALITY).unwrap(),
             Encoding::Zlib => encode_zlib(data).unwrap(),
             Encoding::Zstd => encode_zstd(data).unwrap(),
             _ => panic!("compress_with: unsupported encoding {encoding:?}"),

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -295,7 +295,7 @@ async fn mbt_get_mvt_brotli() {
     );
     assert_eq!(response.headers().get(CONTENT_ENCODING).unwrap(), "br");
     let body = read_body(response).await;
-    assert_eq!(body.len(), 871); // this number could change if compression gets more optimized
+    assert_eq!(body.len(), 1136); // this number could change if compression settings change
     let body = decode_brotli(&body).unwrap();
     assert_eq!(body.len(), 1828);
 }

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -295,7 +295,7 @@ async fn mbt_get_mvt_brotli() {
     );
     assert_eq!(response.headers().get(CONTENT_ENCODING).unwrap(), "br");
     let body = read_body(response).await;
-    assert_eq!(body.len(), 1136); // this number could change if compression settings change
+    assert_eq!(body.len(), 975); // this number could change if compression settings change
     let body = decode_brotli(&body).unwrap();
     assert_eq!(body.len(), 1828);
 }

--- a/mbtiles/src/bindiff.rs
+++ b/mbtiles/src/bindiff.rs
@@ -278,8 +278,7 @@ impl BinDiffer<DifferBefore, DifferAfter> for BinDiffDiffer {
         }
         let new_tile_hash = xxh3_64(&new_tile);
         let data = BsdiffRawDiffer::diff(&old_tile, &new_tile).expect("BinDiff failure");
-        // Stored in the output mbtiles, so prefer ratio over encode speed.
-        let data = encode_brotli(&data, 11)?;
+        let data = encode_brotli(&data)?;
 
         Ok(DifferAfter {
             coord: value.coord,

--- a/mbtiles/src/bindiff.rs
+++ b/mbtiles/src/bindiff.rs
@@ -278,7 +278,8 @@ impl BinDiffer<DifferBefore, DifferAfter> for BinDiffDiffer {
         }
         let new_tile_hash = xxh3_64(&new_tile);
         let data = BsdiffRawDiffer::diff(&old_tile, &new_tile).expect("BinDiff failure");
-        let data = encode_brotli(&data)?;
+        // Stored in the output mbtiles, so prefer ratio over encode speed.
+        let data = encode_brotli(&data, 11)?;
 
         Ok(DifferAfter {
             coord: value.coord,


### PR DESCRIPTION
Related to https://github.com/maplibre/martin/pull/3059 

It results in ~30x response time speedup for `content_encoding: br` requests, and preserves compression ratio for static content from `src/bindiff.rs`.

