### PR TITLE
test: migrate the unrecognized config key e2e tests to rust

### DIFF
--- a/integration-tests/src/martin.rs
+++ b/integration-tests/src/martin.rs
@@ -368,20 +368,30 @@ impl Martin {
         self.log_lines = Some(lines);
     }
 
+    /// Remove every log line containing `needle` and return them in the order
+    /// martin logged them. Must be called after [`Martin::stop`].
+    pub fn take_log_lines(&mut self, needle: &str) -> Vec<String> {
+        self.collected_log()
+            .extract_if(.., |line| line.contains(needle))
+            .collect()
+    }
+
     /// Assert that at least one log line contains `needle`, and consume every
     /// matching line. Must be called after [`Martin::stop`].
     pub fn assert_log_contains(&mut self, needle: &str) {
-        let lines = self
-            .log_lines
-            .as_mut()
-            .expect("assert_log_contains must be called after stop()");
-        let before = lines.len();
-        lines.retain(|line| !line.contains(needle));
+        let taken = self.take_log_lines(needle);
         assert!(
-            lines.len() < before,
+            !taken.is_empty(),
             "log does not contain {needle:?}; log:\n{}",
-            lines.join("\n")
+            self.collected_log().join("\n")
         );
+    }
+
+    /// The log [`Martin::stop`] collected, which the assertions below consume from.
+    fn collected_log(&mut self) -> &mut Vec<String> {
+        self.log_lines
+            .as_mut()
+            .expect("log assertions must be called after stop()")
     }
 
     /// Assert the warnings a martin start that resolves pmtiles configuration emits under this
