### PR TITLE
refactor(discovery): return warnings from Discovery::discover

### DIFF
--- a/martin/src/config/file/tiles/discovery/discovery_trait.rs
+++ b/martin/src/config/file/tiles/discovery/discovery_trait.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use martin_core::tiles::BoxedSource;
 
 use crate::MartinResult;
-use crate::config::file::ProcessConfig;
+use crate::config::file::{ProcessConfig, TileSourceWarning};
 
 /// Per-Source change-detection value. `Opaque` sources only diff on presence, never update.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -16,15 +16,31 @@ pub enum Version {
     Opaque,
 }
 
+/// One `discover()` observation: what should exist now, plus non-fatal findings along the way.
+pub struct Discovered<A> {
+    /// id -> (version, source arguments)
+    pub sources: BTreeMap<String, (Version, A)>,
+    /// Non-fatal findings (a misconfigured source, an unreadable path).
+    pub warnings: Vec<TileSourceWarning>,
+}
+
+impl<A> Discovered<A> {
+    #[must_use]
+    pub fn new(sources: BTreeMap<String, (Version, A)>) -> Self {
+        Self {
+            sources,
+            warnings: Vec::new(),
+        }
+    }
+}
+
 /// Enumerates the sources that should exist now, and builds one on demand.
 pub trait Discovery: Send + Sync + 'static {
     /// Per-source build payload passed from [`discover`](Self::discover) to [`build`](Self::build).
     type Args: Clone + Send + Sync + 'static;
 
     /// Cheap snapshot of id -> (version, source arguments); an `Err` makes the driver retain its baseline.
