### PR TITLE
ci: scope PR-event concurrency groups to the PR number

### DIFF
--- a/.github/workflows/pr-relabeling.yml
+++ b/.github/workflows/pr-relabeling.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 permissions: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
`pull_request_target` resolves `github.ref` to the base branch, so all PRs shared one concurrency group and cancelled each other's title check.