@@ -398,10 +408,7 @@ impl Martin {
     /// after [`ALLOWED_LOG_LINES`] and the lines already consumed by
     /// [`Martin::assert_log_contains`]. Must be called after [`Martin::stop`].
     pub fn assert_log_clean(&mut self) {
-        let lines = self
-            .log_lines
-            .as_mut()
-            .expect("assert_log_clean must be called after stop()");
+        let lines = self.collected_log();
         lines.retain(|line| {
             !ALLOWED_LOG_LINES
                 .iter()

--- a/integration-tests/tests/config_file.rs
+++ b/integration-tests/tests/config_file.rs
@@ -1,0 +1,292 @@
+//! Configuration file keys martin does not recognize.
+
+use std::fs;
+
+use martin_integration_tests::{Martin, MartinBuilder};
+use tempfile::TempDir;
+
+const PMTILES_SOURCE: &str = "
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+";
+
+/// Write `yaml` into a fresh temp dir and start `builder` on it.
+/// The dir is returned because it has to outlive the server.
+/// Relative paths in `yaml` resolve against the workspace root, martin's working directory here.
+async fn start_with_config(builder: MartinBuilder, yaml: &str) -> (TempDir, Martin) {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let path = dir.path().join("config.yaml");
+    fs::write(&path, yaml).expect("failed to write the config file");
+    let martin = builder
+        .arg("--config")
+        .arg(&path)
+        .start()
+        .await
+        .expect("failed to start martin");
+    (dir, martin)
+}
+
+/// The keys named by every `Ignoring unrecognized configuration key '<key>'` line, sorted.
+/// The lines are consumed, so [`Martin::assert_log_clean`] no longer sees them.
+fn unrecognized_keys(martin: &mut Martin) -> Vec<String> {
+    let mut keys = martin
+        .take_log_lines("Ignoring unrecognized configuration key")
+        .iter()
+        .map(|line| {
+            line.split('\'')
+                .nth(1)
+                .expect("the warning quotes the key it ignored")
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+#[tokio::test]
+async fn every_section_reports_its_unrecognized_keys_by_full_path() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder(),
+        "
+warning: 'unrecognized'
+observability:
+  warning: 'unrecognized'
+  metrics:
+    warning: 'unrecognized'
+cors:
+  warning: 'unrecognized'
+  origin: ['*']
+pmtiles:
+  warning: 'unrecognized'
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+mbtiles:
+  warning: 'unrecognized'
+geojson:
+  warning: 'unrecognized'
+sprites:
+  warning: 'unrecognized'
+  paths: tests/fixtures/sprites/src1
+styles:
+  warning: 'unrecognized'
+  sources:
+    maplibre: tests/fixtures/styles/maplibre_demo.json
+fonts:
+  warning: 'unrecognized'
+",
+    )
+    .await;
+
+    martin.stop().await;
+    insta::assert_snapshot!(unrecognized_keys(&mut martin).join("\n"), @r"
+    cors.warning
+    fonts.warning
+    geojson.warning
+    mbtiles.warning
+    observability.metrics.warning
+    observability.warning
+    pmtiles.warning
+    sprites.warning
+    styles.warning
+    warning
+    ");
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_unrecognized_key_does_not_stop_the_configured_sources_from_being_served() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder(),
+        "
+warning: 'unrecognized'
+pmtiles:
+  warning: 'unrecognized'
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+",
+    )
+    .await;
+
+    assert_eq!(martin.get("/health").await.status(), 200);
+    assert!(
+        martin.get("/catalog").await.json()["tiles"]
+            .get("pmt")
+            .is_some(),
+        "the source next to the unrecognized keys must still be published"
+    );
+    let tile = martin.get("/pmt/0/0/0").await;
+    assert_eq!(tile.status(), 200);
+    assert!(
+        tile.body().starts_with(b"\x89PNG"),
+        "expected a png tile body"
+    );
+
+    martin.stop().await;
+    assert_eq!(
+        unrecognized_keys(&mut martin),
+        ["pmtiles.warning", "warning"]
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn the_cog_section_is_reported_in_builds_with_and_without_unstable_cog() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder(),
+        &format!(
+            "
+cog:
+  warning: 'unrecognized'
+{PMTILES_SOURCE}"
+        ),
+    )
+    .await;
+
+    martin.stop().await;
+    let keys = unrecognized_keys(&mut martin);
+    assert!(
+        keys == ["cog"] || keys == ["cog.warning"],
+        "expected the whole section without unstable-cog, or just the key with it, got {keys:?}"
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_object_store_option_is_reported_when_its_value_is_not_a_scalar() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder(),
+        "
+pmtiles:
+  connect_timeout: 5s
+  timeout:
+    nested: 1
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+",
+    )
+    .await;
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        r#"Ignoring unrecognized configuration key 'pmtiles.timeout': Object {"nested": Number(1)}. Only boolean, string or number values are allowed here."#,
+    );
+    assert_eq!(
+        unrecognized_keys(&mut martin),
+        Vec::<String>::new(),
+        "`connect_timeout` names the same object store option set, so its scalar value is accepted"
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn unrecognized_keys_are_left_out_of_the_saved_config() {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let save_config = dir.path().join("save_config.yaml");
+    let (_config_dir, mut martin) = start_with_config(
+        Martin::builder().arg("--save-config").arg(&save_config),
+        "
+warning: 'unrecognized'
+pmtiles:
+  warning: 'unrecognized'
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+",
+    )
+    .await;
+
+    let saved = fs::read_to_string(&save_config).expect("martin did not write --save-config");
+    insta::assert_snapshot!(saved, @r"
+    listen_addresses: 127.0.0.1:0
+    pmtiles:
+      sources:
+        pmt: tests/fixtures/pmtiles/png.pmtiles
+    ");
+
+    martin.stop().await;
+    assert_eq!(
+        unrecognized_keys(&mut martin),
+        ["pmtiles.warning", "warning"]
+    );
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[cfg(feature = "test-pg")]
+#[tokio::test]
+async fn the_postgres_section_reports_its_unrecognized_keys_per_source() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder().with_postgres(),
+        "
+postgres:
+  warning: 'unrecognized'
+  connection_string: ${DATABASE_URL}
+  pool_size: 1
+  tables:
+    points1:
+      warning: 'unrecognized'
+      schema: public
+      table: points1
+      srid: 4326
+      geometry_column: geom
+      geometry_type: POINT
+      properties:
+        gid: int4
+  functions:
+    function_zxy_query:
+      warning: 'unrecognized'
+      schema: public
+      function: function_zxy_query
+",
+    )
+    .await;
+
+    martin.stop().await;
+    insta::assert_snapshot!(unrecognized_keys(&mut martin).join("\n"), @r"
+    postgres.functions.function_zxy_query.warning
+    postgres.tables.points1.warning
+    postgres.warning
+    ");
+    martin.assert_log_clean();
+}
+
+#[cfg(feature = "test-pg")]
+#[tokio::test]
+async fn the_postgres_auto_publish_section_reports_its_unrecognized_keys() {
+    let (_dir, mut martin) = start_with_config(
+        Martin::builder().with_postgres(),
+        "
+postgres:
+  connection_string: ${DATABASE_URL}
+  pool_size: 1
+  auto_publish:
+    warning: 'unrecognized'
+    tables:
+      warning: 'unrecognized'
+      from_schemas: MixedCase
+    functions:
+      warning: 'unrecognized'
+      from_schemas: MixedCase
+",
+    )
+    .await;
+
+    martin.stop().await;
+    insta::assert_snapshot!(unrecognized_keys(&mut martin).join("\n"), @r"
+    postgres.auto_publish.functions.warning
+    postgres.auto_publish.tables.warning
+    postgres.auto_publish.warning
+    ");
+    for unindexed in [
+        "Table public.mat_view has no spatial index on column geom",
+        "Table public.table_source has no spatial index on column geom",
+        "Table public.table_source_geog has no spatial index on column geog",
+    ] {
+        martin.assert_log_contains(unindexed);
+    }
+    martin.assert_log_clean();
+}

--- a/justfile
+++ b/justfile
@@ -652,7 +652,7 @@ test-e2e *args: fetch
 # Run the end-to-end tests that need the PostgreSQL database
 test-e2e-pg *args: fetch start
     cargo build --package martin --package mbtiles
-    cargo test --package martin-integration-tests --features test-pg --test martin_cp --test postgres --test process {{args}}
+    cargo test --package martin-integration-tests --features test-pg --test config_file --test martin_cp --test postgres --test process {{args}}
 
 # Run Rust doc tests
 test-doc *args: fetch

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,5 +1,4 @@
 ---
-warning: 'due to not expected'
 # Connection keep alive timeout [default: 75]
 keep_alive: 75
 
@@ -19,10 +18,8 @@ cache:
 
 # Advanced monitoring options
 observability:
-  warning: 'due to not expected'
   # Configure metrics reported under `/_/metrics`
   metrics:
-    warning: 'due to not expected'
     # Add these labels to every metric
     # Example: `{ env: prod, server: martin }`
     add_labels: {}
@@ -32,7 +29,6 @@ observability:
 # Defaults to `cors: true`, which allows all origins.
 # Sending/Acting on CORS headers can be completely disabled via `cors: false`
 cors:
-  warning: 'due to not expected'
   # Sets the `Access-Control-Allow-Origin` header [default: *]
   # '*' will use the requests `ORIGIN` header
   origin:
@@ -43,7 +39,6 @@ cors:
 
 # Database configuration. This can also be a list of PG configs.
 postgres:
-  warning: 'due to not expected'
   # Database connection string
   connection_string: ${DATABASE_URL:-postgres://postgres@localhost:5432/db}
 
@@ -54,22 +49,18 @@ postgres:
   pool_size: 20
 
   auto_publish:
-    warning: 'due to not expected'
     tables:
-      warning: 'due to not expected'
       from_schemas: autodetect
       id_columns: [feat_id, big_feat_id]
       clip_geom: false
       buffer: 3
       extent: 9000
     functions:
-      warning: 'due to not expected'
       from_schemas: MixedCase # function is function_Mixed_Namen
 
   # Associative arrays of table sources
   tables:
     table_source:
-      warning: 'due to not expected'
       # Table schema (required)
       schema: public
 
@@ -180,7 +171,6 @@ postgres:
   # Associative arrays of function sources
   functions:
     function_zxy_query:
-      warning: 'due to not expected'
       # Schema name (required)
       schema: public
 
@@ -208,7 +198,6 @@ postgres:
 
 
 pmtiles:
-  warning: 'due to not expected'
   paths:
     - http://localhost:5412/webp2.pmtiles
   sources:
@@ -220,32 +209,21 @@ pmtiles:
     pmt2: http://localhost:5412/webp2.pmtiles
 
 sprites:
-  warning: 'due to not expected'
   paths: tests/fixtures/sprites/src1
   sources:
     mysrc: tests/fixtures/sprites/src2
-
-cog:
-  warning: 'due to not expected'
-  paths:
-    - tests/fixtures/cog/rgba_u8_nodata.tiff
-  sources:
-    cog-src1: tests/fixtures/cog/rgba_u8.tif
-    cog-src2: tests/fixtures/cog/rgb_u8.tif
 
 fonts:
   - tests/fixtures/fonts/overpass-mono-regular.ttf
   - tests/fixtures/fonts
 
 styles:
-  warning: 'due to not expected'
   rendering: true
   sources:
     maplibre: tests/fixtures/styles/maplibre_demo.json
   paths:
     - tests/fixtures/styles/src2
 
-geojson:
-  warning: 'due to not expected'
+geojson: {}
 
 tilejson_url_version_param: version

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -443,22 +443,6 @@ test_log_has_str "$LOG_FILE" 'Table public.table_source has no spatial index on 
 test_log_has_str "$LOG_FILE" 'Table public.table_source_geog has no spatial index on column geog'
 test_log_has_str "$LOG_FILE" 'Table public.mat_view has no spatial index on column geom'
 test_log_has_str "$LOG_FILE" 'Ignoring duplicate font: already configured from another path.*font.name=Overpass Mono Regular'
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'observability.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'observability.metrics.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'cors.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.auto_publish.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.auto_publish.tables.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.auto_publish.functions.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.tables.table_source.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'postgres.functions.function_zxy_query.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'pmtiles.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'sprites.warning'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'geojson.warning'. Please check your configuration file for typos."
-# TODO: below should be changed to cog.warning once unstable-cog is made stable
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'cog'. Please check your configuration file for typos."
-test_log_has_str "$LOG_FILE" "Ignoring unrecognized configuration key 'styles.warning'. Please check your configuration file for typos."
 # rendering: true produces different warnings depending on whether the rendering feature is compiled in
 if [[ "$RENDERING_AVAILABLE" == "1" ]]; then
   test_log_has_str "$LOG_FILE" 'experimental feature rendering is enabled'


### PR DESCRIPTION
Ports the 15 `Ignoring unrecognized configuration key` log assertions out of `tests/test.sh` into a new `integration-tests/tests/config_file.rs`.