### PR TITLE
chore(deps): ignore breaking renovate updates we can't fix upstream

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,5 +73,28 @@
       matchCurrentValue: '/^11/',
       enabled: false,
     },
+    {
+      // typescript v7 breaks config/OpenAPI/UI-type generation and coverage (#3022);
+      // fixing it needs upstream changes we don't have capacity to contribute right now.
+      matchManagers: ['npm'],
+      matchPackageNames: ['typescript'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+    },
+    {
+      // ubuntu:26.04 breaks the docker image build (#3017); fixing it needs upstream
+      // changes we don't have capacity to contribute right now.
+      matchDatasources: ['docker'],
+      matchPackageNames: ['ubuntu'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+    },
+    {
+      // static-files 0.3 breaks the Rust build across nearly every target (#2973);
+      // fixing it needs upstream changes we don't have capacity to contribute right now.
+      matchManagers: ['cargo'],
+      matchPackageNames: ['static-files'],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
## Summary
- Adds `enabled: false` package rules to `.github/renovate.json5` for three updates that break CI and need upstream fixes we don't currently have the capacity to contribute:
  - `typescript` v7 (major) — breaks config/OpenAPI/UI-type generation and coverage. Closes #3022.
  - `ubuntu` docker tag v26.04 (major) — breaks the docker image build. Closes #3017.
  - `static-files` crate 0.3 — breaks the Rust build across nearly every target. Closes #2973.

This stops Renovate from repeatedly reopening these PRs every cycle. We can drop these rules once we have bandwidth to fix the underlying breakage (or upstream fixes land).

## Test plan
- [x] Validated `.github/renovate.json5` parses as valid JSON5
- [x] New rules follow the existing `enabled: false` pattern already used for the postgis pin in this file