### PR TITLE
feat(config)!: stop reading configuration from the environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,7 +153,7 @@ curl http://localhost:3000/catalog
 just start
 PGHOST=localhost PGPORT=5411 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=db tests/fixtures/initdb.sh
 export DATABASE_URL='postgres://postgres:postgres@localhost:5411/db'
-cargo run --bin martin -- --webui enable-for-all
+cargo run --bin martin -- --webui enable-for-all "$DATABASE_URL"
 ```
 
 ### Scenario 3 - CLI Tools

--- a/.github/files/homebrew.martin.rb.j2
+++ b/.github/files/homebrew.martin.rb.j2
@@ -37,7 +37,7 @@ class Martin < Formula
 
   def caveats; <<~EOS
     Martin requires a database connection string.
-    It can be passed as a command-line argument or as a DATABASE_URL environment variable.
+    Pass it as a command-line argument, or set it in a config file.
       martin postgres://postgres@localhost/db
   EOS
   end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,11 @@ jobs:
           # directories they build their own in, so the workspace and the temp directory are
           # mounted where the host has them. The container runs as the runner so that the files
           # it writes into those directories stay ours to read and delete.
-          RUN="--rm --net host --platform $PLATFORM --user $(id -u):$(id -g) -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -e RUST_LOG_FORMAT=bare -v $PWD:$PWD -v $TMPDIR:$TMPDIR -w $PWD"
+          # DEFAULT_SRID/PGSSL* are forwarded bare (no `=value`) alongside DATABASE_URL so tests
+          # that check the legacy-env-var migration warnings see them inside the container too --
+          # docker only passes through variables explicitly listed here, never the caller's whole
+          # environment.
+          RUN="--rm --net host --platform $PLATFORM --user $(id -u):$(id -g) -e DATABASE_URL -e DEFAULT_SRID -e PGSSLCERT -e PGSSLKEY -e PGSSLROOTCERT -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -e RUST_LOG_FORMAT=bare -v $PWD:$PWD -v $TMPDIR:$TMPDIR -w $PWD"
           export MARTIN_BIN="docker run $RUN $TAG"
           export MARTIN_CP_BIN="docker run $RUN --entrypoint /usr/local/bin/martin-cp $TAG"
           export MBTILES_BIN="docker run $RUN --entrypoint /usr/local/bin/mbtiles $TAG"
@@ -374,7 +378,11 @@ jobs:
           # directories they build their own in, so the workspace and the temp directory are
           # mounted where the host has them. The container runs as the runner so that the files
           # it writes into those directories stay ours to read and delete.
-          RUN="--rm --net host --platform $PLATFORM --user $(id -u):$(id -g) -e DATABASE_URL -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -e RUST_LOG_FORMAT=bare -v $PWD:$PWD -v $TMPDIR:$TMPDIR -w $PWD"
+          # DEFAULT_SRID/PGSSL* are forwarded bare (no `=value`) alongside DATABASE_URL so tests
+          # that check the legacy-env-var migration warnings see them inside the container too --
+          # docker only passes through variables explicitly listed here, never the caller's whole
+          # environment.
+          RUN="--rm --net host --platform $PLATFORM --user $(id -u):$(id -g) -e DATABASE_URL -e DEFAULT_SRID -e PGSSLCERT -e PGSSLKEY -e PGSSLROOTCERT -e AWS_REGION=eu-central-1 -e AWS_SKIP_CREDENTIALS=1 -e RUST_LOG_FORMAT=bare -v $PWD:$PWD -v $TMPDIR:$TMPDIR -w $PWD"
           export MARTIN_BIN="docker run $RUN $TAG"
           export MARTIN_CP_BIN="docker run $RUN --entrypoint /usr/local/bin/martin-cp $TAG"
           export MBTILES_BIN="docker run $RUN --entrypoint /usr/local/bin/mbtiles $TAG"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -17,8 +17,7 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
-    environment:
-      - DATABASE_URL=postgres://postgres@db/db
+    command: ["postgres://postgres@db/db"]
     depends_on:
       db:
         condition: service_healthy

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -598,7 +598,7 @@ Martin supports multiple deployment patterns:
 === "Container Deployment"
 
     - Docker image with all dependencies
-    - Configuration via environment variables
+    - Configuration via CLI arguments or a mounted config file
     - Health check endpoints
     - Suitable for Kubernetes and container orchestrators
 

--- a/docs/content/env-vars.md
+++ b/docs/content/env-vars.md
@@ -43,13 +43,13 @@ Martin used to read the variables below on its own. It now ignores them, and pri
 startup naming any of them that is still set, together with its replacement. The warning never
 prints the value of a variable, so connection strings and certificate paths stay out of the logs.
 
-| No longer read  | Command line                    | Config file                                   |
-|-----------------|---------------------------------|-----------------------------------------------|
-| `DATABASE_URL`  | `martin "$DATABASE_URL"`        | `postgres.connection_string: ${DATABASE_URL}`  |
-| `DEFAULT_SRID`  | `--default-srid 4326`           | `postgres.default_srid: ${DEFAULT_SRID}`       |
-| `PGSSLCERT`     | `--ssl-cert ./postgresql.crt`   | `postgres.ssl_cert: ${PGSSLCERT}`              |
-| `PGSSLKEY`      | `--ssl-key ./postgresql.key`    | `postgres.ssl_key: ${PGSSLKEY}`                |
-| `PGSSLROOTCERT` | `--ca-root-file ./root.crt`     | `postgres.ssl_root_cert: ${PGSSLROOTCERT}`     |
+| No longer read  | Command line                  | Config file                                   |
+|-----------------|-------------------------------|-----------------------------------------------|
+| `DATABASE_URL`  | `martin "$DATABASE_URL"`      | `postgres.connection_string: ${DATABASE_URL}` |
+| `DEFAULT_SRID`  | `--default-srid 4326`         | `postgres.default_srid: ${DEFAULT_SRID}`      |
+| `PGSSLCERT`     | `--ssl-cert ./postgresql.crt` | `postgres.ssl_cert: ${PGSSLCERT}`             |
+| `PGSSLKEY`      | `--ssl-key ./postgresql.key`  | `postgres.ssl_key: ${PGSSLKEY}`               |
+| `PGSSLROOTCERT` | `--ca-root-file ./root.crt`   | `postgres.ssl_root_cert: ${PGSSLROOTCERT}`    |
 
 ### With the command line
 
@@ -94,9 +94,9 @@ martin --config config.yaml
 
 These are not Martin settings, and are unaffected by the above:
 
-| Environment var           | Description                                                                                                                                                                |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `RUST_LOG`                | Logging level, e.g. `RUST_LOG=debug` or `RUST_LOG=martin=debug`                                                                                                             |
-| `RUST_LOG_FORMAT`         | Log output format: `json`, `full`, `compact` (default), `bare` or `pretty`                                                                                                  |
-| `AWS_LAMBDA_RUNTIME_API`  | Set by the AWS Lambda runtime itself. If present, Martin serves requests through Lambda instead of its own HTTP server. See [Running in AWS Lambda](run-with-lambda.md)      |
-| `AWS_*`                   | Read by the deprecated `pmtiles` S3 compatibility shim, which warns and points at the equivalent [`pmtiles` config keys](sources-pmtiles.md)                                |
+| Environment var          | Description                                                                                                                                                             |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `RUST_LOG`               | Logging level, e.g. `RUST_LOG=debug` or `RUST_LOG=martin=debug`                                                                                                         |
+| `RUST_LOG_FORMAT`        | Log output format: `json`, `full`, `compact` (default), `bare` or `pretty`                                                                                              |
+| `AWS_LAMBDA_RUNTIME_API` | Set by the AWS Lambda runtime itself. If present, Martin serves requests through Lambda instead of its own HTTP server. See [Running in AWS Lambda](run-with-lambda.md) |
+| `AWS_*`                  | Read by the deprecated `pmtiles` S3 compatibility shim, which warns and points at the equivalent [`pmtiles` config keys](sources-pmtiles.md)                            |

--- a/docs/content/env-vars.md
+++ b/docs/content/env-vars.md
@@ -7,16 +7,96 @@ tags:
 
 # Environment Variables
 
-You can configure Martin using environment variables, but only if the configuration file is not used.
-The configuration file itself can use environment variables if needed.
-See [configuration section](config-file/index.md) on how to use environment variables with config files.
-See also [SSL configuration](pg-connections/index.md#ssl-connections) section below.
+Martin takes its configuration from [command line parameters](run-with-cli.md) and
+[configuration files](config-file/index.md) only.
 
-| Environment var <br/> Config File key    | Example                                   | Description                                                                                                                                                                                                |
-|------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DATABASE_URL` <br/> `connection_string` | `postgres://`<br/>`postgres@localhost/db` | Postgres database connection                                                                                                                                                                               |
-| `DEFAULT_SRID` <br/> `default_srid`      | `4326`                                    | If a PostgreSQL table has a geometry column with SRID=0, use this value instead                                                                                                                            |
-| `PGSSLCERT` <br/> `ssl_cert`             | `./postgresql.crt`                        | A file with a client SSL certificate. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT)                                                                             |
-| `PGSSLKEY` <br/> `ssl_key`               | `./postgresql.key`                        | A file with the key for the client SSL certificate. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLKEY)                                                                |
-| `PGSSLROOTCERT` <br/> `ssl_root_cert`    | `./root.crt`                              | A file with trusted root certificate(s). The file should contain a sequence of PEM-formatted CA certificates. [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT) |
-| `AWS_LAMBDA_RUNTIME_API` <br/> -         |                                           | If defined, connect to AWS Lambda to handle requests. The regular HTTP server is not used. See [Running in AWS Lambda](run-with-lambda.md)                                                                 |
+It does **not** configure itself from environment variables that happen to be set in its
+environment. Automatically picking up variables such as `DATABASE_URL` made Martin's behaviour
+depend on whatever else the host had exported -- some platforms set `DATABASE_URL` for you, which
+made a configuration file impossible to use.
+
+Environment variables are still fully supported where they are unambiguous: **inside a
+configuration file**, where you name the variable yourself.
+
+## Using environment variables in a config file
+
+Any value in a config file can reference an environment variable:
+
+```yaml
+postgres:
+  # fails to start if MY_DATABASE_URL is not set
+  connection_string: ${MY_DATABASE_URL}
+```
+
+A default can be supplied with `${VAR:-default}`:
+
+```yaml
+postgres:
+  connection_string: ${MY_DATABASE_URL:-postgresql://postgres@localhost/db}
+```
+
+See the [configuration section](config-file/index.md) for the full substitution syntax.
+
+## Migrating away from the automatic variables
+
+Martin used to read the variables below on its own. It now ignores them, and prints a warning at
+startup naming any of them that is still set, together with its replacement. The warning never
+prints the value of a variable, so connection strings and certificate paths stay out of the logs.
+
+| No longer read  | Command line                    | Config file                                   |
+|-----------------|---------------------------------|-----------------------------------------------|
+| `DATABASE_URL`  | `martin "$DATABASE_URL"`        | `postgres.connection_string: ${DATABASE_URL}`  |
+| `DEFAULT_SRID`  | `--default-srid 4326`           | `postgres.default_srid: ${DEFAULT_SRID}`       |
+| `PGSSLCERT`     | `--ssl-cert ./postgresql.crt`   | `postgres.ssl_cert: ${PGSSLCERT}`              |
+| `PGSSLKEY`      | `--ssl-key ./postgresql.key`    | `postgres.ssl_key: ${PGSSLKEY}`                |
+| `PGSSLROOTCERT` | `--ca-root-file ./root.crt`     | `postgres.ssl_root_cert: ${PGSSLROOTCERT}`     |
+
+### With the command line
+
+Old:
+
+```bash
+export DATABASE_URL=postgresql://postgres@localhost/db
+export DEFAULT_SRID=4326
+martin
+```
+
+New -- pass the connection string as an argument:
+
+```bash
+martin --default-srid 4326 "$DATABASE_URL"
+```
+
+### With a config file
+
+Old -- if `config.yaml` did not define a `postgres` source itself, `DATABASE_URL` silently added
+one anyway:
+
+```bash
+export DATABASE_URL=postgresql://postgres@localhost/db
+martin --config config.yaml
+```
+
+New -- name the variable in the config file:
+
+```yaml
+# config.yaml
+postgres:
+  connection_string: ${DATABASE_URL}
+  default_srid: 4326
+```
+
+```bash
+martin --config config.yaml
+```
+
+## Variables Martin still reacts to
+
+These are not Martin settings, and are unaffected by the above:
+
+| Environment var           | Description                                                                                                                                                                |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `RUST_LOG`                | Logging level, e.g. `RUST_LOG=debug` or `RUST_LOG=martin=debug`                                                                                                             |
+| `RUST_LOG_FORMAT`         | Log output format: `json`, `full`, `compact` (default), `bare` or `pretty`                                                                                                  |
+| `AWS_LAMBDA_RUNTIME_API`  | Set by the AWS Lambda runtime itself. If present, Martin serves requests through Lambda instead of its own HTTP server. See [Running in AWS Lambda](run-with-lambda.md)      |
+| `AWS_*`                   | Read by the deprecated `pmtiles` S3 compatibility shim, which warns and points at the equivalent [`pmtiles` config keys](sources-pmtiles.md)                                |