-    fn discover(
-        &self,
-    ) -> impl Future<Output = MartinResult<BTreeMap<String, (Version, Self::Args)>>> + Send;
+    fn discover(&self) -> impl Future<Output = MartinResult<Discovered<Self::Args>>> + Send;
 
     /// Builds one source; an `Err` rides into that source's `NewSource`.
     fn build(

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -10,7 +10,7 @@ use martin_core::tiles::BoxedSource;
 use tokio::fs::{self, DirEntry};
 
 use crate::config::file::file_config::is_remote_url;
-use crate::config::file::tiles::discovery::{Discovery, Version};
+use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
 use crate::config::file::{CachePolicy, FileConfigEnum, ProcessConfig};
 use crate::config::primitives::{IdResolver, OptOneMany};
 use crate::{MartinError, MartinResult};
@@ -115,7 +115,7 @@ impl FsDiscovery {
 impl Discovery for FsDiscovery {
     type Args = (PathBuf, CachePolicy);
 
-    async fn discover(&self) -> MartinResult<BTreeMap<String, (Version, Self::Args)>> {
+    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
         let discovered = discover_sources_by_ext(
             &self.directories,
             self.extensions,
@@ -124,12 +124,14 @@ impl Discovery for FsDiscovery {
         )
         .await?;
 
-        Ok(discovered
-            .into_iter()
-            .map(|(id, (path, modified_at_ms, policy))| {
-                (id, (Version::Tracked(modified_at_ms), (path, policy)))
-            })
-            .collect())
+        Ok(Discovered::new(
+            discovered
+                .into_iter()
+                .map(|(id, (path, modified_at_ms, policy))| {
+                    (id, (Version::Tracked(modified_at_ms), (path, policy)))
+                })
+                .collect(),
+        ))
     }
 
     async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {
@@ -253,7 +255,7 @@ mod tests {
             unreachable_builder(),
         );
 
-        let snapshot = discovery.discover().await.expect("discover");
+        let snapshot = discovery.discover().await.expect("discover").sources;
 
         let mut ids: Vec<&String> = snapshot.keys().collect();
         ids.sort();

--- a/martin/src/config/file/tiles/discovery/mod.rs
+++ b/martin/src/config/file/tiles/discovery/mod.rs
@@ -2,7 +2,7 @@
 //! `ObjectStoreDiscovery` for remote `PMTiles` prefixes.
 
 mod discovery_trait;
-pub use discovery_trait::{Discovery, Version};
+pub use discovery_trait::{Discovered, Discovery, Version};
 
 #[cfg(any(
     feature = "mbtiles",

--- a/martin/src/config/file/tiles/discovery/object_store.rs
+++ b/martin/src/config/file/tiles/discovery/object_store.rs
@@ -13,7 +13,7 @@ use crate::MartinResult;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;
-use crate::config::file::tiles::discovery::{Discovery, Version};
+use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
 use crate::config::file::{
     CachePolicy, ConfigFileError, FileConfigEnum, TileSourceConfiguration as _,
 };
@@ -95,7 +95,7 @@ impl ObjectStoreDiscovery {
 impl Discovery for ObjectStoreDiscovery {
     type Args = Url;
 
-    async fn discover(&self) -> MartinResult<BTreeMap<String, (Version, Self::Args)>> {
+    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
         // Per-prefix failures are logged and skipped so a transient outage doesn't flap the catalog.
         let mut out: BTreeMap<String, (Version, Url)> = BTreeMap::new();
         for prefix in &self.remote_prefixes {
@@ -112,7 +112,7 @@ impl Discovery for ObjectStoreDiscovery {
                 }
             }
         }
-        Ok(out)
+        Ok(Discovered::new(out))
     }
 
     async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -1,13 +1,12 @@
 //! [`PostgresDiscovery`]: a [`Discovery`] over a `PostgreSQL` connection's tables and functions.
 
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use martin_core::tiles::BoxedSource;
 use tokio::sync::OnceCell;
 
 use crate::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig, SourceSpec};
-use crate::config::file::tiles::discovery::{Discovery, Version};
+use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
 use crate::config::file::{CachePolicy, ProcessConfig};
 use crate::config::primitives::IdResolver;
 use crate::{MartinError, MartinResult};
@@ -70,15 +69,15 @@ impl PostgresDiscovery {
 impl Discovery for PostgresDiscovery {
     type Args = SourceSpec;
 
-    async fn discover(&self) -> MartinResult<BTreeMap<String, (Version, Self::Args)>> {
+    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
         let (specs, warnings) = self.builder().await?.discover().await?;
-        for warning in &warnings {
-            tracing::warn!(?warning, "tile source discovery warning during reload");
-        }
-        Ok(specs
-            .into_iter()
-            .map(|(id, spec)| (id, (Version::Tracked(spec.fingerprint()), spec)))
-            .collect())
+        Ok(Discovered {
+            sources: specs
+                .into_iter()
+                .map(|(id, spec)| (id, (Version::Tracked(spec.fingerprint()), spec)))
+                .collect(),
+            warnings,
+        })
     }
 
     async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {
@@ -134,7 +133,8 @@ mod tests {
         let snapshot = discovery_for(&connstr)
             .discover()
             .await
-            .expect("discovery discover");
+            .expect("discovery discover")
+            .sources;
 
         let snapshot_ids: Vec<&String> = snapshot.keys().collect();
         let spec_ids: Vec<&String> = specs.keys().collect();
@@ -168,8 +168,8 @@ mod tests {
         seed(&connstr, ROADS_TABLE_SQL).await;
 
         let discovery = discovery_for(&connstr);
-        let first = discovery.discover().await.expect("first discover");
-        let second = discovery.discover().await.expect("second discover");
+        let first = discovery.discover().await.expect("first discover").sources;
+        let second = discovery.discover().await.expect("second discover").sources;
         assert_eq!(
             versions(&first),
             versions(&second),
@@ -183,10 +183,18 @@ mod tests {
         seed(&connstr, ROADS_TABLE_SQL).await;
 
         let discovery = discovery_for(&connstr);
-        let before = discovery.discover().await.expect("discover before ALTER");
+        let before = discovery
+            .discover()
+            .await
+            .expect("discover before ALTER")
+            .sources;
 
         seed(&connstr, "ALTER TABLE public.roads ADD COLUMN name text;").await;
-        let after = discovery.discover().await.expect("discover after ALTER");
+        let after = discovery
+            .discover()
+            .await
+            .expect("discover after ALTER")
+            .sources;
 
         assert_ne!(
             before["roads"].0, after["roads"].0,
@@ -205,7 +213,7 @@ mod tests {
         .await;
 
         let discovery = discovery_for(&connstr);
-        let snapshot = discovery.discover().await.expect("discover");
+        let snapshot = discovery.discover().await.expect("discover").sources;
         let (_version, spec) = snapshot.get("points").expect("spec for points");
 
         let source = discovery.build("points", spec).await.expect("build");

--- a/martin/src/config/file/tiles/driver/reconcile.rs
+++ b/martin/src/config/file/tiles/driver/reconcile.rs
@@ -62,7 +62,7 @@ impl<D: Discovery, S: Sink> ReloadDriver<D, S> {
     /// startup, so applying would double-add.
     async fn seed(&mut self) {
         match self.discovery.discover().await {
-            Ok(next) => self.baseline = Some(next),
+            Ok(next) => self.baseline = Some(next.sources),
             Err(error) => {
                 tracing::warn!(?error, "reload seed discovery failed; baseline deferred");
             }
@@ -77,6 +77,10 @@ impl<D: Discovery, S: Sink> ReloadDriver<D, S> {
                 return;
             }
         };
+        for warning in &next.warnings {
+            tracing::warn!(%warning, "tile source discovery warning during reload");
+        }
+        let next = next.sources;
 
         let Some(prev) = self.baseline.as_ref() else {
             // No baseline yet (the seed failed): record it without applying, so already-served
@@ -133,6 +137,7 @@ mod tests {
 
     use super::*;
     use crate::config::file::ProcessConfig;
+    use crate::config::file::tiles::discovery::Discovered;
 
     /// A minimal in-memory [`Source`] returning a fixed tile; used to populate advisories.
     #[derive(Debug, Clone)]
@@ -228,14 +233,14 @@ mod tests {
     impl Discovery for FakeDiscovery {
         type Args = ();
 
-        fn discover(&self) -> impl Future<Output = MartinResult<Snapshot>> + Send {
+        fn discover(&self) -> impl Future<Output = MartinResult<Discovered<()>>> + Send {
             let snap = self
                 .snapshots
                 .lock()
                 .expect("FakeDiscovery mutex poisoned")
                 .pop_front()
                 .unwrap_or_else(|| Ok(Snapshot::new()));
-            std::future::ready(snap)
+            std::future::ready(snap.map(Discovered::new))
         }
 
         fn build(


### PR DESCRIPTION
Second piece split out of #3130.

`PostgresDiscovery` logged its discovery warnings inline, so the driver never saw them, and the other kinds had no channel to report any. `discover()` now returns `Discovered { sources, warnings }` and the `ReloadDriver` owns the logging: one place for every kind, same warn-per-tick behavior as before.

The reason beyond tidiness: #3130's `init()` has to hand these warnings to the caller's `on_invalid` policy (abortable at startup, warn-only live), and that's only possible once they're in the return value instead of a log side effect.

No behavior change on main.
