### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0119,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0049,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2026-0105,RUSTSEC-2025-0141,RUSTSEC-2026-0145,RUSTSEC-2026-0179,RUSTSEC-2026-0180,RUSTSEC-2026-0178,RUSTSEC-2026-0189,RUSTSEC-2026-0194,RUSTSEC-2026-0195
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436,RUSTSEC-2025-0119,RUSTSEC-2025-0134,RUSTSEC-2026-0002,RUSTSEC-2026-0007,RUSTSEC-2026-0049,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2026-0105,RUSTSEC-2025-0141,RUSTSEC-2026-0145,RUSTSEC-2026-0179,RUSTSEC-2026-0180,RUSTSEC-2026-0178,RUSTSEC-2026-0189,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2026-0258
           # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing side channels => not used exploitably
           # RUSTSEC-2024-0436 = paste - no longer maintained
           # RUSTSEC-2025-0119 = number_prefix is unmaintained, but we need no change in this lib
@@ -60,6 +60,7 @@ jobs:
           # RUSTSEC-2026-0189 = rmcp Streamable HTTP DNS rebinding; only pulled in via hotpath's hotpath-mcp profiling tool, never compiled into the shipped server
           # RUSTSEC-2026-0194 = quick-xml quadratic attribute-check dos; transitive via object_store 0.13 (quick-xml ^0.39), patched only in quick-xml 0.41 which needs a breaking object_store 0.14 bump
           # RUSTSEC-2026-0195 = quick-xml unbounded namespace-declaration dos; same object_store 0.13 pin, patched only in quick-xml 0.41
+          # RUSTSEC-2026-0258 = h2 unbounded empty DATA frames dos; remaining leg is h2@0.3.27 pinned by actix-http (still on h2 "0.3" even at 3.13.3), no patched 0.3.x release exists
   dependency-review:
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "martin-config-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "approx",
  "brotli 8.0.4",
@@ -5329,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.13.2"
+version = "3.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53200bd1513e569e6e644181c922cec072c121a27db5b38d45e88e630c369366"
+checksum = "11004b0e9b44b4eb3d15e0c3132b96fb178c7e50a74758b2f17bb9cc9a7fb4f6"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -402,7 +402,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -413,7 +413,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1104,7 +1104,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "hyper 1.10.1",
  "hyper-rustls",