--- a/docs/content/files/compose.nginx.yaml
+++ b/docs/content/files/compose.nginx.yaml
@@ -13,8 +13,7 @@ services:
   martin:
     image: ghcr.io/maplibre/martin:1.14.0
     restart: unless-stopped
-    environment:
-      - DATABASE_URL=postgres://postgres:password@db/db
+    command: ["postgres://postgres:password@db/db"]
     depends_on:
       - db
 

--- a/docs/content/getting-involved.md
+++ b/docs/content/getting-involved.md
@@ -112,9 +112,9 @@ Just copy and paste after it, and modify your pasted like this:
             "kind": "bin"
         }
     },
-    "args": ["postgres://postgres:postgres@localhost:5411/db"], // add your arguments here
+    "args": ["--default-srid=4490", "postgres://postgres:postgres@localhost:5411/db"], // add your arguments here
      "env": {
-         "DEFAULT_SRID": 4490, // add your env here
+         "RUST_LOG": "martin=debug", // add your env here
      },
     "cwd": "${workspaceFolder}"
 },

--- a/docs/content/help/martin-cp.txt
+++ b/docs/content/help/martin-cp.txt
@@ -91,6 +91,12 @@ Options:
 
           Can be either a positive integer or unlimited if omitted.
 
+      --ssl-cert <SSL_CERT>
+          A file with a client SSL certificate. Replaces the `PGSSLCERT` environment variable
+
+      --ssl-key <SSL_KEY>
+          A file with the key for the client SSL certificate. Replaces the `PGSSLKEY` environment variable
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/docs/content/help/martin.txt
+++ b/docs/content/help/martin.txt
@@ -80,6 +80,12 @@ Options:
 
           Can be either a positive integer or unlimited if omitted.
 
