### PR TITLE
refactor(reload): build advisory additions and updates concurrently

### DIFF
--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -393,7 +393,7 @@ pub async fn resolve_files<T: TileSourceConfiguration>(
 
 /// How many tile sources are opened at once at startup and on reload.
 /// Opening a remote source is a few dependent round trips, so serial opens cost latency times source count.
-/// 
+///
 /// FIXME: make this constant dependent on system size (number of cores) and source types (local/remote)
 #[cfg(feature = "_tiles")]
 pub const MAX_CONCURRENT_SOURCE_INITS: usize = 64;

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -391,6 +391,12 @@ pub async fn resolve_files<T: TileSourceConfiguration>(
     resolve_int(config, idr, extension, default_cache).await
 }
 
+/// How many tile sources are opened at once at startup and on reload. Opening a remote source is
+/// a few dependent round trips, so serial opens cost latency times source count; this bounds the
+/// fan-out so thousands of sources do not mean thousands of simultaneous requests.
+#[cfg(feature = "_tiles")]
+pub const MAX_CONCURRENT_SOURCE_INITS: usize = 32;
+
 #[cfg(feature = "_tiles")]
 async fn resolve_int<T: TileSourceConfiguration>(
     config: &mut FileConfigEnum<T>,

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -391,11 +391,12 @@ pub async fn resolve_files<T: TileSourceConfiguration>(
     resolve_int(config, idr, extension, default_cache).await
 }
 
-/// How many tile sources are opened at once at startup and on reload. Opening a remote source is
-/// a few dependent round trips, so serial opens cost latency times source count; this bounds the
-/// fan-out so thousands of sources do not mean thousands of simultaneous requests.
+/// How many tile sources are opened at once at startup and on reload.
+/// Opening a remote source is a few dependent round trips, so serial opens cost latency times source count.
+/// 
+/// FIXME: make this constant dependent on system size (number of cores) and source types (local/remote)
 #[cfg(feature = "_tiles")]
-pub const MAX_CONCURRENT_SOURCE_INITS: usize = 32;
+pub const MAX_CONCURRENT_SOURCE_INITS: usize = 64;
 
 #[cfg(feature = "_tiles")]
 async fn resolve_int<T: TileSourceConfiguration>(

--- a/martin/src/reload.rs
+++ b/martin/src/reload.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use futures::stream::{self, StreamExt as _};
 use martin_core::tiles::BoxedSource;
 
 use crate::MartinResult;
-use crate::config::file::ProcessConfig;
+use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ProcessConfig};
 
 /// A source to be added or updated in the [`TileSourceManager`](super::TileSourceManager).
 #[derive(Debug)]
@@ -40,6 +41,7 @@ impl ReloadAdvisory {
     ///
     /// Any source that disappears is a removal; any source that appears is an addition.
     /// Sources that remain are left untouched (no update concept without versions).
+    /// Additions are built concurrently.
     pub async fn from_sets<F>(
         previous_ids: &BTreeSet<String>,
         next_ids: &BTreeSet<String>,
@@ -54,14 +56,12 @@ impl ReloadAdvisory {
             .map(|id| DeletedSource { id: id.clone() })
             .collect();
 
-        let mut additions: Vec<NewSource> = vec![];
-        for id in next_ids.difference(previous_ids) {
-            additions.push(NewSource {
-                id: id.clone(),
-                source: initializer(id.clone()).await,
-                process: process.clone(),
-            });
-        }
+        let additions = build_all(
+            next_ids.difference(previous_ids).cloned(),
+            &initializer,
+            &process,
+        )
+        .await;
 
         Self {
             additions,
@@ -73,7 +73,7 @@ impl ReloadAdvisory {
     /// Generates an advisory for **versioned** sources (e.g., `MBTiles`, COG).
     ///
     /// Compares keys and version values to distinguish between additions, removals,
-    /// and updates (version changed).
+    /// and updates (version changed). Additions and updates are built concurrently.
     pub async fn from_maps<F, V: Eq + Copy>(
         previous_map: &BTreeMap<String, V>,
         next_map: &BTreeMap<String, V>,
@@ -83,35 +83,27 @@ impl ReloadAdvisory {
     where
         F: AsyncFn(String) -> MartinResult<BoxedSource>,
     {
-        let mut advisory = Self::default();
+        let removals = previous_map
+            .keys()
+            .filter(|id| !next_map.contains_key(*id))
+            .map(|id| DeletedSource { id: id.clone() })
+            .collect();
 
-        for id in previous_map.keys() {
-            if !next_map.contains_key(id) {
-                advisory.removals.insert(DeletedSource { id: id.clone() });
-            }
-        }
-
+        let mut to_update = Vec::new();
+        let mut to_add = Vec::new();
         for (id, &next_version) in next_map {
             match previous_map.get(id) {
-                Some(&prev_version) if next_version != prev_version => {
-                    advisory.updates.push(NewSource {
-                        id: id.clone(),
-                        source: initializer(id.clone()).await,
-                        process: process.clone(),
-                    });
-                }
-                None => {
-                    advisory.additions.push(NewSource {
-                        id: id.clone(),
-                        source: initializer(id.clone()).await,
-                        process: process.clone(),
-                    });
-                }
+                Some(&prev_version) if next_version != prev_version => to_update.push(id.clone()),
+                None => to_add.push(id.clone()),
                 _ => {} // Unchanged
             }
         }
 
-        advisory
+        Self {
+            updates: build_all(to_update, &initializer, &process).await,
+            additions: build_all(to_add, &initializer, &process).await,
+            removals,
+        }
     }
 
     /// Returns `true` if there are no changes.
@@ -119,6 +111,28 @@ impl ReloadAdvisory {
     pub fn is_empty(&self) -> bool {
         self.additions.is_empty() && self.updates.is_empty() && self.removals.is_empty()
     }
+}
+
+/// Builds every id, at most [`MAX_CONCURRENT_SOURCE_INITS`] at a time, preserving input order.
+async fn build_all<F>(
+    ids: impl IntoIterator<Item = String>,
+    initializer: &F,
+    process: &ProcessConfig,
+) -> Vec<NewSource>
+where
+    F: AsyncFn(String) -> MartinResult<BoxedSource>,
+{
+    stream::iter(ids)
+        .map(|id| async move {
+            NewSource {
+                source: initializer(id.clone()).await,
+                id,
+                process: process.clone(),
+            }
+        })
+        .buffered(MAX_CONCURRENT_SOURCE_INITS)
+        .collect()
+        .await
 }
 
 #[cfg(test)]

--- a/martin/src/reload.rs
+++ b/martin/src/reload.rs
@@ -41,7 +41,6 @@ impl ReloadAdvisory {
     ///
     /// Any source that disappears is a removal; any source that appears is an addition.
     /// Sources that remain are left untouched (no update concept without versions).
-    /// Additions are built concurrently.
     pub async fn from_sets<F>(
         previous_ids: &BTreeSet<String>,
         next_ids: &BTreeSet<String>,
@@ -73,7 +72,7 @@ impl ReloadAdvisory {
     /// Generates an advisory for **versioned** sources (e.g., `MBTiles`, COG).
     ///
     /// Compares keys and version values to distinguish between additions, removals,
-    /// and updates (version changed). Additions and updates are built concurrently.
+    /// and updates (version changed).
     pub async fn from_maps<F, V: Eq + Copy>(
         previous_map: &BTreeMap<String, V>,
         next_map: &BTreeMap<String, V>,


### PR DESCRIPTION
First piece split out of #3130.

`ReloadAdvisory::from_sets`/`from_maps` awaited each source build one at a time, so a reconcile tick that picks up several sources pays their build latencies in sequence. This collects the ids first and builds them through a buffered stream, shared between both constructors as `build_all()`. Input order is preserved, and the fan-out is capped at `MAX_CONCURRENT_SOURCE_INITS` (32): #3122 showed what unbounded opens do once you have a few thousand sources.

Both issue-attached PRs sit on this hunk. #3130 needs it to keep `init()`-at-startup at parity with the old concurrent `resolve()` (0.645s → 0.642s on the 35-source test DB). #3131 carries it today and rebases down to just the pmtiles changes once this lands.

Signatures are unchanged; the existing advisory tests cover ordering and content.
