### PR TITLE
test: migrate the COG source e2e tests to rust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,7 +34,6 @@ coverage
 pg_data/
 target/
 test_log*
-tests/mbtiles_temp_files/
 tests/output/
 tmp/
 tsconfig.tsbuildinfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,21 @@ jobs:
       - name: Run cargo test
         run: just test-packages-ci
       - run: just test-doc
+  test-cog:
+    name: COG GeoTIFF tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs:
+      - lint-rust
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false }
+      - uses: ./.github/actions/setup-rust
+        with: { cache: true }
+      - name: Run COG tests
+        run: just test-cog
   test-duckdb:
     name: DuckDB GeoParquet tests
     permissions:
@@ -997,6 +1012,7 @@ jobs:
       - check-features
       - lint-rust-dependencies
       - unit-test-rust
+      - test-cog
       - unit-test-svc-pg
       - unit-test-svc-minio
       - test-multi-os

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ coverage
 pg_data/
 target/
 test_log*
-tests/mbtiles_temp_files/
 tests/output/
 tmp/
 tsconfig.tsbuildinfo

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
+test-cog = []
 test-duckdb = []
 test-pg = []
 

--- a/integration-tests/src/martin.rs
+++ b/integration-tests/src/martin.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use brotli::Decompressor;
 use flate2::read::GzDecoder;
-use image::ImageReader;
+use image::{ImageFormat, ImageReader};
 use mlt_core::fast_mvt::{MvtReaderRef, MvtTile};
 use mlt_core::{Decoder, Layer, Parser, TileLayer};
 use regex::Regex;
