### PR TITLE
chore(ci): sync the martin image tag in every docs file, not a hardcoded list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,13 +86,8 @@ repos:
           bash -c '
             VERSION=$(grep "^version = " martin/Cargo.toml | sed "s/version = \"\(.*\)\"/\1/")
             sed -i "s/version\": \".*\"/version\": \"$VERSION\"/" martin/martin-ui/package.json
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/content/run-with-docker-compose.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/content/run-with-nginx.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" docs/content/run-with-docker.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/content/installation.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" docs/content/run-with-lambda.md
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]* %ghcr.io/maplibre/martin:$VERSION %" justfile
-            sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%" demo/docker-compose.yml
+            grep -rl "ghcr.io/maplibre/martin:" docs demo justfile \
+              | xargs -r sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%"
             echo "Synced version to $VERSION"
           '
         language: system

--- a/docs/content/files/compose.nginx.yaml
+++ b/docs/content/files/compose.nginx.yaml
@@ -11,7 +11,7 @@ services:
       - martin
 
   martin:
-    image: ghcr.io/maplibre/martin:1.12.0
+    image: ghcr.io/maplibre/martin:1.13.0
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgres://postgres:password@db/db


### PR DESCRIPTION
The extracted `docs/content/files/compose.nginx.yaml` was missed by the hardcoded path list, so renovate kept bumping it by hand.