### PR TITLE
fix(sprites): dedupe/cap sprite ids and bound rasterization concurrency

### DIFF
--- a/martin-core/src/resources/sprites/cache.rs
+++ b/martin-core/src/resources/sprites/cache.rs
@@ -13,9 +13,11 @@ pub const NO_SPRITE_CACHE: OptSpriteCache = None;
 
 /// Cache key for sprite data.
 ///
-/// `ids` is the comma-joined list of sprite source IDs from the request path.
-/// Invalidation by source ID matches by token (not substring): invalidating
-/// `"foo"` does not invalidate entries keyed against `"foobar"`.
+/// `ids` is the comma-joined list of sprite source IDs from the request path,
+/// normalized (sorted and deduplicated) via [`crate::sprites::normalize_sprite_ids`]
+/// so that equivalent requests - different id order, repeated ids - share one
+/// cache entry. Invalidation by source ID matches by token (not substring):
+/// invalidating `"foo"` does not invalidate entries keyed against `"foobar"`.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct SpriteCacheKey {
     ids: String,

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -15,7 +15,12 @@ pub enum SpriteError {
 
     /// Too many distinct sprite source IDs requested at once.
     #[error("Requested {requested} sprite ids, but at most {max} are allowed per request")]
-    TooManySpriteIds { requested: usize, max: usize },
+    TooManySpriteIds {
+        /// Number of distinct ids in the request.
+        requested: usize,
+        /// Maximum number of distinct ids allowed per request.
+        max: usize,
+    },
 
     /// I/O error accessing sprite file or directory.
     #[error("IO error {0}: {1}")]

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -13,6 +13,10 @@ pub enum SpriteError {
     #[error("Sprite {0} not found")]
     SpriteNotFound(String),
 
+    /// Too many distinct sprite source IDs requested at once.
+    #[error("Requested {requested} sprite ids, but at most {max} are allowed per request")]
+    TooManySpriteIds { requested: usize, max: usize },
+
     /// I/O error accessing sprite file or directory.
     #[error("IO error {0}: {1}")]
     IoError(#[source] std::io::Error, PathBuf),

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use dashmap::{DashMap, Entry};
-use futures::future::try_join_all;
+use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 pub use spreet::Spritesheet;
@@ -37,8 +37,52 @@ use crate::walk_files;
 
 const SVG_EXTENSIONS: &[&str] = &["svg"];
 
+/// Maximum number of distinct sprite source ids accepted in a single request.
+///
+/// Bounds the amount of per-request work (file reads, SVG parses, rasterization)
+/// an attacker can trigger by stuffing a request path with many ids.
+const MAX_SPRITE_IDS_PER_REQUEST: usize = 128;
+
+/// Maximum number of SVGs parsed and rasterized concurrently while building one spritesheet.
+const MAX_CONCURRENT_SPRITE_PARSES: usize = 16;
+
 fn discover_svgs(path: &Path) -> Result<Vec<PathBuf>, SpriteError> {
     walk_files(path, SVG_EXTENSIONS).map_err(|e| IoError(e.into(), path.to_path_buf()))
+}
+
+/// Splits a comma-separated, optionally `@2x`-suffixed sprite id list from a
+/// request path into the requested pixel ratio and a deduplicated, sorted
+/// list of source ids.
+///
+/// Sorting and deduplicating here (rather than only at spritesheet-build
+/// time) means equivalent requests - regardless of id order or repeat count
+/// - do the same amount of work and can share one cache entry.
+fn split_and_dedup_ids(ids: &str) -> (Vec<&str>, u8) {
+    let (ids, dpi) = if let Some(ids) = ids.strip_suffix("@2x") {
+        (ids, 2)
+    } else {
+        (ids, 1)
+    };
+
+    let mut unique_ids: Vec<&str> = ids.split(',').collect();
+    unique_ids.sort_unstable();
+    unique_ids.dedup();
+
+    (unique_ids, dpi)
+}
+
+/// Normalizes a request-path sprite id list so that equivalent requests
+/// (different id order, repeated ids) share one cache entry instead of
+/// each producing a distinct cache miss.
+#[must_use]
+pub fn normalize_sprite_ids(ids: &str) -> String {
+    let (unique_ids, dpi) = split_and_dedup_ids(ids);
+    let joined = unique_ids.join(",");
+    if dpi == 2 {
+        format!("{joined}@2x")
+    } else {
+        joined
+    }
 }
 
 mod error;
@@ -156,14 +200,17 @@ impl SpriteSources {
         err(Debug),
     )]
     pub async fn get_sprites(&self, ids: &str, as_sdf: bool) -> Result<Spritesheet, SpriteError> {
-        let (ids, dpi) = if let Some(ids) = ids.strip_suffix("@2x") {
-            (ids, 2)
-        } else {
-            (ids, 1)
-        };
+        let (unique_ids, dpi) = split_and_dedup_ids(ids);
 
-        let sprite_ids = ids
-            .split(',')
+        if unique_ids.len() > MAX_SPRITE_IDS_PER_REQUEST {
+            return Err(SpriteError::TooManySpriteIds {
+                requested: unique_ids.len(),
+                max: MAX_SPRITE_IDS_PER_REQUEST,
+            });
+        }
+
+        let sprite_ids = unique_ids
+            .into_iter()
             .map(|id| self.get(id))
             .collect::<Result<Vec<_>, SpriteError>>()?;
 
@@ -237,7 +284,10 @@ pub async fn get_spritesheet(
             futures.push(parse_sprite(name, path, pixel_ratio, as_sdf));
         }
     }
-    let sprites = try_join_all(futures).await?;
+    let sprites: Vec<(String, Sprite)> = stream::iter(futures)
+        .buffer_unordered(MAX_CONCURRENT_SPRITE_PARSES)
+        .try_collect()
+        .await?;
     let mut builder = SpritesheetBuilder::new();
     if as_sdf {
         builder.make_sdf();
@@ -255,6 +305,63 @@ pub async fn get_spritesheet(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_sprite_ids_collapses_order_and_duplicates() {
+        assert_eq!(normalize_sprite_ids("b,a,b"), "a,b");
+        assert_eq!(normalize_sprite_ids("b,a@2x"), "a,b@2x");
+        assert_eq!(normalize_sprite_ids("a"), "a");
+    }
+
+    #[tokio::test]
+    async fn duplicate_ids_are_deduplicated_before_rendering() {
+        let mut sprites = SpriteSources::default();
+        sprites.add_source(
+            "src1".to_owned(),
+            PathBuf::from("../tests/fixtures/sprites/src1"),
+        );
+
+        let single = sprites.get_sprites("src1", false).await.unwrap();
+        let repeated_ids = vec!["src1"; 50].join(",");
+        let repeated = sprites.get_sprites(&repeated_ids, false).await.unwrap();
+
+        assert_eq!(single.get_index(), repeated.get_index());
+        assert_eq!(single.encode_png().unwrap(), repeated.encode_png().unwrap());
+    }
+
+    #[tokio::test]
+    async fn too_many_ids_are_rejected_before_any_work() {
+        let mut sprites = SpriteSources::default();
+        sprites.add_source(
+            "src1".to_owned(),
+            PathBuf::from("../tests/fixtures/sprites/src1"),
+        );
+
+        // distinct, nonexistent ids: this must fail on the count check,
+        // never reach the per-id source lookup.
+        let ids = (0..=MAX_SPRITE_IDS_PER_REQUEST)
+            .map(|i| format!("nonexistent{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let err = sprites.get_sprites(&ids, false).await.unwrap_err();
+        assert!(matches!(err, SpriteError::TooManySpriteIds { .. }));
+    }
+
+    #[tokio::test]
+    async fn exactly_max_ids_is_not_rejected_by_the_count_check() {
+        let sprites = SpriteSources::default();
+
+        // exactly at the cap, with distinct nonexistent ids: the count check
+        // must not trip, so this should fail on the per-id lookup instead.
+        let ids = (0..MAX_SPRITE_IDS_PER_REQUEST)
+            .map(|i| format!("nonexistent{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let err = sprites.get_sprites(&ids, false).await.unwrap_err();
+        assert!(matches!(err, SpriteError::SpriteNotFound(_)));
+    }
 
     #[tokio::test]
     async fn sprites() {

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -325,7 +325,10 @@ mod tests {
         let repeated_ids = vec!["src1"; 50].join(",");
         let repeated = sprites.get_sprites(&repeated_ids, false).await.unwrap();
 
-        assert_eq!(single.get_index(), repeated.get_index());
+        assert_eq!(
+            serde_json::to_value(single.get_index()).unwrap(),
+            serde_json::to_value(repeated.get_index()).unwrap()
+        );
         assert_eq!(single.encode_png().unwrap(), repeated.encode_png().unwrap());
     }
 
@@ -337,14 +340,14 @@ mod tests {
             PathBuf::from("../tests/fixtures/sprites/src1"),
         );
 
-        // distinct, nonexistent ids: this must fail on the count check,
-        // never reach the per-id source lookup.
         let ids = (0..=MAX_SPRITE_IDS_PER_REQUEST)
             .map(|i| format!("nonexistent{i}"))
             .collect::<Vec<_>>()
             .join(",");
 
-        let err = sprites.get_sprites(&ids, false).await.unwrap_err();
+        let Err(err) = sprites.get_sprites(&ids, false).await else {
+            panic!("expected TooManySpriteIds, got Ok");
+        };
         assert!(matches!(err, SpriteError::TooManySpriteIds { .. }));
     }
 
@@ -352,14 +355,14 @@ mod tests {
     async fn exactly_max_ids_is_not_rejected_by_the_count_check() {
         let sprites = SpriteSources::default();
 
-        // exactly at the cap, with distinct nonexistent ids: the count check
-        // must not trip, so this should fail on the per-id lookup instead.
         let ids = (0..MAX_SPRITE_IDS_PER_REQUEST)
             .map(|i| format!("nonexistent{i}"))
             .collect::<Vec<_>>()
             .join(",");
 
-        let err = sprites.get_sprites(&ids, false).await.unwrap_err();
+        let Err(err) = sprites.get_sprites(&ids, false).await else {
+            panic!("expected SpriteNotFound, got Ok");
+        };
         assert!(matches!(err, SpriteError::SpriteNotFound(_)));
     }
 

--- a/martin/src/srv/sprites.rs
+++ b/martin/src/srv/sprites.rs
@@ -1,12 +1,14 @@
 use std::string::ToString as _;
 
 use actix_middleware_etag::Etag;
-use actix_web::error::ErrorNotFound;
+use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use actix_web::http::header::{ContentType, LOCATION};
 use actix_web::middleware::Compress;
 use actix_web::web::{Bytes, Data, Path};
 use actix_web::{HttpResponse, Result as ActixResult, route};
-use martin_core::sprites::{OptSpriteCache, SpriteCacheKey, SpriteError, SpriteSources};
+use martin_core::sprites::{
+    OptSpriteCache, SpriteCacheKey, SpriteError, SpriteSources, normalize_sprite_ids,
+};
 use serde::Deserialize;
 use tracing::{instrument, warn};
 
@@ -63,7 +65,7 @@ pub async fn get_sprite_png(
     let png = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(path.source_ids.clone(), is_sdf, false),
+                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, false),
                 async || get_sprite(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -131,7 +133,7 @@ pub async fn get_sprite_sdf_png(
     let png = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(path.source_ids.clone(), is_sdf, false),
+                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, false),
                 async || get_sprite(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -200,7 +202,7 @@ pub async fn get_sprite_json(
     let json = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(path.source_ids.clone(), is_sdf, true),
+                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, true),
                 async || get_index(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -269,7 +271,7 @@ pub async fn get_sprite_sdf_json(
     let json = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(path.source_ids.clone(), is_sdf, true),
+                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, true),
                 async || get_index(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -331,6 +333,9 @@ fn map_sprite_compute_error(e: &SpriteComputeError) -> actix_web::Error {
     match e {
         SpriteComputeError::Sprite(err @ SpriteError::SpriteNotFound(_)) => {
             ErrorNotFound(err.to_string())
+        }
+        SpriteComputeError::Sprite(err @ SpriteError::TooManySpriteIds { .. }) => {
+            ErrorBadRequest(err.to_string())
         }
         other => map_internal_error(other),
     }


### PR DESCRIPTION
Fixes https://github.com/maplibre/martin/security/advisories/GHSA-5x5g-6p4c-jqfh