### PR TITLE
test(config-macros): cover the derive error paths and untested shapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,6 +5196,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rstest",
  "serde",
  "syn 2.0.119",
 ]

--- a/martin-config-macros/Cargo.toml
+++ b/martin-config-macros/Cargo.toml
@@ -20,6 +20,7 @@ quote.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
+rstest.workspace = true
 serde.workspace = true
 
 [lints]

--- a/martin-config-macros/src/lib.rs
+++ b/martin-config-macros/src/lib.rs
@@ -230,3 +230,104 @@ fn container_rename_all(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use syn::parse::Parser as _;
+    use syn::{DeriveInput, Field};
+
+    use crate::{expand, serde_field_name, serde_flag_is_set};
+
+    fn parse_field(src: &str) -> Field {
+        Field::parse_named.parse_str(src).expect("field parses")
+    }
+
+    #[rstest]
+    #[case::rename_all_on_struct(
+        r#"#[serde(rename_all = "kebab-case")] struct S { a: bool }"#,
+        "does not support `#[serde(rename_all)]`"
+    )]
+    #[case::rename_all_on_enum(
+        r#"#[serde(rename_all = "kebab-case")] enum E { A }"#,
+        "does not support `#[serde(rename_all)]`"
+    )]
+    #[case::rename_all_beside_other_options(
+        r#"#[serde(deny_unknown_fields, rename_all = "kebab-case")] struct S { a: bool }"#,
+        "does not support `#[serde(rename_all)]`"
+    )]
+    #[case::rename_all_in_a_second_attribute(
+        r#"#[serde(default)] #[serde(rename_all = "kebab-case")] struct S { a: bool }"#,
+        "does not support `#[serde(rename_all)]`"
+    )]
+    #[case::union("union U { a: bool }", "cannot be derived for unions")]
+    #[case::tuple_struct("struct S(bool);", "cannot be derived for tuple structs")]
+    #[case::newtype_struct("struct S(Inner);", "cannot be derived for tuple structs")]
+    fn expand_rejects(#[case] src: &str, #[case] expected: &str) {
+        let input: DeriveInput = syn::parse_str(src).expect("input parses");
+        let err = expand(&input).expect_err("input is rejected").to_string();
+        assert!(err.contains(expected), "unexpected error: {err}");
+    }
+
+    #[rstest]
+    #[case::unit_struct("struct S;")]
+    #[case::empty_struct("struct S {}")]
+    #[case::rename_all_fields_is_a_different_option(
+        r#"#[serde(rename_all_fields = "kebab-case")] enum E { A { b: bool } }"#
+    )]
+    #[case::rename_all_on_a_variant(
+        r#"enum E { #[serde(rename_all = "kebab-case")] A { b: bool } }"#
+    )]
+    #[case::non_serde_rename_all(r#"#[schemars(rename_all = "kebab-case")] struct S { a: bool }"#)]
+    fn expand_accepts(#[case] src: &str) {
+        let input: DeriveInput = syn::parse_str(src).expect("input parses");
+        expand(&input).expect("input is accepted");
+    }
+
+    #[rstest]
+    #[case::no_attributes("a: bool", "a")]
+    #[case::rename(r#"#[serde(rename = "renamed")] a: bool"#, "renamed")]
+    #[case::rename_after_a_valued_option(
+        r#"#[serde(default = "d", rename = "renamed")] a: bool"#,
+        "renamed"
+    )]
+    #[case::rename_after_a_bare_flag(r#"#[serde(default, rename = "renamed")] a: bool"#, "renamed")]
+    #[case::rename_in_a_second_attribute(
+        r#"#[serde(default)] #[serde(rename = "renamed")] a: bool"#,
+        "renamed"
+    )]
+    #[case::rename_without_a_value("#[serde(rename)] a: bool", "a")]
+    #[case::rename_with_a_non_string_value("#[serde(rename = 7)] a: bool", "a")]
+    #[case::other_namespace(r#"#[schemars(rename = "renamed")] a: bool"#, "a")]
+    #[case::unrelated_option(r#"#[serde(alias = "renamed")] a: bool"#, "a")]
+    fn field_name(#[case] src: &str, #[case] expected: &str) {
+        let field = parse_field(src);
+        let ident = field.ident.clone().expect("field is named");
+        assert_eq!(serde_field_name(&field, &ident), expected);
+    }
+
+    #[rstest]
+    #[case::bare_flag("#[serde(flatten)] a: bool", "flatten", true)]
+    #[case::flag_after_a_valued_option(
+        r#"#[serde(default = "d", flatten)] a: bool"#,
+        "flatten",
+        true
+    )]
+    #[case::flag_before_a_valued_option(
+        r#"#[serde(flatten, default = "d")] a: bool"#,
+        "flatten",
+        true
+    )]
+    #[case::flag_in_a_second_attribute("#[serde(default)] #[serde(skip)] a: bool", "skip", true)]
+    #[case::absent("#[serde(default)] a: bool", "flatten", false)]
+    #[case::prefix_of_another_option(
+        r#"#[serde(skip_serializing_if = "f")] a: bool"#,
+        "skip",
+        false
+    )]
+    #[case::other_namespace("#[schemars(flatten)] a: bool", "flatten", false)]
+    #[case::no_attributes("a: bool", "flatten", false)]
+    fn flag_is_set(#[case] src: &str, #[case] name: &str, #[case] expected: bool) {
+        assert_eq!(serde_flag_is_set(&parse_field(src).attrs, name), expected);
+    }
+}

