### PR TITLE
perf(pmtiles): open file sources concurrently and share one client per store

### DIFF
--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 
+#[cfg(feature = "_tiles")]
+use futures::stream::{self, StreamExt as _};
 pub use martin_config_macros::ConfigurationLivecycleHooks;
 use martin_core::CacheZoomRange;
 #[cfg(feature = "_tiles")]
@@ -454,9 +456,19 @@ async fn resolve_int<T: TileSourceConfiguration>(
         }
     }
 
+    let custom = &cfg.custom;
+    let opened = stream::iter(planned)
+        .map(|p| async move {
+            let result = p.open(custom).await;
+            (p, result)
+        })
+        .buffered(MAX_CONCURRENT_SOURCE_INITS)
+        .collect::<Vec<_>>()
+        .await;
+
     let mut results = Vec::new();
-    for p in planned {
-        match p.open(&cfg.custom).await {
+    for (p, result) in opened {
+        match result {
             Ok(src) => {
                 p.log_configured();
                 if !p.from_sources

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -10,9 +10,14 @@ use aws_config::profile::ProfileFileRegionProvider;
 use aws_credential_types::provider::{ProvideCredentials as _, SharedCredentialsProvider};
 #[cfg(test)]
 use aws_runtime::env_config::file::EnvConfigFiles;
+use dashmap::DashMap;
 use martin_core::tiles::BoxedSource;
 use martin_core::tiles::pmtiles::{PmtCache, PmtCacheInstance, PmtilesSource};
 use object_store::aws::{AmazonS3Builder, AwsCredential, AwsCredentialProvider};
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::client::{ClientOptions, HttpClient, HttpConnector, ReqwestConnector};
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::http::HttpBuilder;
 use object_store::{CredentialProvider, ObjectStore, ObjectStoreScheme};
 use serde::{Deserialize, Serialize};
 use tracing::{trace, warn};
@@ -116,6 +121,11 @@ pub struct PmtConfig {
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub aws_credentials: Option<AwsCredentialProvider>,
 
+    /// HTTP clients shared by every remote source of this config (internal state, not serialized)
+    #[serde(skip)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub(crate) http_clients: SharedHttpClients,
+
     #[cfg(test)]
     #[serde(skip)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -136,6 +146,7 @@ impl Default for PmtConfig {
             unrecognized: UnrecognizedValues::default(),
             pmtiles_directory_cache: PmtCache::default(),
             aws_credentials: None,
+            http_clients: SharedHttpClients::default(),
             #[cfg(test)]
             aws_profile_files: None,
         }
@@ -153,7 +164,7 @@ impl PartialEq for PmtConfig {
         let base = base
             && self.convert_to_mlt == other.convert_to_mlt
             && self.convert_to_mvt == other.convert_to_mvt;
-        // pmtiles_directory_cache is intentionally excluded from equality check
+        // pmtiles_directory_cache and http_clients are intentionally excluded from equality check
         base
     }
 }
@@ -264,26 +275,48 @@ impl PmtConfig {
         }
     }
 
+    /// Builds the store for `url`. Remote stores share this config's HTTP clients.
     pub(crate) fn parse_url_opts(
         &self,
         url: &Url,
     ) -> object_store::Result<(Box<dyn ObjectStore>, object_store::path::Path)> {
-        let (scheme, path) = ObjectStoreScheme::parse(url)?;
-        if scheme != ObjectStoreScheme::AmazonS3 {
-            return object_store::parse_url_opts(url, &self.options);
+        macro_rules! with_options {
+            ($builder:ty, $url:expr) => {
+                self.options
+                    .iter()
+                    .fold(
+                        <$builder>::new().with_url($url.to_string()),
+                        |builder, (key, value)| match key.parse() {
+                            Ok(key) => builder.with_config(key, value),
+                            Err(_) => builder,
+                        },
+                    )
+                    .with_http_connector(self.http_clients.clone())
+            };
         }
 
-        let mut builder = self.options.iter().fold(
-            AmazonS3Builder::new().with_url(url.to_string()),
-            |builder, (key, value)| match key.parse() {
-                Ok(key) => builder.with_config(key, value),
-                Err(_) => builder,
-            },
-        );
-        if let Some(credentials) = &self.aws_credentials {
-            builder = builder.with_credentials(Arc::clone(credentials));
-        }
-        Ok((Box::new(builder.build()?), path))
+        let (scheme, path) = ObjectStoreScheme::parse(url)?;
+        let store: Box<dyn ObjectStore> = match scheme {
+            ObjectStoreScheme::AmazonS3 => {
+                let mut builder = with_options!(AmazonS3Builder, url);
+                if let Some(credentials) = &self.aws_credentials {
+                    builder = builder.with_credentials(Arc::clone(credentials));
+                }
+                Box::new(builder.build()?)
+            }
+            ObjectStoreScheme::GoogleCloudStorage => {
+                Box::new(with_options!(GoogleCloudStorageBuilder, url).build()?)
+            }
+            ObjectStoreScheme::MicrosoftAzure => {
+                Box::new(with_options!(MicrosoftAzureBuilder, url).build()?)
+            }
+            ObjectStoreScheme::Http => {
+                let origin = &url[..url::Position::BeforePath];
+                Box::new(with_options!(HttpBuilder, origin).build()?)
+            }
+            _ => return object_store::parse_url_opts(url, &self.options),
+        };
+        Ok((store, path))
     }
 
     /// Partition options and unrecognized keys
@@ -483,6 +516,21 @@ impl TileSourceConfiguration for PmtConfig {
     }
 }
 
+/// One HTTP client per distinct [`ClientOptions`], handed to every store built from one
+/// [`PmtConfig`], so its sources share connection pools instead of each opening their own.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SharedHttpClients(Arc<DashMap<String, HttpClient>>);
+
+impl HttpConnector for SharedHttpClients {
+    fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
+        let client = self
+            .0
+            .entry(format!("{options:?}"))
+            .or_try_insert_with(|| ReqwestConnector::default().connect(options))?;
+        Ok(client.clone())
+    }
+}
+
 #[derive(Debug)]
 pub struct AwsSdkCredentialProvider {
     provider: SharedCredentialsProvider,
@@ -513,9 +561,38 @@ impl CredentialProvider for AwsSdkCredentialProvider {
 mod tests {
     use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
     use indoc::indoc;
+    use rstest::rstest;
     use tempfile::tempdir;
 
     use super::*;
+
+    #[rstest]
+    #[case::s3("s3://bucket-a/one.pmtiles", "s3://bucket-b/two.pmtiles")]
+    #[case::https(
+        "https://tiles.example.com/one.pmtiles",
+        "https://other.example.com/two.pmtiles"
+    )]
+    #[case::gcs("gs://bucket-a/one.pmtiles", "gs://bucket-b/two.pmtiles")]
+    #[case::azure("az://container-a/one.pmtiles", "az://container-b/two.pmtiles")]
+    #[case::mixed("s3://bucket-a/one.pmtiles", "https://tiles.example.com/two.pmtiles")]
+    fn remote_sources_share_http_clients(#[case] first: &str, #[case] second: &str) {
+        let mut config = PmtConfig::default();
+        config
+            .options
+            .insert("aws_region".to_owned(), "us-east-1".to_owned());
+        config
+            .options
+            .insert("skip_signature".to_owned(), "true".to_owned());
+        config.options.insert(
+            "azure_storage_account_name".to_owned(),
+            "account".to_owned(),
+        );
+        config.parse_url_opts(&Url::parse(first).unwrap()).unwrap();
+        let clients = config.http_clients.0.len();
+        assert!(clients > 0);
+        config.parse_url_opts(&Url::parse(second).unwrap()).unwrap();
+        assert_eq!(config.http_clients.0.len(), clients);
+    }
 
     fn profile_files() -> (tempfile::TempDir, EnvConfigFiles) {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
tl;dr: 1,000 remote PMTiles reduced from 95s to 3.7s.

Refs #2937, Fixes #3122.

@CommanderStorm you said feel free to look into where the time goes, so I did. I put 1,000 PMTiles on a local MinIO behind toxiproxy with 40ms of added latency, which is the only way to see this on a laptop: on plain localhost the same 1,000 sources start in 3s and everything looks fine.

Where it goes: startup opens file sources one at a time, and each remote PMTiles open is a few dependent round trips (header, directory, metadata) on a fresh S3 client. So it's latency x source count, whether the sources are listed under `sources:` or discovered from an `s3://bucket/` prefix (the reloader's first tick builds serially too). @mazedm80's 20 minutes for 4,000 sources at real S3 latency lines up with that.

Two changes, they go together:

- Sources are opened with a bounded fan-out (`MAX_CONCURRENT_SOURCE_INITS = 32`) in `resolve_files` and in `ReloadAdvisory` builds. Ids, duplicate handling, and `--save-config` output resolve in the same order as before; only the open is concurrent. That's the 95s -> 3.7s, both paths.
- `PmtConfig` keeps one `ObjectStore` per store root (bucket or host), shared by every source under it. Concurrency alone was a bad idea on its own: with per-source clients I saw 1,000 idle keep-alive sockets held open (main peaks at 339 as they trickle out; 4,000 sources would sail past a default `ulimit`). Shared clients: 32 sockets, and RSS 36MB instead of 76MB on main.

Why 32: enough to hide latency at any realistic RTT, small enough that a big config doesn't look like a burst to S3. Happy to make it a knob if you'd rather, I just couldn't think of a WHY someone would need to turn it.

Not done here: the lazy-init idea from the issue (the catalog needs each source's TileJSON, so something has to open them; making that fast seemed better than making it later), and recursive local discovery from #2937, which I'd like to do next once we settle the source-ID mapping you mentioned. I'll open that conversation on the discussion.

Tests: a unit test pins the store sharing (same bucket/host -> one client, different -> two); the existing file-source and `--save-config` snapshot suites cover the ordering. Local `test-minio` green.