+      --ssl-cert <SSL_CERT>
+          A file with a client SSL certificate. Replaces the `PGSSLCERT` environment variable
+
+      --ssl-key <SSL_KEY>
+          A file with the key for the client SSL certificate. Replaces the `PGSSLKEY` environment variable
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -13,7 +13,10 @@ If using Martin with PostgreSQL database, you must install PostGIS with at least
 
 Martin is also available as a [Docker image](https://ghcr.io/maplibre/martin). You could either share a configuration
 file from the host with the container via the `-v` param, or you can let Martin auto-discover all sources e.g. by
-passing `DATABASE_URL` or specifying the .mbtiles/.pmtiles files or URLs to .pmtiles.
+passing a connection string or specifying the .mbtiles/.pmtiles files or URLs to .pmtiles.
+
+The config file may reference environment variables passed into the container, e.g.
+`connection_string: ${DATABASE_URL}` -- see [environment variables](env-vars.md).
 
 ```bash
 export PGPASSWORD=postgres  # secret!

--- a/docs/content/pg-connections/index.md
+++ b/docs/content/pg-connections/index.md
@@ -15,9 +15,9 @@ See the [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-connect.
 
 Martin supports PostgreSQL `sslmode` settings: `disable`, `prefer`, `require`, `verify-ca` and `verify-full`.
 See the [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for mode descriptions.
-Certificates can be provided in the configuration file or via environment variables (same as `psql`).
-Environment variables apply to all PostgreSQL connections.
-See [environment vars](../env-vars.md) for details.
+Certificates can be provided in the configuration file (`ssl_cert`, `ssl_key`, `ssl_root_cert`) or on the command line (`--ssl-cert`, `--ssl-key`, `--ca-root-file`).
+Command line certificates apply to all PostgreSQL connections.
+Martin no longer picks up `psql`'s `PGSSLCERT`, `PGSSLKEY` and `PGSSLROOTCERT` variables by itself -- see [environment vars](../env-vars.md) for how to migrate.
 
 By default, `sslmode` is `prefer` - encrypt (don't check certificates) if the server supports it, but the connection proceeds without SSL if not supported.
 This matches `psql` default behavior.

--- a/docs/content/pg-ssl-certificates.md
+++ b/docs/content/pg-ssl-certificates.md
@@ -174,16 +174,12 @@ SELECT * FROM pg_stat_ssl WHERE pid = pg_backend_pid();
 
 ## Martin Configuration
 
-Martin can be configured using environment variables, [the CLI](run-with-cli.md), or the [configuration file](config-file/index.md).
+Martin can be configured using [the CLI](run-with-cli.md) or the [configuration file](config-file/index.md).
 Which of them you choose is up to you.
 You do not need to configure things twice.
 
-??? "Environment Variables (click to expand)"
-    ```bash
-    export PGSSLROOTCERT=./ca-cert.pem
-    export DATABASE_URL="postgres://postgres:password@localhost:5432/postgres?sslmode=verify-full"
-    martin
-    ```
+Martin does not read `PGSSLROOTCERT` or `DATABASE_URL` on its own -- see
+[environment variables](env-vars.md) if you keep them in your environment.
 
 ??? "Configuration File (click to expand)"
     ```yaml
@@ -209,14 +205,14 @@ export PGSSLROOTCERT=./ca-cert.pem
 psql -h localhost -U postgres -d postgres -v
 
 # Debug Martin
-RUST_LOG=debug RUST_LOG_FORMAT=pretty martin postgres://...
+RUST_LOG=debug RUST_LOG_FORMAT=pretty martin --ca-root-file ./ca-cert.pem postgres://...
 ```
 
 These are the errors that can occur:
 
 ??? "Certificate verification failed (click to expand)"
     - Check server certificate is signed by the CA
-    - Verify CA certificate path in `PGSSLROOTCERT`
+    - Verify the CA certificate path passed to Martin (`--ca-root-file` / `ssl_root_cert`), and `PGSSLROOTCERT` for `psql`
     - Ensure certificate files are readable
 
 ??? "Hostname verification failed (click to expand)"

--- a/docs/content/recipes.md
+++ b/docs/content/recipes.md
@@ -31,7 +31,9 @@ You can use Martin with [Managed PostgreSQL from Heroku](https://www.heroku.com/
 heroku pg:psql -a APP_NAME -c 'create extension postgis'
 ```
 
-Use the same environment variables as Heroku [suggests for psql](https://devcenter.heroku.com/articles/heroku-postgres-via-mtls#step-2-configure-environment-variables).
+Set the same environment variables Heroku [suggests for psql](https://devcenter.heroku.com/articles/heroku-postgres-via-mtls#step-2-configure-environment-variables),
+and hand them to Martin explicitly -- Martin does not read them on its own, see
+[environment variables](env-vars.md).
 
 ```bash
 export DATABASE_URL=$(heroku config:get DATABASE_URL -a APP_NAME)
@@ -39,7 +41,10 @@ export PGSSLCERT=DIRECTORY/PREFIXpostgresql.crt
 export PGSSLKEY=DIRECTORY/PREFIXpostgresql.key
 export PGSSLROOTCERT=DIRECTORY/PREFIXroot.crt
 
-martin
+martin --ssl-cert "$PGSSLCERT" \
+       --ssl-key "$PGSSLKEY" \
+       --ca-root-file "$PGSSLROOTCERT" \
+       "$DATABASE_URL"
 ```
 
 You may also be able to validate SSL certificate with an explicit sslmode, e.g.

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -18,8 +18,7 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
-    environment:
-      - DATABASE_URL=postgres://postgres:password@db/db
+    command: ["postgres://postgres:password@db/db"]
     depends_on:
       - db
 

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -11,11 +11,15 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 
 ### Using Non-Local PostgreSQL
 
+Pass the connection string as an argument. Martin does not read `DATABASE_URL` on its own -- see
+[environment variables](env-vars.md) if you would rather keep it in a variable and reference it
+from a config file.
+
 ```bash
 docker run \
   -p 3000:3000 \
-  -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.14.0
+  ghcr.io/maplibre/martin:1.14.0 \
+  postgres://postgres@postgres.example.org/db
 ```
 
 ### Exposing Local Files
@@ -52,8 +56,8 @@ You would not need to export ports with `-p` because the container is already us
 ```bash
 docker run \
   --net=host \
-  -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.14.0
+  ghcr.io/maplibre/martin:1.14.0 \
+  postgres://postgres@localhost/db
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -63,8 +67,8 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 ```bash
 docker run \
   -p 3000:3000 \
-  -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.14.0
+  ghcr.io/maplibre/martin:1.14.0 \
+  postgres://postgres@host.docker.internal/db
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -74,6 +78,6 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 ```bash
 docker run \
   -p 3000:3000 \
-  -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.14.0
+  ghcr.io/maplibre/martin:1.14.0 \
+  postgres://postgres@docker.for.win.localhost/db
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -12,7 +12,7 @@ Martin can run in AWS Lambda.
 This is useful if you want to serve tiles from a serverless environment, while accessing "nearby" data from a PostgreSQL database or PMTiles file in S3, without exposing the raw file to the world to prevent download abuse and improve performance.
 
 Lambda has two deployment models: zip file and container-based. When using zip file deployment, there is an online code editor to edit the yaml configuration.
-When using container-based deployment, we can pass our configuration on the command line or environment variables.
+When using container-based deployment, we can pass our configuration on the command line.
 
 Everything can be performed via AWS CloudShell, or you can install the AWS CLI and the AWS SAM CLI, and configure authentication.
 The CloudShell also runs in a particular AWS region.

--- a/docs/content/run/index.md
+++ b/docs/content/run/index.md
@@ -6,7 +6,8 @@ icon: material/play-circle
 
 Martin requires at least one PostgreSQL [connection string](../pg-connections/index.md) or a [tile source file](../sources-files/index.md)
 as a command-line argument.
-A PG connection string can also be passed via the `DATABASE_URL` environment variable.
+A PG connection string can also be set in a [configuration file](../config-file/index.md), where it may reference an environment variable, e.g. `connection_string: ${DATABASE_URL}`.
+Martin does not read `DATABASE_URL` on its own -- see [environment variables](../env-vars.md).
 [DuckDB / GeoParquet sources](../sources-duckdb.md) are configured in a [configuration file](../config-file/index.md) instead, and require Martin to be built with `--features=unstable-duckdb`.
 
 ```bash

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -49,6 +49,15 @@ pub fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
+/// The test database's connection string, which the justfile and CI export as `DATABASE_URL`.
+///
+/// Martin itself no longer reads this variable; the harness passes the value to it explicitly.
+#[must_use]
+fn test_database_url() -> String {
+    env::var("DATABASE_URL")
+        .expect("DATABASE_URL must point at the test database; start it with `just start`")
+}
+
 /// A workspace binary, run from its debug build unless `env_var` names another one.
 ///
 /// `env_var` may hold a program plus leading arguments (e.g. a `docker run ...` invocation).

--- a/e2e-tests/src/martin.rs
+++ b/e2e-tests/src/martin.rs
@@ -1,11 +1,12 @@
 //! The `martin` server subprocess and the responses it answers with.
 
+use std::env;
 use std::ffi::OsString;
+use std::fs;
 use std::io::{self, Cursor, Read as _};
 use std::process::{ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use std::{env, fs};
 
 use brotli::Decompressor;
 use flate2::read::GzDecoder;
@@ -20,7 +21,7 @@ use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 
-use crate::{binary_command, workspace_root};
+use crate::{binary_command, test_database_url, workspace_root};
 
 const READY_TIMEOUT: Duration = Duration::from_mins(1);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -90,13 +91,23 @@ impl MartinBuilder {
         self
     }
 
-    /// Serve from the `PostgreSQL` database that `DATABASE_URL` points at.
+    // The two helpers below stay separate because martin rejects a config file combined with CLI
+    // connection arguments (`ConfigAndConnectionsError`).
+    /// Make `DATABASE_URL` visible to the subprocess so a config file can expand `${DATABASE_URL}`.
+    ///
+    /// Martin no longer connects to it on its own, so this is only useful together with
+    /// [`MartinBuilder::config`]; use [`MartinBuilder::with_postgres_connection`] otherwise.
     #[must_use]
     pub fn with_postgres(mut self) -> Self {
-        let url = env::var("DATABASE_URL")
-            .expect("DATABASE_URL must point at the test database; start it with `just start`");
-        self.database_url = Some(url);
+        self.database_url = Some(test_database_url());
         self
+    }
+
+    /// Serve from the `PostgreSQL` database that `DATABASE_URL` points at, passing its connection
+    /// string as a CLI argument the way a user now has to.
+    #[must_use]
+    pub fn with_postgres_connection(self) -> Self {
+        self.arg(test_database_url())
     }
 
     /// Spawn martin and wait until it responds over HTTP.
@@ -124,6 +135,19 @@ impl MartinBuilder {
         }
         if let Some(url) = &self.database_url {
             cmd.env("DATABASE_URL", url);
+        }
+        // The harness's own PGSSL* variables, if the test runner set any (CI does for the
+        // verify-ca/verify-full sslmode matrix, and `just test-ssl-cert` does for client-cert
+        // auth), become explicit CLI flags the way a real deployer now has to pass them -- martin
+        // itself no longer reads these variables.
+        if let Ok(root_cert) = env::var("PGSSLROOTCERT") {
+            cmd.arg("--ca-root-file").arg(root_cert);
+        }
+        if let Ok(cert) = env::var("PGSSLCERT") {
+            cmd.arg("--ssl-cert").arg(cert);
+        }
+        if let Ok(key) = env::var("PGSSLKEY") {
+            cmd.arg("--ssl-key").arg(key);
         }
 
         let mut child = cmd.spawn().map_err(StartError::Spawn)?;

--- a/e2e-tests/src/martin_cp.rs
+++ b/e2e-tests/src/martin_cp.rs
@@ -4,14 +4,13 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Stdio;
 
-use crate::{binary_command, display_args, workspace_root};
+use crate::{binary_command, display_args, test_database_url, workspace_root};
 
 /// One run of the `martin-cp` binary, which reaches a database only through
 /// [`MartinCp::with_postgres`].
 #[derive(Debug, Default)]
 pub struct MartinCp {
     args: Vec<OsString>,
-    database_url: Option<String>,
 }
 
 impl MartinCp {
@@ -27,13 +26,11 @@ impl MartinCp {
         self
     }
 
-    /// Copy from the `PostgreSQL` database that `DATABASE_URL` points at.
+    /// Copy from the `PostgreSQL` database that `DATABASE_URL` points at, passing its connection
+    /// string as a CLI argument the way a user now has to.
     #[must_use]
-    pub fn with_postgres(mut self) -> Self {
-        let url = env::var("DATABASE_URL")
-            .expect("DATABASE_URL must point at the test database; start it with `just start`");
-        self.database_url = Some(url);
-        self
+    pub fn with_postgres(self) -> Self {
+        self.arg(test_database_url())
     }
 
     /// Run the copy, require it to succeed, and return what it logged.
@@ -45,8 +42,16 @@ impl MartinCp {
             .env("RUST_LOG_FORMAT", "bare")
             .args(&self.args)
             .stdin(Stdio::null());
-        if let Some(url) = &self.database_url {
-            cmd.env("DATABASE_URL", url);
+        // See the matching comment in `MartinBuilder::start`: martin-cp shares `PostgresArgs`
+        // with martin, so it needs the same PGSSL* -> CLI-flag translation.
+        if let Ok(root_cert) = env::var("PGSSLROOTCERT") {
+            cmd.arg("--ca-root-file").arg(root_cert);
+        }
+        if let Ok(cert) = env::var("PGSSLCERT") {
+            cmd.arg("--ssl-cert").arg(cert);
+        }
+        if let Ok(key) = env::var("PGSSLKEY") {
+            cmd.arg("--ssl-key").arg(key);
         }
         let described = display_args(&self.args);
         let output = cmd

--- a/e2e-tests/tests/env_vars.rs
+++ b/e2e-tests/tests/env_vars.rs
@@ -1,0 +1,93 @@
+//! Legacy environment variables martin used to configure itself from.
+//!
+//! Martin now takes its settings from CLI parameters and config files only. The variables below are
+//! still detected, but only so that startup can point at the replacement -- they change nothing.
+
+use std::fs;
+
+use martin_e2e_tests::Martin;
+use tempfile::TempDir;
+
+/// Deliberately unreachable: a martin that still honoured `DATABASE_URL` would fail to start.
+/// The password is here so the tests can prove it never reaches the log.
+const LEGACY_URL: &str = "postgres://legacy_user:legacy_secret@127.0.0.1:1/legacy_db";
+const LEGACY_PASSWORD: &str = "legacy_secret";
+
+const PMTILES_SOURCE: &str = "
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+";
+
+#[tokio::test]
+async fn a_legacy_database_url_adds_no_source_when_sources_come_from_the_cli() {
+    let dir = TempDir::new().expect("failed to create a temp dir");
+    let save_config = dir.path().join("save_config.yaml");
+    let mut martin = Martin::builder()
+        .env("DATABASE_URL", LEGACY_URL)
+        .env("DEFAULT_SRID", "900913")
+        .arg("tests/fixtures/pmtiles/png.pmtiles")
+        .arg("--save-config")
+        .arg(&save_config)
+        .start()
+        .await
+        .expect("martin must ignore DATABASE_URL rather than connect to it");
+
+    let saved = fs::read_to_string(&save_config).expect("martin did not write --save-config");
+    assert!(
+        !saved.contains("postgres"),
+        "DATABASE_URL must not publish a postgres source; saved config:\n{saved}"
+    );
+
+    martin.stop().await;
+    // All three checks below land on the same warning line, so they read it once instead of
+    // calling `assert_log_contains` three times -- that consumes (removes) the whole matching
+    // line on its first call, which would make the second and third checks fail spuriously.
+    let warning = martin.take_log_lines("Environment variable DATABASE_URL is set but ignored");
+    assert_eq!(
+        warning.len(),
+        1,
+        "expected exactly one DATABASE_URL warning; log:\n{}",
+        warning.join("\n")
+    );
+    assert!(
+        warning[0].contains(r#"martin "$DATABASE_URL""#),
+        "warning is missing the CLI replacement: {}",
+        warning[0]
+    );
+    assert!(
+        warning[0].contains("postgres.connection_string: ${DATABASE_URL}"),
+        "warning is missing the config replacement: {}",
+        warning[0]
+    );
+    martin.assert_log_contains("Environment variable DEFAULT_SRID is set but ignored");
+    assert_no_secret_in_log(&mut martin);
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn a_legacy_database_url_is_reported_next_to_a_config_file_that_does_not_use_it() {
+    let mut martin = Martin::builder()
+        .env("DATABASE_URL", LEGACY_URL)
+        .config(PMTILES_SOURCE)
+        .start()
+        .await
+        .expect("martin must ignore DATABASE_URL rather than connect to it");
+
+    martin.stop().await;
+    martin.assert_log_contains("Environment variable DATABASE_URL is set but ignored");
+    assert_no_secret_in_log(&mut martin);
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+/// The warning names the variable; printing what is in it would leak a password into the log.
+fn assert_no_secret_in_log(martin: &mut Martin) {
+    let leaked = martin.take_log_lines(LEGACY_PASSWORD);
+    assert!(
+        leaked.is_empty(),
+        "the log leaked the value of DATABASE_URL:\n{}",
+        leaked.join("\n")
+    );
+}

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -14,7 +14,7 @@ async fn martin_with_postgres() -> Martin {
 
 async fn start_with_postgres(builder: MartinBuilder) -> Martin {
     builder
-        .with_postgres()
+        .with_postgres_connection()
         // also adopt tables whose geometry column has SRID 0
         .arg("--default-srid")
         .arg("900913")

--- a/justfile
+++ b/justfile
@@ -531,11 +531,12 @@ restart:
     {{just}} start
 
 # Start Martin server
-run *args='--webui enable-for-all': fetch
+# Martin no longer picks DATABASE_URL up on its own, so the default args pass it explicitly.
+run *args=('--webui enable-for-all ' + quote(DATABASE_URL)): fetch
     cargo run -p martin -- {{args}}
 
 # Start release-compiled Martin server and a test database
-run-release *args='--webui enable-for-all': fetch start
+run-release *args=('--webui enable-for-all ' + quote(DATABASE_URL)): fetch start
     cargo run -p martin --release -- {{args}}
 
 # Check semver compatibility with prior published version. Install it with `cargo install cargo-semver-checks`

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use tracing::{info, warn};
+use tracing::info;
 
 use super::bounds::BoundsCalcType;
 use super::connections::Arguments;
@@ -9,7 +9,6 @@ use crate::config::file::UnrecognizedValues;
 use crate::config::file::postgres::{
     DEFAULT_POOL_SIZE, DEFAULT_RELOAD_INTERVAL, PostgresConfig, PostgresSslCerts,
 };
-use crate::config::primitives::env::Env;
 use crate::config::primitives::{OptBoolObj, OptOneMany};
 
 #[derive(clap::Args, Debug, PartialEq, Default)]
@@ -35,17 +34,19 @@ pub struct PostgresArgs {
     /// Can be either a positive integer or unlimited if omitted.
     #[arg(short, long)]
     pub max_feature_count: Option<usize>,
+    /// A file with a client SSL certificate. Replaces the `PGSSLCERT` environment variable.
+    #[arg(long)]
+    pub ssl_cert: Option<std::path::PathBuf>,
+    /// A file with the key for the client SSL certificate. Replaces the `PGSSLKEY` environment variable.
+    #[arg(long)]
+    pub ssl_key: Option<std::path::PathBuf>,
 }
 
 impl PostgresArgs {
-    pub fn into_config(
-        self,
-        cli_strings: &mut Arguments,
-        env: &impl Env,
-    ) -> OptOneMany<PostgresConfig> {
-        let connections = Self::extract_conn_strings(cli_strings, env);
-        let default_srid = self.get_default_srid(env);
-        let certs = self.get_certs(env);
+    pub fn into_config(self, cli_strings: &mut Arguments) -> OptOneMany<PostgresConfig> {
+        let connections = Self::extract_conn_strings(cli_strings);
+        let default_srid = self.default_srid;
+        let certs = self.get_certs();
 
         let results: Vec<_> = connections
             .into_iter()
@@ -84,6 +85,8 @@ impl PostgresArgs {
             auto_bounds,
             max_feature_count,
             ca_root_file,
+            ssl_cert,
+            ssl_key,
         } = self;
 
         if let Some(value) = default_srid {
@@ -127,68 +130,43 @@ impl PostgresArgs {
                 c.ssl_certificates.ssl_root_cert.clone_from(&ca_root_file);
             });
         }
+        if let Some(ref value) = ssl_cert {
+            info!(
+                "Overriding client SSL certificate to {} on all Postgres connections because of a CLI parameter",
+                value.display()
+            );
+            pg_config.iter_mut().for_each(|c| {
+                c.ssl_certificates.ssl_cert.clone_from(&ssl_cert);
+            });
+        }
+        if let Some(ref value) = ssl_key {
+            info!(
+                "Overriding client SSL key to {} on all Postgres connections because of a CLI parameter",
+                value.display()
+            );
+            pg_config.iter_mut().for_each(|c| {
+                c.ssl_certificates.ssl_key.clone_from(&ssl_key);
+            });
+        }
     }
 
-    fn extract_conn_strings(cli_strings: &mut Arguments, env: &impl Env) -> Vec<String> {
-        let mut connections = cli_strings.process(|v| {
+    fn extract_conn_strings(cli_strings: &mut Arguments) -> Vec<String> {
+        cli_strings.process(|v| {
             if is_postgres_connection_string(v) {
                 Take(v.to_owned())
             } else {
                 Ignore
             }
-        });
-        if connections.is_empty()
-            && let Some(s) = env.get_env_str("DATABASE_URL")
-        {
-            if is_postgres_connection_string(&s) {
-                info!("Using env var DATABASE_URL to connect to PostgreSQL");
-                connections.push(s);
-            } else {
-                warn!("Environment var DATABASE_URL is not a valid postgres connection string");
-            }
-        }
-
-        connections
+        })
     }
 
-    fn get_default_srid(&self, env: &impl Env) -> Option<i32> {
-        if self.default_srid.is_some() {
-            return self.default_srid;
-        }
-        let srid = env.get_env_str("DEFAULT_SRID")?;
-        match srid.parse::<i32>() {
-            Ok(v) => {
-                info!("Using env var DEFAULT_SRID={v} to set default SRID");
-                Some(v)
-            }
-            Err(v) => {
-                warn!("Env var DEFAULT_SRID is not a valid integer {srid}: {v}");
-                None
-            }
-        }
-    }
-
-    fn get_certs(&self, env: &impl Env) -> PostgresSslCerts {
-        let mut result = PostgresSslCerts {
-            ssl_cert: Self::parse_env_var(env, "PGSSLCERT", "ssl certificate"),
-            ssl_key: Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate"),
+    fn get_certs(&self) -> PostgresSslCerts {
+        PostgresSslCerts {
+            ssl_cert: self.ssl_cert.clone(),
+            ssl_key: self.ssl_key.clone(),
             ssl_root_cert: self.ca_root_file.clone(),
             unrecognized: UnrecognizedValues::default(),
-        };
-        if result.ssl_root_cert.is_none() {
-            result.ssl_root_cert = Self::parse_env_var(env, "PGSSLROOTCERT", "root certificate(s)");
         }
-
-        result
-    }
-
-    fn parse_env_var(env: &impl Env, env_var: &str, info: &str) -> Option<std::path::PathBuf> {
-        let path = env.var_os(env_var).map(std::path::PathBuf::from);
-        if let Some(p) = &path {
-            let p = p.display();
-            info!("Using env {env_var}={p} to load {info}");
-        }
-        path
     }
 }
 
@@ -199,12 +177,10 @@ fn is_postgres_connection_string(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
     use std::path::PathBuf;
 
     use super::*;
     use crate::MartinError;
-    use crate::config::primitives::env::FauxEnv;
 
     #[test]
     fn extracts_conn_strings() {
@@ -214,7 +190,7 @@ mod tests {
             "mysql://localhost:3306".to_owned(),
         ]);
         assert_eq!(
-            PostgresArgs::extract_conn_strings(&mut args, &FauxEnv::default()),
+            PostgresArgs::extract_conn_strings(&mut args),
             vec!["postgresql://localhost:5432", "postgres://localhost:5432"]
         );
         assert!(matches!(args.check(), Err(
@@ -222,25 +198,19 @@ mod tests {
     }
 
     #[test]
-    fn extract_conn_strings_from_env() {
+    fn no_cli_connection_yields_no_config() {
+        // `DATABASE_URL` used to fill this in implicitly; connections now come from the CLI or
+        // from a config file only.
         let mut args = Arguments::new(vec![]);
-        let env = FauxEnv(
-            vec![(
-                "DATABASE_URL",
-                OsString::from("postgresql://localhost:5432"),
-            )]
-            .into_iter()
-            .collect(),
-        );
-        let strings = PostgresArgs::extract_conn_strings(&mut args, &env);
-        assert_eq!(strings, vec!["postgresql://localhost:5432"]);
+        let config = PostgresArgs::default().into_config(&mut args);
+        assert_eq!(config, OptOneMany::NoVals);
         args.check().unwrap();
     }
 
     #[test]
     fn merge_into_config() {
         let mut args = Arguments::new(vec!["postgres://localhost:5432".to_owned()]);
-        let config = PostgresArgs::default().into_config(&mut args, &FauxEnv::default());
+        let config = PostgresArgs::default().into_config(&mut args);
         assert_eq!(
             config,
             OptOneMany::One(PostgresConfig {
@@ -251,19 +221,16 @@ mod tests {
         args.check().unwrap();
     }
 
+    /// The CLI replacements for the removed `DEFAULT_SRID` and `PGSSLROOTCERT` variables.
     #[test]
     fn merge_into_config2() {
-        let mut args = Arguments::new(vec![]);
-        let env = FauxEnv(
-            vec![
-                ("DATABASE_URL", OsString::from("postgres://localhost:5432")),
-                ("DEFAULT_SRID", OsString::from("10")),
-                ("PGSSLROOTCERT", OsString::from("file")),
-            ]
-            .into_iter()
-            .collect(),
-        );
-        let config = PostgresArgs::default().into_config(&mut args, &env);
+        let mut args = Arguments::new(vec!["postgres://localhost:5432".to_owned()]);
+        let pg_args = PostgresArgs {
+            default_srid: Some(10),
+            ca_root_file: Some(PathBuf::from("file")),
+            ..Default::default()
+        };
+        let config = pg_args.into_config(&mut args);
         assert_eq!(
             config,
             OptOneMany::One(PostgresConfig {
@@ -279,25 +246,18 @@ mod tests {
         args.check().unwrap();
     }
 
+    /// The CLI replacements for the removed `PGSSLCERT` and `PGSSLKEY` variables.
     #[test]
     fn merge_into_config3() {
-        let mut args = Arguments::new(vec![]);
-        let env = FauxEnv(
-            vec![
-                ("DATABASE_URL", OsString::from("postgres://localhost:5432")),
-                ("DEFAULT_SRID", OsString::from("10")),
-                ("PGSSLCERT", OsString::from("cert")),
-                ("PGSSLKEY", OsString::from("key")),
-                ("PGSSLROOTCERT", OsString::from("root")),
-            ]
-            .into_iter()
-            .collect(),
-        );
+        let mut args = Arguments::new(vec!["postgres://localhost:5432".to_owned()]);
         let pg_args = PostgresArgs {
             default_srid: Some(20),
+            ssl_cert: Some(PathBuf::from("cert")),
+            ssl_key: Some(PathBuf::from("key")),
+            ca_root_file: Some(PathBuf::from("root")),
             ..Default::default()
         };
-        let config = pg_args.into_config(&mut args, &env);
+        let config = pg_args.into_config(&mut args);
         assert_eq!(
             config,
             OptOneMany::One(PostgresConfig {
@@ -313,5 +273,35 @@ mod tests {
             })
         );
         args.check().unwrap();
+    }
+
+    /// A config file's values must survive; the SSL CLI flags override them like `--ca-root-file`.
+    #[test]
+    fn override_config_applies_ssl_cli_flags() {
+        let mut config = OptOneMany::One(PostgresConfig {
+            connection_string: Some("postgres://localhost:5432".to_owned()),
+            ssl_certificates: PostgresSslCerts {
+                ssl_cert: Some(PathBuf::from("from-config")),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        PostgresArgs {
+            ssl_cert: Some(PathBuf::from("from-cli")),
+            ssl_key: Some(PathBuf::from("key-from-cli")),
+            ..Default::default()
+        }
+        .override_config(&mut config);
+        let OptOneMany::One(cfg) = config else {
+            panic!("expected exactly one postgres config");
+        };
+        assert_eq!(
+            cfg.ssl_certificates.ssl_cert,
+            Some(PathBuf::from("from-cli"))
+        );
+        assert_eq!(
+            cfg.ssl_certificates.ssl_key,
+            Some(PathBuf::from("key-from-cli"))
+        );
     }
 }

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -28,6 +28,8 @@ use crate::config::file::ConfigurationLivecycleHooks;
 use crate::config::file::FileConfigEnum;
 #[cfg(feature = "fonts")]
 use crate::config::file::fonts::FontConfig;
+#[cfg(feature = "postgres")]
+use crate::config::file::warn_legacy_env_vars;
 use crate::config::file::{Config, OnInvalid};
 #[cfg(feature = "postgres")]
 use crate::config::primitives::env::Env;
@@ -105,6 +107,13 @@ impl Args {
             return Err(ConfigAndConnectionsError(self.meta.connection));
         }
 
+        // With a config file, `read_config` has already reported the legacy environment variables
+        // against its contents, skipping the ones the file explicitly references.
+        #[cfg(feature = "postgres")]
+        if self.meta.config.is_none() {
+            warn_legacy_env_vars(env, None);
+        }
+
         if self.srv.cache_size.is_some() {
             config.cache.size_mb = self.srv.cache_size;
         }
@@ -140,7 +149,7 @@ impl Args {
         {
             let pg_args = self.pg.unwrap_or_default();
             if config.postgres.is_none() {
-                config.postgres = pg_args.into_config(&mut cli_strings, env);
+                config.postgres = pg_args.into_config(&mut cli_strings);
             } else {
                 // config was loaded from a file, we can only apply a few CLI overrides to it
                 pg_args.override_config(&mut config.postgres);
@@ -395,6 +404,76 @@ mod tests {
             let res = Args::try_parse_from(params);
             assert!(res.is_err(), "Expected error, got: {res:?} for {params:?}");
         }
+    }
+
+    /// The environment used to be a source of configuration all by itself. It no longer is.
+    #[test]
+    #[cfg(feature = "postgres")]
+    fn cli_ignores_the_legacy_env_vars() {
+        let args = Args::parse_from(["martin"]);
+
+        let mut config = Config::default();
+        args.merge_into_config(&mut config, &legacy_env()).unwrap();
+
+        assert_eq!(config, Config::default());
+    }
+
+    /// The CLI replacements win, and are not disturbed by the legacy variables still being set.
+    #[test]
+    #[cfg(feature = "postgres")]
+    fn cli_replacements_configure_what_the_legacy_env_used_to() {
+        use crate::config::primitives::OptOneMany;
+
+        let args = Args::parse_from([
+            "martin",
+            "--default-srid",
+            "4326",
+            "--ssl-cert",
+            "cli.crt",
+            "--ssl-key",
+            "cli.key",
+            "--ca-root-file",
+            "cli-root.crt",
+            "postgres://localhost:5432/from-cli",
+        ]);
+
+        let mut config = Config::default();
+        args.merge_into_config(&mut config, &legacy_env()).unwrap();
+
+        let pg = match config.postgres {
+            OptOneMany::One(pg) => pg,
+            other => panic!("expected exactly one postgres config, got: {other:?}"),
+        };
+        assert_eq!(
+            pg.connection_string.as_deref(),
+            Some("postgres://localhost:5432/from-cli")
+        );
+        assert_eq!(pg.default_srid, Some(4326));
+        assert_eq!(pg.ssl_certificates.ssl_cert, Some(PathBuf::from("cli.crt")));
+        assert_eq!(pg.ssl_certificates.ssl_key, Some(PathBuf::from("cli.key")));
+        assert_eq!(
+            pg.ssl_certificates.ssl_root_cert,
+            Some(PathBuf::from("cli-root.crt"))
+        );
+    }
+
+    /// Every variable martin used to read implicitly, all set at once.
+    #[cfg(feature = "postgres")]
+    fn legacy_env() -> FauxEnv {
+        use std::ffi::OsString;
+
+        [
+            (
+                "DATABASE_URL",
+                OsString::from("postgres://localhost:5432/from-env"),
+            ),
+            ("DEFAULT_SRID", OsString::from("900913")),
+            ("PGSSLCERT", OsString::from("env.crt")),
+            ("PGSSLKEY", OsString::from("env.key")),
+            ("PGSSLROOTCERT", OsString::from("env-root.crt")),
+        ]
+        .into_iter()
+        .collect()
     }
 
     #[test]

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -258,7 +258,7 @@ impl Diagnostic for ConfigFileError {
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         let help: &'static str = match self {
             Self::NoSources => {
-                "Provide tile sources via --connection, environment variables (e.g. DATABASE_URL), or a config file passed with --config."
+                "Provide tile sources as connection arguments (e.g. `martin postgres://...`), or in a config file passed with --config."
             }
             Self::CorsNoOriginsConfigured => {
                 "Either set `cors: true` (allow all origins) or provide at least one entry in `origin` under the cors block."

--- a/martin/src/config/file/main/parse.rs
+++ b/martin/src/config/file/main/parse.rs
@@ -13,34 +13,79 @@ pub fn read_config(file_name: &Path, env: &impl Env) -> ConfigFileResult<Config>
     let contents = std::fs::read_to_string(file_name)
         .map_err(|e| ConfigFileError::ConfigLoadError(e, file_name.into()))?;
     #[cfg(feature = "postgres")]
-    warn_unused_pg_env_vars(env, &contents);
+    warn_legacy_env_vars(env, Some(&contents));
     parse_config(&contents, &env.as_property_map(), file_name)
 }
 
+/// Environment variables Martin used to configure itself from automatically, each paired with the
+/// CLI flag and the config file key that replace it.
+///
+/// Martin no longer reads any of these; they are only detected so that a startup warning can point
+/// at the replacement. Only the *names* are ever logged -- `DATABASE_URL` and the SSL paths are
+/// sensitive.
 #[cfg(feature = "postgres")]
-fn warn_unused_pg_env_vars(env: &impl Env, contents: &str) {
-    let set_vars: Vec<&str> = [
+const LEGACY_ENV_VARS: [(&str, &str, &str); 5] = [
+    (
         "DATABASE_URL",
+        r#"martin "$DATABASE_URL""#,
+        "postgres.connection_string: ${DATABASE_URL}",
+    ),
+    (
         "DEFAULT_SRID",
+        r#"--default-srid "$DEFAULT_SRID""#,
+        "postgres.default_srid: ${DEFAULT_SRID}",
+    ),
+    (
         "PGSSLCERT",
+        r#"--ssl-cert "$PGSSLCERT""#,
+        "postgres.ssl_cert: ${PGSSLCERT}",
+    ),
+    (
         "PGSSLKEY",
+        r#"--ssl-key "$PGSSLKEY""#,
+        "postgres.ssl_key: ${PGSSLKEY}",
+    ),
+    (
         "PGSSLROOTCERT",
-    ]
-    .into_iter()
-    .filter(|v| env.var_os(v).is_some())
-    .collect();
+        r#"--ca-root-file "$PGSSLROOTCERT""#,
+        "postgres.ssl_root_cert: ${PGSSLROOTCERT}",
+    ),
+];
+
+/// Warn once at startup about the environment variables Martin used to configure itself from that
+/// are set but no longer used.
+///
+/// `config_contents` is the raw YAML of the config file that was loaded, if any. A variable the
+/// config explicitly references as `${VAR}` is doing exactly what it should, so it is not reported.
+/// Variable values are never logged.
+#[cfg(feature = "postgres")]
+pub fn warn_legacy_env_vars(env: &impl Env, config_contents: Option<&str>) {
+    let set_vars: Vec<_> = LEGACY_ENV_VARS
+        .into_iter()
+        .filter(|(name, _, _)| env.var_os(name).is_some())
+        .collect();
     if set_vars.is_empty() {
         return;
     }
-    let Ok(value) = serde_saphyr::from_str::<serde_json::Value>(contents) else {
-        return;
+    let referenced = match config_contents {
+        // An unparseable config is about to abort startup with a proper diagnostic; staying quiet
+        // beats claiming a variable is unused when we cannot tell whether it is referenced.
+        Some(contents) => match serde_saphyr::from_str::<serde_json::Value>(contents) {
+            Ok(value) => Some(value),
+            Err(_) => return,
+        },
+        None => None,
     };
-    for v in set_vars {
-        if !json_value_references_var(&value, v) {
-            warn!(
-                "Environment variable {v} is set, but will be ignored because a configuration file was loaded. Any environment variables can be used inside the config yaml file."
-            );
+    for (name, cli, config_key) in set_vars {
+        if referenced
+            .as_ref()
+            .is_some_and(|value| json_value_references_var(value, name))
+        {
+            continue;
         }
+        warn!(
+            "Environment variable {name} is set but ignored: Martin no longer configures itself from environment variables. Pass it on the command line (`{cli}`), or reference it from a config file (`{config_key}`). See https://maplibre.org/martin/env-vars/"
+        );
     }
 }
 
@@ -741,6 +786,110 @@ mod tests {
                 !string_references_var(s, "DATABASE_URL"),
                 "expected no hit in {s:?}"
             );
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    mod legacy_env {
+        use std::ffi::OsString;
+
+        use super::super::warn_legacy_env_vars;
+        use crate::config::primitives::env::FauxEnv;
+
+        const SECRET: &str = "postgres://user:hunter2@localhost/db";
+
+        fn faux(pairs: &[(&'static str, &str)]) -> FauxEnv {
+            pairs
+                .iter()
+                .map(|(k, v)| (*k, OsString::from(*v)))
+                .collect()
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn no_warning_without_legacy_vars() {
+            warn_legacy_env_vars(&FauxEnv::default(), None);
+            assert!(!logs_contain("is set but ignored"));
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn warns_with_cli_and_config_replacement_without_a_config_file() {
+            warn_legacy_env_vars(&faux(&[("DATABASE_URL", SECRET)]), None);
+            assert!(logs_contain(
+                "Environment variable DATABASE_URL is set but ignored"
+            ));
+            assert!(logs_contain(r#"martin "$DATABASE_URL""#));
+            assert!(logs_contain("postgres.connection_string: ${DATABASE_URL}"));
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn never_logs_the_value() {
+            warn_legacy_env_vars(
+                &faux(&[
+                    ("DATABASE_URL", SECRET),
+                    ("PGSSLKEY", "/secrets/postgresql.key"),
+                ]),
+                None,
+            );
+            assert!(!logs_contain("hunter2"));
+            assert!(!logs_contain("/secrets/postgresql.key"));
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn every_legacy_var_is_reported() {
+            let env = faux(&[
+                ("DATABASE_URL", SECRET),
+                ("DEFAULT_SRID", "4326"),
+                ("PGSSLCERT", "cert"),
+                ("PGSSLKEY", "key"),
+                ("PGSSLROOTCERT", "root"),
+            ]);
+            warn_legacy_env_vars(&env, None);
+            for (name, _, _) in super::super::LEGACY_ENV_VARS {
+                assert!(
+                    logs_contain(&format!("Environment variable {name} is set but ignored")),
+                    "{name} was not reported"
+                );
+            }
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn explicit_config_reference_is_not_reported() {
+            warn_legacy_env_vars(
+                &faux(&[("DATABASE_URL", SECRET)]),
+                Some("postgres:\n  connection_string: ${DATABASE_URL}\n"),
+            );
+            assert!(!logs_contain("is set but ignored"));
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn unreferenced_var_is_reported_even_with_a_config_file() {
+            warn_legacy_env_vars(
+                &faux(&[("DATABASE_URL", SECRET), ("DEFAULT_SRID", "4326")]),
+                Some("postgres:\n  connection_string: ${DATABASE_URL}\n"),
+            );
+            assert!(!logs_contain(
+                "Environment variable DATABASE_URL is set but ignored"
+            ));
+            assert!(logs_contain(
+                "Environment variable DEFAULT_SRID is set but ignored"
+            ));
+        }
+
+        #[test]
+        #[tracing_test::traced_test]
+        fn unparseable_config_stays_quiet() {
+            // The same unbalanced quote `syntax_error_unbalanced_quote` above pins as a parse error.
+            warn_legacy_env_vars(
+                &faux(&[("DATABASE_URL", SECRET)]),
+                Some("srv:\n  listen_addresses: \"0.0.0.0:3000\n  worker_processes: 4\n"),
+            );
+            assert!(!logs_contain("is set but ignored"));
         }
     }
 }


### PR DESCRIPTION
Closes #1052

## Summary

Martin no longer implicitly configures itself from:

- `DATABASE_URL`
- `DEFAULT_SRID`
- `PGSSLCERT`
- `PGSSLKEY`
- `PGSSLROOTCERT`

Configuration now comes from CLI arguments and config files.

Explicit environment substitution inside config files remains supported, including `${VAR}`-style values.

Legacy variables are detected and produce migration guidance without printing their values.

## Migration

| Legacy variable | CLI replacement | Config replacement |
| --- | --- | --- |
| `DATABASE_URL` | positional connection string | `postgres.connection_string` |
| `DEFAULT_SRID` | `--default-srid` | `postgres.default_srid` |
| `PGSSLCERT` | `--ssl-cert` *(new)* | `postgres.ssl_cert` |
| `PGSSLKEY` | `--ssl-key` *(new)* | `postgres.ssl_key` |
| `PGSSLROOTCERT` | `--ca-root-file` | `postgres.ssl_root_cert` |

`--ssl-cert` and `--ssl-key` are new CLI flags, added because those two previously had no CLI equivalent; they mirror `--ca-root-file`.

The e2e test harness was updated to explicitly forward SSL cert paths through CLI flags (instead of relying on the removed implicit env reads), so the existing verify-ca/verify-full CI matrix and `just test-ssl-cert` keep working.

The pmtiles `AWS_*` compatibility shim is intentionally untouched — it already warns and migrates into `pmtiles.*` config keys, and CI depends on it. Happy to remove it in a follow-up if that's in scope for this issue.

## Testing

- `cargo check --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets` (warnings denied)
- `cargo build -p martin`
- `cargo test --package martin-e2e-tests --test env_vars` (new, no database needed)
- Relevant `martin` crate unit tests (config/CLI/postgres args)
- DB-backed e2e tests (`config_file`, `martin_cp`, `postgres`, `process`) compile successfully

DB-backed e2e tests were not executed locally because Docker/Linux containers were unavailable on the Windows development machine. Those tests should be validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)