--- a/martin-config-macros/tests/derive.rs
+++ b/martin-config-macros/tests/derive.rs
@@ -1,5 +1,5 @@
-use config::file::{Bag, CollectUnrecognizedKeys};
-use martin_config_macros::CollectUnrecognizedKeys;
+use config::file::{Bag, CollectUnrecognizedKeys, ConfigurationLivecycleHooks as _};
+use martin_config_macros::{CollectUnrecognizedKeys, ConfigurationLivecycleHooks};
 use serde::Deserialize;
 
 mod config {
@@ -14,6 +14,12 @@ mod config {
                 let mut out = UnrecognizedKeys::new();
                 self.collect_unrecognized("", &mut out);
                 out
+            }
+        }
+
+        pub trait ConfigurationLivecycleHooks: CollectUnrecognizedKeys {
+            fn finalize(&mut self) -> Result<(), String> {
+                Ok(())
             }
         }
 
@@ -47,6 +53,12 @@ mod config {
                 }
             }
         }
+
+        impl<T: CollectUnrecognizedKeys + ?Sized> CollectUnrecognizedKeys for &T {
+            fn collect_unrecognized(&self, path: &str, out: &mut UnrecognizedKeys) {
+                (**self).collect_unrecognized(path, out);
+            }
+        }
     }
 }
 
@@ -60,7 +72,7 @@ fn keys(value: &impl CollectUnrecognizedKeys) -> Vec<String> {
     keys
 }
 
-#[derive(Deserialize, CollectUnrecognizedKeys)]
+#[derive(Default, Deserialize, CollectUnrecognizedKeys)]
 struct Inner {
     known: bool,
     #[serde(flatten)]
@@ -152,14 +164,137 @@ fn rename_sets_the_segment() {
     );
 }
 
+#[derive(Deserialize, CollectUnrecognizedKeys)]
+struct WithRenameBesideOtherOptions {
+    #[serde(default, rename = "renamed")]
+    child: Inner,
+}
+
+#[test]
+fn rename_is_found_beside_other_serde_options() {
+    assert_eq!(
+        keys(&WithRenameBesideOtherOptions {
+            child: inner(&["typo"])
+        }),
+        ["renamed.typo"]
+    );
+}
+
 #[derive(CollectUnrecognizedKeys)]
 enum Variants {
     Empty,
     Wrapped(Inner),
+    Pair(Inner, Inner),
+    Shaped { first: Inner, second: Inner },
 }
 
 #[test]
 fn enum_dispatches_to_active_variant() {
     assert!(keys(&Variants::Empty).is_empty());
     assert_eq!(keys(&Variants::Wrapped(inner(&["typo"]))), ["typo"]);
+}
+
+#[test]
+fn enum_tuple_variant_recurses_into_every_field() {
+    let value = Variants::Pair(inner(&["a"]), inner(&["b"]));
+    assert_eq!(keys(&value), ["a", "b"]);
+}
+
+#[test]
+fn enum_struct_variant_adds_a_segment_per_field() {
+    let value = Variants::Shaped {
+        first: inner(&["a"]),
+        second: inner(&["b"]),
+    };
+    assert_eq!(keys(&value), ["first.a", "second.b"]);
+}
+
+#[derive(CollectUnrecognizedKeys)]
+struct UnitStruct;
+
+#[test]
+fn unit_structs_collect_nothing() {
+    assert!(keys(&UnitStruct).is_empty());
+}
+
+#[derive(CollectUnrecognizedKeys)]
+struct Generic<T> {
+    inner: T,
+}
+
+#[test]
+fn generic_parameters_gain_a_trait_bound() {
+    assert_eq!(
+        keys(&Generic {
+            inner: inner(&["typo"])
+        }),
+        ["inner.typo"]
+    );
+}
+
+#[derive(CollectUnrecognizedKeys)]
+struct WithWhereClause<T>
+where
+    T: Default,
+{
+    inner: T,
+}
+
+#[test]
+fn where_clauses_are_preserved() {
+    let value = WithWhereClause {
+        inner: bag(&["typo"]),
+    };
+    assert_eq!(keys(&value), ["inner.typo"]);
+}
+
+#[derive(CollectUnrecognizedKeys)]
+struct WithConstGeneric<const N: usize> {
+    child: Inner,
+}
+
+#[test]
+fn const_generics_are_left_unbounded() {
+    let value: WithConstGeneric<3> = WithConstGeneric {
+        child: inner(&["typo"]),
+    };
+    assert_eq!(keys(&value), ["child.typo"]);
+}
+
+#[derive(CollectUnrecognizedKeys)]
+struct WithLifetime<'a> {
+    child: &'a Inner,
+}
+
+#[test]
+fn lifetimes_are_preserved() {
+    let child = inner(&["typo"]);
+    assert_eq!(keys(&WithLifetime { child: &child }), ["child.typo"]);
+}
+
+#[derive(CollectUnrecognizedKeys, ConfigurationLivecycleHooks)]
+struct Hooked {
+    child: Inner,
+}
+
+#[test]
+fn livecycle_hooks_derive_opts_into_the_default_finalize() {
+    let mut value = Hooked {
+        child: inner(&["typo"]),
+    };
+    assert_eq!(value.finalize(), Ok(()));
+    assert_eq!(keys(&value), ["child.typo"]);
+}
+
+#[derive(CollectUnrecognizedKeys, ConfigurationLivecycleHooks)]
+struct HookedGeneric<T: CollectUnrecognizedKeys> {
+    inner: T,
+}
+
+#[test]
+fn livecycle_hooks_derive_carries_generics_over() {
+    let mut value = HookedGeneric {
+        inner: inner(&["typo"]),
+    };
+    assert_eq!(value.finalize(), Ok(()));
 }


### PR DESCRIPTION
Adds unit tests for the rejected-input paths in `martin-config-macros` and integration tests for the derive shapes that had no coverage.