@@ -2918,7 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3640,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4057,7 +4057,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -4556,7 +4556,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5688,7 +5688,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6806,7 +6806,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7298,7 +7298,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -7605,7 +7605,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7673,7 +7673,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7857,7 +7857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2c6921c8ce48fb1b052b457619d008834039d80325992ed3bc55bbe6c155ad"
 dependencies = [
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.23.1",
  "encoding_rs_io",
  "granit-parser",
  "miette",
@@ -8222,7 +8222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8767,7 +8767,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8800,7 +8800,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8810,7 +8810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9325,7 +9325,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -10202,7 +10202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "martin-config-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "actix-web",
  "approx",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "approx",
  "brotli 8.0.4",
@@ -5321,7 +5321,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,10 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.9.0"
-martin-config-macros = { path = "./martin-config-macros", version = "0.1.0" }
-martin-core = { path = "./martin-core", version = "0.10.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.5" }
-mbtiles = { path = "./mbtiles", version = "0.19.0" }
+martin-config-macros = { path = "./martin-config-macros", version = "0.1.1" }
+martin-core = { path = "./martin-core", version = "0.11.0", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.6" }
+mbtiles = { path = "./mbtiles", version = "0.19.1" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,10 @@ json-patch = "4"
 lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.8.5"
-martin-config-macros = { path = "./martin-config-macros", version = "0.1.0" }
-martin-core = { path = "./martin-core", version = "0.10.0", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.5" }
-mbtiles = { path = "./mbtiles", version = "0.19.0" }
+martin-config-macros = { path = "./martin-config-macros", version = "0.1.1" }
+martin-core = { path = "./martin-core", version = "0.11.0", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.6" }
+mbtiles = { path = "./mbtiles", version = "0.19.1" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12.3", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.13.0
+    image: ghcr.io/maplibre/martin:1.14.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/files/compose.nginx.yaml
+++ b/docs/content/files/compose.nginx.yaml
@@ -11,7 +11,7 @@ services:
       - martin
 
   martin:
-    image: ghcr.io/maplibre/martin:1.13.0
+    image: ghcr.io/maplibre/martin:1.14.0
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgres://postgres:password@db/db

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.13.0 \
+           ghcr.io/maplibre/martin:1.14.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.13.0
+    image: ghcr.io/maplibre/martin:1.14.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.13.0
+  ghcr.io/maplibre/martin:1.14.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.13.0 \
+  ghcr.io/maplibre/martin:1.14.0 \
   /files
 ```
 
@@ -36,7 +36,7 @@ You can also pass any [CLI flags](run-with-cli.md) after the image name, for exa
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.13.0 \
+  ghcr.io/maplibre/martin:1.14.0 \
   --webui enable-for-all \
   /files
 ```
@@ -53,7 +53,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.13.0
+  ghcr.io/maplibre/martin:1.14.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -64,7 +64,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.13.0
+  ghcr.io/maplibre/martin:1.14.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -75,5 +75,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.13.0
+  ghcr.io/maplibre/martin:1.14.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -22,13 +22,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.13.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.14.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.13.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.14.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -347,7 +347,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.13.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.14.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/justfile
+++ b/justfile
@@ -396,7 +396,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.13.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.14.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-config-macros/CHANGELOG.md
+++ b/martin-config-macros/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/maplibre/martin/compare/martin-config-macros-v0.1.0...martin-config-macros-v0.1.1) - 2026-08-05
+
+### Other
+
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- *(config-macros)* cover the derive error paths and untested shapes ([#3092](https://github.com/maplibre/martin/pull/3092))

--- a/martin-config-macros/CHANGELOG.md
+++ b/martin-config-macros/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/maplibre/martin/compare/martin-config-macros-v0.1.0...martin-config-macros-v0.1.1) - 2026-08-17
+
+### Other
+
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- *(config-macros)* cover the derive error paths and untested shapes ([#3092](https://github.com/maplibre/martin/pull/3092))

--- a/martin-config-macros/Cargo.toml
+++ b/martin-config-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-config-macros"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Derive macros for MapLibre's Martin tile server configuration types."
 keywords = ["maps", "tiles", "tileserver", "proc-macro"]

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0](https://github.com/maplibre/martin/compare/martin-core-v0.10.0...martin-core-v0.11.0) - 2026-08-17
 
+### Security
+
+- **Repeated sprite ids let a single request amplify into unbounded rasterization work** ([GHSA-5x5g-6p4c-jqfh](https://github.com/maplibre/martin/security/advisories/GHSA-5x5g-6p4c-jqfh), medium severity). The sprite cache rasterized and cached one SVG per id in a request's id list, with no cap on id count and no deduplication, so repeating a single valid id let an unauthenticated client multiply rasterization work at a ratio of its own choosing. Fixed by capping ids per request, deduplicating before doing the work, normalizing the cache key, and bounding rasterization concurrency. Done in [#3123](https://github.com/maplibre/martin/pull/3123).
+
 ### Added
 
 - e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
 
 ### Fixed
 
-- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
 - *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
 
 ### Other

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/maplibre/martin/compare/martin-core-v0.10.0...martin-core-v0.11.0) - 2026-08-17
+
+### Added
+
+- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
+
+### Fixed
+
+- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
+- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
+
+### Other
+
+- move the remaining rendering tests to e2e and drop mitmproxy ([#3104](https://github.com/maplibre/martin/pull/3104))
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+
 ## [0.10.0](https://github.com/maplibre/martin/compare/martin-core-v0.9.0...martin-core-v0.10.0) - 2026-07-25
 
 ### Added

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/maplibre/martin/compare/martin-core-v0.10.0...martin-core-v0.11.0) - 2026-08-05
+
+### Added
+
+- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
+
+### Fixed
+
+- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
+
+### Other
+
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+
 ## [0.10.0](https://github.com/maplibre/martin/compare/martin-core-v0.9.0...martin-core-v0.10.0) - 2026-07-25
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0](https://github.com/maplibre/martin/compare/martin-v1.13.0...martin-v1.14.0) - 2026-08-17
+
+### Added
+
+- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
+
+### Fixed
+
+- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
+- *(deps)* update dependency lucide-react to v1.27.0 ([#3096](https://github.com/maplibre/martin/pull/3096))
+- *(deps)* update npm dependencies ([#3083](https://github.com/maplibre/martin/pull/3083))
+- install configuration in /etc for debian package ([#3078](https://github.com/maplibre/martin/pull/3078))
+- log the resolved listen address on startup ([#3053](https://github.com/maplibre/martin/pull/3053))
+- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
+
+### Other
+
+- *(deps)* Bump js-yaml from 4.2.0 to 4.3.1 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3110](https://github.com/maplibre/martin/pull/3110))
+- *(deps)* autoupdate pre-commit ([#3109](https://github.com/maplibre/martin/pull/3109))
+- replace Codecov with GitHub-native code coverage ([#3108](https://github.com/maplibre/martin/pull/3108))
+- move the remaining rendering tests to e2e and drop mitmproxy ([#3104](https://github.com/maplibre/martin/pull/3104))
+- migrate the COG source e2e tests to rust ([#3101](https://github.com/maplibre/martin/pull/3101))
+- *(deps-dev)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3100](https://github.com/maplibre/martin/pull/3100))
+- *(deps)* autoupdate pre-commit ([#3098](https://github.com/maplibre/martin/pull/3098))
+- *(deps-dev)* Bump brace-expansion from 2.1.1 to 2.1.4 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3099](https://github.com/maplibre/martin/pull/3099))
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- *(deps)* autoupdate pre-commit ([#3071](https://github.com/maplibre/martin/pull/3071))
+- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
+- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
+- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
+
 ## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25
 
 ### Passthrough sources: config-file wiring

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0](https://github.com/maplibre/martin/compare/martin-v1.13.0...martin-v1.14.0) - 2026-08-05
+
+### Added
+
+- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
+
+### Fixed
+
+- *(deps)* update dependency lucide-react to v1.27.0 ([#3096](https://github.com/maplibre/martin/pull/3096))
+- *(deps)* update npm dependencies ([#3083](https://github.com/maplibre/martin/pull/3083))
+- install configuration in /etc for debian package ([#3078](https://github.com/maplibre/martin/pull/3078))
+- log the resolved listen address on startup ([#3053](https://github.com/maplibre/martin/pull/3053))
+- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
+
+### Other
+
+- *(deps-dev)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3100](https://github.com/maplibre/martin/pull/3100))
+- *(deps)* autoupdate pre-commit ([#3098](https://github.com/maplibre/martin/pull/3098))
+- *(deps-dev)* Bump brace-expansion from 2.1.1 to 2.1.4 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3099](https://github.com/maplibre/martin/pull/3099))
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- *(deps)* autoupdate pre-commit ([#3071](https://github.com/maplibre/martin/pull/3071))
+- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
+- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
+- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
+
 ## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25
 
 ### Passthrough sources: config-file wiring

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,34 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.14.0](https://github.com/maplibre/martin/compare/martin-v1.13.0...martin-v1.14.0) - 2026-08-17
 
+### Security
+
+Two vulnerabilities reported through our security advisories are fixed in this release:
+
+- **Out-of-gamut CIE colors in the static-overlay body could permanently kill render workers** ([GHSA-6774-6cqw-f586](https://github.com/maplibre/martin/security/advisories/GHSA-6774-6cqw-f586), high severity, only affects deployments with the opt-in, Linux-only `rendering` feature enabled). An unauthenticated `POST /style/{id}/static/...` body could carry a CSS color such as `lab()` or `oklch()` whose channels `csscolorparser` does not clamp to `0..=1`. That out-of-gamut value reached an unchecked assertion deep in the renderer, permanently killing one of martin's 2-8 render workers per request; a handful of ~180-byte requests could disable static rendering for the life of the process. Fixed by clamping colors to the valid gamut before they reach the renderer. Done in [#3124](https://github.com/maplibre/martin/pull/3124).
+- **Repeated sprite ids let a single request amplify into unbounded rasterization work** ([GHSA-5x5g-6p4c-jqfh](https://github.com/maplibre/martin/security/advisories/GHSA-5x5g-6p4c-jqfh), medium severity). `/sprite/{ids}.png` rasterized and cached one SVG per id in the comma-separated id list, with no cap on id count and no deduplication, so repeating a single valid id let an unauthenticated client multiply server work at a ratio of its own choosing. Fixed by capping ids per request, deduplicating before doing the work, and bounding rasterization concurrency. Done in [#3123](https://github.com/maplibre/martin/pull/3123).
+
 ### Added
 
 - e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))
 
 ### Fixed
 
-- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
-- *(deps)* update dependency lucide-react to v1.27.0 ([#3096](https://github.com/maplibre/martin/pull/3096))
-- *(deps)* update npm dependencies ([#3083](https://github.com/maplibre/martin/pull/3083))
 - install configuration in /etc for debian package ([#3078](https://github.com/maplibre/martin/pull/3078))
 - log the resolved listen address on startup ([#3053](https://github.com/maplibre/martin/pull/3053))
 - *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))
 
 ### Other
 
-- *(deps)* Bump js-yaml from 4.2.0 to 4.3.1 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3110](https://github.com/maplibre/martin/pull/3110))
-- *(deps)* autoupdate pre-commit ([#3109](https://github.com/maplibre/martin/pull/3109))
+- migrated the COG source, MBTiles pack/unpack, and the remaining rendering e2e tests to Rust, dropping mitmproxy in the process ([#3104](https://github.com/maplibre/martin/pull/3104), [#3101](https://github.com/maplibre/martin/pull/3101), [#3064](https://github.com/maplibre/martin/pull/3064))
 - replace Codecov with GitHub-native code coverage ([#3108](https://github.com/maplibre/martin/pull/3108))
-- move the remaining rendering tests to e2e and drop mitmproxy ([#3104](https://github.com/maplibre/martin/pull/3104))
-- migrate the COG source e2e tests to rust ([#3101](https://github.com/maplibre/martin/pull/3101))
-- *(deps-dev)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3100](https://github.com/maplibre/martin/pull/3100))
-- *(deps)* autoupdate pre-commit ([#3098](https://github.com/maplibre/martin/pull/3098))
-- *(deps-dev)* Bump brace-expansion from 2.1.1 to 2.1.4 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3099](https://github.com/maplibre/martin/pull/3099))
 - enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
-- *(deps)* autoupdate pre-commit ([#3071](https://github.com/maplibre/martin/pull/3071))
 - Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
+- *(deps)* update dependency lucide-react to v1.27.0 ([#3096](https://github.com/maplibre/martin/pull/3096))
+- *(deps)* update npm dependencies ([#3083](https://github.com/maplibre/martin/pull/3083))
 - *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
-- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
+- *(deps)* dependency bumps and pre-commit autoupdates ([#3110](https://github.com/maplibre/martin/pull/3110), [#3109](https://github.com/maplibre/martin/pull/3109), [#3100](https://github.com/maplibre/martin/pull/3100), [#3099](https://github.com/maplibre/martin/pull/3099), [#3098](https://github.com/maplibre/martin/pull/3098), [#3071](https://github.com/maplibre/martin/pull/3071))
 
 ## [1.13.0](https://github.com/maplibre/martin/compare/martin-v1.12.0...martin-v1.13.0) - 2026-07-25
 

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.13.0"
+version = "1.14.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.8.2",
         "@radix-ui/react-dialog": "1.1.23",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.13.0"
+  "version": "1.14.0"
 }

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/maplibre/martin/compare/mbtiles-v0.19.0...mbtiles-v0.19.1) - 2026-08-05
+
+### Other
+
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
+- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
+- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
+
 ## [0.19.0](https://github.com/maplibre/martin/compare/mbtiles-v0.18.1...mbtiles-v0.19.0) - 2026-07-25
 
 ### Added

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/maplibre/martin/compare/mbtiles-v0.19.0...mbtiles-v0.19.1) - 2026-08-17
+
+### Other
+
+- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
+- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
+- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
+- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
+
 ## [0.19.0](https://github.com/maplibre/martin/compare/mbtiles-v0.18.1...mbtiles-v0.19.0) - 2026-07-25
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-config-macros`: 0.1.0 -> 0.1.1
* `martin-tile-utils`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `mbtiles`: 0.19.0 -> 0.19.1 (✓ API compatible changes)
* `martin-core`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `martin`: 1.13.0 -> 1.14.0

### ⚠ `martin-core` breaking changes

```text
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant MbtilesError::AcquireConnError in /tmp/.tmpWeI5Dc/martin/martin-core/src/tiles/mbtiles/error.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `martin-config-macros`

<blockquote>

## [0.1.1](https://github.com/maplibre/martin/compare/martin-config-macros-v0.1.0...martin-config-macros-v0.1.1) - 2026-08-17

### Other

- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
- *(config-macros)* cover the derive error paths and untested shapes ([#3092](https://github.com/maplibre/martin/pull/3092))
</blockquote>


## `mbtiles`

<blockquote>

## [0.19.1](https://github.com/maplibre/martin/compare/mbtiles-v0.19.0...mbtiles-v0.19.1) - 2026-08-17

### Other

- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
</blockquote>

## `martin-core`

<blockquote>

## [0.11.0](https://github.com/maplibre/martin/compare/martin-core-v0.10.0...martin-core-v0.11.0) - 2026-08-17

### Added

- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))

### Fixed

- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))

### Other

- move the remaining rendering tests to e2e and drop mitmproxy ([#3104](https://github.com/maplibre/martin/pull/3104))
- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
</blockquote>

## `martin`

<blockquote>

## [1.14.0](https://github.com/maplibre/martin/compare/martin-v1.13.0...martin-v1.14.0) - 2026-08-17

### Added

- e2e local geoparquet wiring via duckdb ([#3054](https://github.com/maplibre/martin/pull/3054))

### Fixed

- *(sprites)* dedupe/cap sprite ids and bound rasterization concurrency ([#3123](https://github.com/maplibre/martin/pull/3123))
- *(deps)* update dependency lucide-react to v1.27.0 ([#3096](https://github.com/maplibre/martin/pull/3096))
- *(deps)* update npm dependencies ([#3083](https://github.com/maplibre/martin/pull/3083))
- install configuration in /etc for debian package ([#3078](https://github.com/maplibre/martin/pull/3078))
- log the resolved listen address on startup ([#3053](https://github.com/maplibre/martin/pull/3053))
- *(geojson)* advertise vector_layers in TileJSON ([#3082](https://github.com/maplibre/martin/pull/3082))

### Other

- *(deps)* Bump js-yaml from 4.2.0 to 4.3.1 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3110](https://github.com/maplibre/martin/pull/3110))
- *(deps)* autoupdate pre-commit ([#3109](https://github.com/maplibre/martin/pull/3109))
- replace Codecov with GitHub-native code coverage ([#3108](https://github.com/maplibre/martin/pull/3108))
- move the remaining rendering tests to e2e and drop mitmproxy ([#3104](https://github.com/maplibre/martin/pull/3104))
- migrate the COG source e2e tests to rust ([#3101](https://github.com/maplibre/martin/pull/3101))
- *(deps-dev)* Bump the npm_and_yarn group across 2 directories with 1 update ([#3100](https://github.com/maplibre/martin/pull/3100))
- *(deps)* autoupdate pre-commit ([#3098](https://github.com/maplibre/martin/pull/3098))
- *(deps-dev)* Bump brace-expansion from 2.1.1 to 2.1.4 in /martin/martin-ui in the npm_and_yarn group across 1 directory ([#3099](https://github.com/maplibre/martin/pull/3099))
- enable additional clippy restriction lints ([#3095](https://github.com/maplibre/martin/pull/3095))
- *(deps)* autoupdate pre-commit ([#3071](https://github.com/maplibre/martin/pull/3071))
- Change dynamic brotli encoding level from 11 to 4 ([#3061](https://github.com/maplibre/martin/pull/3061))
- *(deps)* Update hotpath and instrument decoders ([#3059](https://github.com/maplibre/martin/pull/3059))
- migrate the mbtiles pack/unpack e2e tests to rust ([#3064](https://github.com/maplibre/martin/pull/3064))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).