@@ -582,11 +582,23 @@ impl TestResponse {
     /// PNG, JPEG or WebP whatever the `content-type` header says.
     #[must_use]
     pub fn image_size(&self) -> (u32, u32) {
+        self.image_reader()
+            .into_dimensions()
+            .expect("response body is not a raster image")
+    }
+
+    /// Format the decompressed response body is encoded in, read out of the bytes themselves.
+    #[must_use]
+    pub fn image_format(&self) -> ImageFormat {
+        self.image_reader()
+            .format()
+            .expect("response body is not a raster image")
+    }
+
+    fn image_reader(&self) -> ImageReader<Cursor<&Vec<u8>>> {
         ImageReader::new(Cursor::new(&self.body))
             .with_guessed_format()
             .expect("reading from memory cannot fail")
-            .into_dimensions()
-            .expect("response body is not a raster image")
     }
 
     /// Headers as sorted `name: value` lines with nondeterministic headers

--- a/integration-tests/tests/cog.rs
+++ b/integration-tests/tests/cog.rs
@@ -1,0 +1,366 @@
+//! COG (`Cloud Optimized GeoTIFF`) sources: discovered in a directory, configured by id, and
+//! reloaded while the server runs.
+//!
+//! Binary has to be built with `unstable-cog`.
+
+#![cfg(feature = "test-cog")]
+
+use std::fs;
+
+use image::ImageFormat;
+use martin_integration_tests::{Martin, WatchedDir, fixture};
+use rstest::rstest;
+use serde_json::{Number, Value};
+
+async fn martin_with_the_cog_dir() -> Martin {
+    Martin::builder()
+        .arg("tests/fixtures/cog")
+        .start()
+        .await
+        .expect("failed to start martin")
+}
+
+/// The tilejson of `id`, with the server address redacted and every float rounded to ten digits,
+/// which is as far as the extent arithmetic agrees across platforms.
+async fn tilejson(martin: &Martin, id: &str) -> Value {
+    let response = martin.get(&format!("/{id}")).await;
+    assert_eq!(response.status(), 200);
+    let mut tilejson = serde_json::from_str::<Value>(&martin.redact(&response.text()))
+        .expect("tilejson is not valid json");
+    round_floats(&mut tilejson);
+    tilejson
+}
+
+fn round_floats(value: &mut Value) {
+    match value {
+        Value::Number(number) if number.is_f64() => {
+            let float = number.as_f64().expect("a f64 number");
+            *number = Number::from_f64((float * 1e10).round() / 1e10)
+                .expect("rounding keeps a finite float finite");
+        }
+        Value::Array(items) => items.iter_mut().for_each(round_floats),
+        Value::Object(entries) => entries.values_mut().for_each(round_floats),
+        _ => {}
+    }
+}
+
+#[tokio::test]
+async fn a_directory_publishes_a_source_per_file() {
+    let tmp = tempfile::tempdir().expect("failed to create a temp dir");
+    let save_config = tmp.path().join("save_config.yaml");
+    let mut martin = Martin::builder()
+        .arg("--save-config")
+        .arg(&save_config)
+        .arg("tests/fixtures/cog")
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let catalog = martin.get("/catalog").await;
+    assert_eq!(catalog.status(), 200);
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(catalog.json()["tiles"], @r#"
+        {
+          "usda_naip_128_none_z2": {
+            "content_type": "image/png"
+          },
+          "usda_naip_256_lzw_z3": {
+            "content_type": "image/png"
+          },
+          "usda_naip_512_deflate_z2": {
+            "content_type": "image/png"
+          },
+          "usda_naip_512_jpeg_z5": {
+            "content_type": "image/jpeg"
+          },
+          "usda_naip_512_webp_z5": {
+            "content_type": "image/webp"
+          }
+        }
+        "#);
+    });
+
+    let saved = fs::read_to_string(&save_config).expect("martin did not write --save-config");
+    insta::assert_snapshot!(saved, @r"
+    listen_addresses: 127.0.0.1:0
+    cog:
+      paths: tests/fixtures/cog
+      sources:
+        usda_naip_128_none_z2: tests/fixtures/cog/usda_naip_128_none_z2.tif
+        usda_naip_256_lzw_z3: tests/fixtures/cog/usda_naip_256_lzw_z3.tif
+        usda_naip_512_deflate_z2: tests/fixtures/cog/usda_naip_512_deflate_z2.tif
+        usda_naip_512_jpeg_z5: tests/fixtures/cog/usda_naip_512_jpeg_z5.tif
+        usda_naip_512_webp_z5: tests/fixtures/cog/usda_naip_512_webp_z5.tif
+    ");
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn a_file_is_published_under_its_stem() {
+    let mut martin = Martin::builder()
+        .arg(fixture("cog/usda_naip_512_webp_z5.tif"))
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["tiles"], @r#"
+    {
+      "usda_naip_512_webp_z5": {
+        "content_type": "image/webp"
+      }
+    }
+    "#);
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn a_configured_source_is_published_under_its_configured_id() {
+    let mut martin = Martin::builder()
+        .config(
+            "\
+cog:
+  sources:
+    naip: tests/fixtures/cog/usda_naip_512_webp_z5.tif
+",
+        )
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["tiles"], @r#"
+    {
+      "naip": {
+        "content_type": "image/webp"
+      }
+    }
+    "#);
+    assert_eq!(martin.get("/naip/13/1334/3042").await.status(), 200);
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::none_128("usda_naip_128_none_z2", 18, 19, 128, "png")]
+#[case::lzw_256("usda_naip_256_lzw_z3", 16, 18, 256, "png")]
+#[case::deflate_512("usda_naip_512_deflate_z2", 16, 17, 512, "png")]
+#[case::jpeg_512("usda_naip_512_jpeg_z5", 13, 17, 512, "jpeg")]
+#[case::webp_512("usda_naip_512_webp_z5", 13, 17, 512, "webp")]
+#[tokio::test]
+async fn the_tilejson_reports_the_zoom_range_each_overview_resolves_to(
+    #[case] id: &str,
+    #[case] minzoom: u8,
+    #[case] maxzoom: u8,
+    #[case] tile_size: u32,
+    #[case] format: &str,
+) {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    let tilejson = tilejson(&martin, id).await;
+    assert_eq!(tilejson["minzoom"], minzoom);
+    assert_eq!(tilejson["maxzoom"], maxzoom);
+    assert_eq!(tilejson["tileSize"], tile_size);
+    assert_eq!(tilejson["format"], format);
+    assert_eq!(
+        tilejson["tiles"][0],
+        Value::from(format!("http://[ADDR]/{id}/{{z}}/{{x}}/{{y}}"))
+    );
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn the_tilejson_bounds_are_the_area_the_image_covers() {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    insta::assert_json_snapshot!(tilejson(&martin, "usda_naip_512_webp_z5").await, @r#"
+    {
+      "bounds": [
+        -121.376953125,
+        41.9349765005,
+        -121.3330078125,
+        42.0003251483
+      ],
+      "center": [
+        -121.3549804687,
+        41.9676592037,
+        15
+      ],
+      "format": "webp",
+      "maxzoom": 17,
+      "minzoom": 13,
+      "tileSize": 512,
+      "tilejson": "3.0.0",
+      "tiles": [
+        "http://[ADDR]/usda_naip_512_webp_z5/{z}/{x}/{y}"
+      ]
+    }
+    "#);
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::none_128(
+    "usda_naip_128_none_z2/18/42712/97343",
+    "image/png",
+    ImageFormat::Png,
+    128
+)]
+#[case::lzw_256(
+    "usda_naip_256_lzw_z3/16/10677/24336",
+    "image/png",
+    ImageFormat::Png,
+    256
+)]
+#[case::deflate_512(
+    "usda_naip_512_deflate_z2/16/10677/24336",
+    "image/png",
+    ImageFormat::Png,
+    512
+)]
+#[case::jpeg_512(
+    "usda_naip_512_jpeg_z5/13/1334/3042",
+    "image/jpeg",
+    ImageFormat::Jpeg,
+    512
+)]
+#[case::webp_512(
+    "usda_naip_512_webp_z5/13/1334/3042",
+    "image/webp",
+    ImageFormat::WebP,
+    512
+)]
+#[tokio::test]
+async fn every_compression_serves_a_tile_of_the_images_own_format(
+    #[case] path: &str,
+    #[case] content_type: &str,
+    #[case] format: ImageFormat,
+    #[case] tile_size: u32,
+) {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    let tile = martin.get(&format!("/{path}")).await;
+    assert_eq!(tile.status(), 200);
+    assert_eq!(tile.header("content-type"), Some(content_type));
+    assert_eq!(tile.image_format(), format);
+    assert_eq!(tile.image_size(), (tile_size, tile_size));
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn the_shape_of_a_tile_response() {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    let tile = martin.get("/usda_naip_128_none_z2/18/42712/97343").await;
+    insta::assert_snapshot!(tile.headers_snapshot(), @r#"
+    content-length: 5286
+    content-type: image/png
+    etag: "2AVfi5bwOxse4moV0Fj1Aw"
+    vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+    "#);
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn a_tile_the_image_does_not_cover_is_empty() {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    let tile = martin.get("/usda_naip_128_none_z2/18/0/0").await;
+    assert_eq!(tile.status(), 204);
+    assert!(tile.body().is_empty(), "an empty tile has no body");
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[rstest]
+#[case::below_the_lowest_overview("12/667/1521")]
+#[case::above_the_full_resolution_image("18/42704/97344")]
+#[tokio::test]
+async fn a_zoom_no_overview_resolves_to_is_rejected(#[case] coordinates: &str) {
+    let mut martin = martin_with_the_cog_dir().await;
+
+    let tile = martin
+        .get(&format!("/usda_naip_512_jpeg_z5/{coordinates}"))
+        .await;
+    assert_eq!(tile.status(), 404);
+    let zoom = coordinates.split('/').next().expect("a zoom level");
+    let expected = format!(
+        "Zoom {zoom} is outside the supported range: usda_naip_512_jpeg_z5 supports zoom 13-17"
+    );
+    assert_eq!(tile.text(), expected);
+
+    martin.stop().await;
+    martin.assert_log_contains(&format!("ERROR error=\"{expected}\""));
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn reload_adds_updates_and_removes_a_source() {
+    let watched = WatchedDir::new();
+    let mut martin = Martin::builder()
+        .arg(watched.dir())
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    assert_eq!(
+        martin.get("/catalog").await.json()["tiles"],
+        serde_json::json!({})
+    );
+
+    watched.install(
+        fixture("cog/usda_naip_128_none_z2.tif"),
+        "usda_naip_128_none_z2.tif",
+    );
+    martin.wait_for_source("usda_naip_128_none_z2").await;
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["tiles"], @r#"
+    {
+      "usda_naip_128_none_z2": {
+        "content_type": "image/png"
+      }
+    }
+    "#);
+    assert_eq!(
+        martin
+            .get("/usda_naip_128_none_z2/18/42712/97343")
+            .await
+            .status(),
+        200
+    );
+
+    watched.touch("usda_naip_128_none_z2.tif");
+    martin
+        .wait_for_log("Updated source source.id=usda_naip_128_none_z2")
+        .await;
+
+    watched.remove("usda_naip_128_none_z2.tif");
+    martin
+        .wait_for_source_removed("usda_naip_128_none_z2")
+        .await;
+    assert_eq!(
+        martin
+            .get("/usda_naip_128_none_z2/18/42712/97343")
+            .await
+            .status(),
+        404
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains("Added source source.id=usda_naip_128_none_z2");
+    martin.assert_log_contains("Updated source source.id=usda_naip_128_none_z2");
+    martin.assert_log_contains("Removed source source.id=usda_naip_128_none_z2");
+    martin.assert_log_contains(r#"ERROR error="Source usda_naip_128_none_z2 does not exist""#);
+    martin.assert_log_clean();
+}

--- a/justfile
+++ b/justfile
@@ -614,6 +614,13 @@ test-pg: fetch start
 test-minio: fetch
     cargo test --features test-minio --no-default-features --test pmt_minio_test
 
+# Run COG/GeoTIFF tests only, including the end-to-end ones
+test-cog: fetch
+    cargo test -p martin --features unstable-cog --no-default-features --lib
+    cargo test -p martin-core --features unstable-cog --no-default-features --lib
+    cargo build --package martin --no-default-features --features unstable-cog
+    cargo test --package martin-integration-tests --features test-cog --test cog
+
 # Run DuckDB/GeoParquet tests only, including the end-to-end ones
 test-duckdb: fetch
     cargo test -p martin --features test-duckdb --no-default-features --lib

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -222,7 +222,12 @@ serde_with.workspace = true
 static-files = { workspace = true, optional = true }
 thiserror.workspace = true
 tilejson.workspace = true
-tokio = { workspace = true, features = ["io-std", "rt-multi-thread", "signal"] }
+tokio = { workspace = true, features = [
+    "fs",
+    "io-std",
+    "rt-multi-thread",
+    "signal",
+] }
 tracing.workspace = true
 tracing-actix-web.workspace = true
 tracing-indicatif.workspace = true

--- a/tests/expected/auto/save_config.yaml
+++ b/tests/expected/auto/save_config.yaml
@@ -390,7 +390,6 @@ pmtiles:
   paths:
   - tests/fixtures/mbtiles
   - tests/fixtures/pmtiles
-  - tests/fixtures/cog
   sources:
     png: tests/fixtures/pmtiles/png.pmtiles
     stamen_toner__raster_CC-BY-ODbL_z3: tests/fixtures/pmtiles/stamen_toner__raster_CC-BY+ODbL_z3.pmtiles
@@ -398,7 +397,6 @@ mbtiles:
   paths:
   - tests/fixtures/mbtiles
   - tests/fixtures/pmtiles
-  - tests/fixtures/cog
   sources:
     geography-class-jpg: tests/fixtures/mbtiles/geography-class-jpg.mbtiles
     geography-class-jpg-diff: tests/fixtures/mbtiles/geography-class-jpg-diff.mbtiles
@@ -418,7 +416,6 @@ mbtiles:
 geojson:
 - tests/fixtures/mbtiles
 - tests/fixtures/pmtiles
-- tests/fixtures/cog
 sprites: tests/fixtures/sprites/src1
 styles:
 - tests/fixtures/styles/maplibre_demo.json

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,10 +19,6 @@ TEST_OUT_BASE_DIR="$(dirname "$0")/output"
 LOG_DIR="${LOG_DIR:-target/test_logs}"
 mkdir -p "$LOG_DIR"
 
-TEST_TEMP_DIR="$(dirname "$0")/mbtiles_temp_files"
-rm -rf "$TEST_TEMP_DIR"
-mkdir -p "$TEST_TEMP_DIR"
-
 # Verify the tools used in the tests are available
 # todo add more verification for other tools like jq file curl sqlite3...
 if ! command -v mvt > /dev/null; then
@@ -146,22 +142,6 @@ test_mvt() {
   rm "$FILENAME"
 }
 
-test_png() {
-  # 3rd argument is optional, .png by default
-  FILENAME="$TEST_OUT_DIR/$1.${3:-png}"
-  URL="$MARTIN_URL/$2"
-
-  echo "Testing $(basename "$FILENAME") from $URL"
-  $CURL --dump-header  "$FILENAME.headers" "$URL" > "$FILENAME"
-  clean_headers_dump "$FILENAME.headers"
-
-  if [[ $OSTYPE == linux* || $OSTYPE == darwin* ]]; then
-    # some 'file' versions are more verbose, but CI is not
-    # we must reduce this to match their output
-    file "$FILENAME" | $SED 's#Web/P image, with alpha, 511+1x511+1#Web/P image#' > "$FILENAME.txt"
-  fi
-}
-
 # Delete line from a file $1 that matches parameter $2 and log the action
 remove_lines() {
   FILE="$1"
@@ -191,20 +171,6 @@ clean_headers_dump() {
   mv "$FILE.tmp" "$FILE"
   # we need to remove the first line as squeezing repeat newlines makes does not remove this empty line
   $SED --in-place '1d' "$FILE"
-}
-
-# Stage the fixture outside the watched directory and rename it in, so it appears atomically.
-# A plain `cp` writes in place, letting the reload watcher read a 0-byte file mid-copy.
-# Staging inside the watched directory is not enough either: the watcher still observes the
-# intermediate `.staging` file and warns when it is renamed away mid-scan.
-# The staging path is in the destination's parent directory, which shares its filesystem, so the
-# rename is atomic and the watcher only ever sees the finished file appear in one step.
-install_watched_fixture() {
-  SRC="$1"
-  DEST="$2"
-  STAGING="$(dirname "$DEST")/../$(basename "$DEST").staging"
-  cp "$SRC" "$STAGING"
-  mv "$STAGING" "$DEST"
 }
 
 test_log_has_str() {
@@ -238,35 +204,6 @@ validate_log() {
     echo "Log file $LOG_FILE has unexpected warnings or errors"
     exit 1
   fi
-}
-
-wait_for_catalog_source_removed() {
-  SOURCE_ID="$1"
-  echo "Waiting for source '$SOURCE_ID' to be removed from catalog..."
-  for _ in {1..30}; do
-    if ! $CURL "$MARTIN_URL/catalog" 2>/dev/null | jq -e --arg id "$SOURCE_ID" '.tiles | has($id)' > /dev/null 2>&1; then
-      echo "Source '$SOURCE_ID' has been removed from catalog."
-      return 0
-    fi
-    sleep 1
-  done
-  echo "ERROR: Source '$SOURCE_ID' was not removed from catalog within 30s"
-  exit 1
-}
-
-wait_for_log_str() {
-  WAIT_LOG_FILE="$1"
-  EXPECTED="$2"
-  echo "Waiting for '$EXPECTED' in $WAIT_LOG_FILE..."
-  for _ in {1..30}; do
-    if grep -q "$EXPECTED" "$WAIT_LOG_FILE" 2>/dev/null; then
-      echo "Found '$EXPECTED' in log."
-      return 0
-    fi
-    sleep 1
-  done
-  echo "ERROR: '$EXPECTED' not found in $WAIT_LOG_FILE within 30s"
-  exit 1
 }
 
 echo "::group::versions"
@@ -310,7 +247,7 @@ TEST_OUT_DIR="${TEST_OUT_BASE_DIR}/${TEST_NAME}"
 mkdir -p "$TEST_OUT_DIR"
 
 
-ARG=(--default-srid 900913 --auto-bounds calc --save-config "${TEST_OUT_DIR}/save_config.yaml" tests/fixtures/mbtiles tests/fixtures/pmtiles tests/fixtures/cog --sprite tests/fixtures/sprites/src1 --font tests/fixtures/fonts/overpass-mono-regular.ttf --font tests/fixtures/fonts --style tests/fixtures/styles/maplibre_demo.json --style tests/fixtures/styles/src2 --style tests/fixtures/styles/relative_urls.json --tilejson-url-version-param version )
+ARG=(--default-srid 900913 --auto-bounds calc --save-config "${TEST_OUT_DIR}/save_config.yaml" tests/fixtures/mbtiles tests/fixtures/pmtiles --sprite tests/fixtures/sprites/src1 --font tests/fixtures/fonts/overpass-mono-regular.ttf --font tests/fixtures/fonts --style tests/fixtures/styles/maplibre_demo.json --style tests/fixtures/styles/src2 --style tests/fixtures/styles/relative_urls.json --tilejson-url-version-param version )
 export DATABASE_URL="$MARTIN_DATABASE_URL"
 
 set -x
@@ -320,22 +257,6 @@ MARTIN_PROC_ID=$(jobs -p | tail -n 1)
 trap "echo 'Stopping Martin server $MARTIN_PROC_ID...'; kill -9 $MARTIN_PROC_ID 2> /dev/null || true; echo 'Stopped Martin server $MARTIN_PROC_ID';" EXIT HUP INT TERM
 wait_for "$MARTIN_PROC_ID" Martin "$MARTIN_URL/health"
 unset DATABASE_URL
-
-# TODO: enable below once unstable-cog is stable
-#>&2 echo "***** Test server response for COG(Cloud Optimized GeoTiff) source *****"
-#test_jsn rgb_u8       rgb_u8
-#test_png rgb_u8_0_0_0 rgb_u8/0/0/0
-#test_png rgb_u8_3_0_0 rgb_u8/3/0/0
-#test_png rgb_u8_3_1_1 rgb_u8/3/1/1
-
-#test_jsn rgba_u8       rgba_u8
-#test_png rgba_u8_0_0_0 rgba_u8/0/0/0
-#test_png rgba_u8_3_0_0 rgba_u8/3/0/0
-#test_png rgba_u8_3_1_1 rgba_u8/3/1/1
-
-#test_jsn rgba_u8_nodata       rgba_u8_nodata
-#test_png rgba_u8_nodata_0_0_0 rgba_u8_nodata/0/0/0
-#test_png rgba_u8_nodata_1_0_0 rgba_u8_nodata/1/0/0
 
 kill_process "$MARTIN_PROC_ID" Martin
 
@@ -441,69 +362,5 @@ for file in $(find ./tests/output/ ./tests/expected/ -name "*.json" -type f); do
     mv "$file.tmp" "$file"
 done
 echo "::endgroup::"
-
-# The COG reloader is only active when compiled with --features unstable-cog.
-# Detect this at runtime by copying a .tif file and checking whether it appears in the catalog.
-echo "::group::Test COG hot reload"
-TEST_NAME="cog_reload"
-LOG_FILE="${LOG_DIR}/${TEST_NAME}.txt"
-TEST_OUT_DIR="${TEST_OUT_BASE_DIR}/${TEST_NAME}"
-COG_RELOAD_WATCH_DIR="${TEST_TEMP_DIR}/cog_reload_watch"
-mkdir -p "$TEST_OUT_DIR" "$COG_RELOAD_WATCH_DIR"
-
-ARG=("$COG_RELOAD_WATCH_DIR")
-set -x
-$MARTIN_BIN "${ARG[@]}" 2>&1 | tee "$LOG_FILE" &
-MARTIN_PROC_ID=$(jobs -p | tail -n 1)
-{ set +x; } 2> /dev/null
-trap "echo 'Stopping Martin server $MARTIN_PROC_ID...'; kill -9 $MARTIN_PROC_ID 2> /dev/null || true; echo 'Stopped Martin server $MARTIN_PROC_ID';" EXIT HUP INT TERM
-wait_for "$MARTIN_PROC_ID" Martin "$MARTIN_URL/health"
-
-COG_SOURCE_ID="usda_naip_128_none_z2"
-install_watched_fixture "tests/fixtures/cog/${COG_SOURCE_ID}.tif" "$COG_RELOAD_WATCH_DIR/${COG_SOURCE_ID}.tif"
-
-COG_ENABLED=0
-for _ in {1..10}; do
-  if $CURL "$MARTIN_URL/catalog" 2>/dev/null | jq -e --arg id "$COG_SOURCE_ID" '.tiles | has($id)' > /dev/null 2>&1; then
-    COG_ENABLED=1
-    break
-  fi
-  sleep 1
-done
-
-if [[ "$COG_ENABLED" == "1" ]]; then
-  >&2 echo "COG reloader is active - running hot reload tests"
-  test_jsn cog_reload_catalog_added catalog
-
-  >&2 echo "Test COG reload: updating a COG file triggers source update"
-  touch "$COG_RELOAD_WATCH_DIR/${COG_SOURCE_ID}.tif"
-  wait_for_log_str "$LOG_FILE" "Updated source source.id=${COG_SOURCE_ID}"
-  test_jsn cog_reload_catalog_updated catalog
-
-  >&2 echo "Test COG reload: removing a COG file triggers source removal"
-  rm "$COG_RELOAD_WATCH_DIR/${COG_SOURCE_ID}.tif"
-  wait_for_catalog_source_removed "$COG_SOURCE_ID"
-  $CURL "$MARTIN_URL/catalog" | jq --sort-keys > "$TEST_OUT_DIR/catalog_after_remove.json"
-
-  kill_process "$MARTIN_PROC_ID" Martin
-  trap - EXIT HUP INT TERM
-
-  test_log_has_str "$LOG_FILE" "Added source source.id=${COG_SOURCE_ID}"
-  test_log_has_str "$LOG_FILE" "Updated source source.id=${COG_SOURCE_ID}"
-  test_log_has_str "$LOG_FILE" "Removed source source.id=${COG_SOURCE_ID}"
-else
-  >&2 echo "COG reloader not active (binary not compiled with unstable-cog) - skipping COG reload tests"
-  rm -f "$COG_RELOAD_WATCH_DIR/${COG_SOURCE_ID}.tif"
-  kill_process "$MARTIN_PROC_ID" Martin
-  trap - EXIT HUP INT TERM
-fi
-
-test_log_has_str "$LOG_FILE" 'WARN Defaulting `pmtiles.allow_http` to `true`. This is likely to become an error in the future for better security.'
-test_log_has_str "$LOG_FILE" 'WARN Environment variable AWS_SKIP_CREDENTIALS is deprecated. Please use pmtiles.skip_signature in the configuration file instead.'
-test_log_has_str "$LOG_FILE" 'WARN Environment variable AWS_REGION is deprecated. Please use pmtiles.region in the configuration file instead.'
-validate_log "$LOG_FILE"
-echo "::endgroup::"
-
-rm -rf "$TEST_TEMP_DIR"
 
 >&2 echo "All integration tests have passed"


### PR DESCRIPTION
Moves the COG hot-reload shell group into a feature-gated `integration-tests/tests/cog.rs` and covers the sources the shell suite never could.