### PR TITLE
fix(postgres): keep per-source convert_to_* overrides on the reload path

### DIFF
--- a/martin/src/config/file/tiles/discovery/discovery_trait.rs
+++ b/martin/src/config/file/tiles/discovery/discovery_trait.rs
@@ -34,6 +34,22 @@ impl<A> Discovered<A> {
     }
 }
 
+/// A built source, with anything source-specific the catalog must apply alongside it.
+pub struct BuiltSource {
+    pub source: BoxedSource,
+    /// Per-source override of the kind's [`Discovery::process`], if the source configures one.
+    pub process: Option<ProcessConfig>,
+}
+
+impl From<BoxedSource> for BuiltSource {
+    fn from(source: BoxedSource) -> Self {
+        Self {
+            source,
+            process: None,
+        }
+    }
+}
+
 /// Enumerates the sources that should exist now, and builds one on demand.
 pub trait Discovery: Send + Sync + 'static {
     /// Per-source build payload passed from [`discover`](Self::discover) to [`build`](Self::build).
@@ -47,7 +63,7 @@ pub trait Discovery: Send + Sync + 'static {
         &self,
         id: &str,
         args: &Self::Args,
-    ) -> impl Future<Output = MartinResult<BoxedSource>> + Send;
+    ) -> impl Future<Output = MartinResult<BuiltSource>> + Send;
 
     /// `ProcessConfig` stamped onto every source this kind emits.
     fn process(&self) -> ProcessConfig;

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -10,13 +10,13 @@ use martin_core::tiles::BoxedSource;
 use tokio::fs::{self, DirEntry};
 
 use crate::config::file::file_config::is_remote_url;
-use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
+use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{CachePolicy, FileConfigEnum, ProcessConfig};
 use crate::config::primitives::{IdResolver, OptOneMany};
 use crate::{MartinError, MartinResult};
 
 /// The future an [`FsSourceBuilder`] returns: the freshly-built source, or an init error.
-type BuiltSource = BoxFuture<'static, MartinResult<BoxedSource>>;
+type BuildFuture = BoxFuture<'static, MartinResult<BoxedSource>>;
 
 /// Opens one discovered file as a source.
 ///
@@ -28,7 +28,7 @@ type BuiltSource = BoxFuture<'static, MartinResult<BoxedSource>>;
 /// The mbtiles/cog builders capture nothing and would coerce to a bare `fn` pointer.
 /// They share this one type so all kinds yield the same concrete `FsDiscovery`.
 /// The cost is a single heap allocation per reloader at startup.
-pub type FsSourceBuilder = Box<dyn Fn(String, PathBuf, CachePolicy) -> BuiltSource + Send + Sync>;
+pub type FsSourceBuilder = Box<dyn Fn(String, PathBuf, CachePolicy) -> BuildFuture + Send + Sync>;
 
 /// A [`Discovery`] that enumerates source files under the watched directories.
 pub struct FsDiscovery {
@@ -134,8 +134,10 @@ impl Discovery for FsDiscovery {
         ))
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {
-        (self.build)(id.to_owned(), args.0.clone(), args.1).await
+    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
+        (self.build)(id.to_owned(), args.0.clone(), args.1)
+            .await
+            .map(Into::into)
     }
 
     fn process(&self) -> ProcessConfig {

--- a/martin/src/config/file/tiles/discovery/mod.rs
+++ b/martin/src/config/file/tiles/discovery/mod.rs
@@ -2,7 +2,7 @@
 //! `ObjectStoreDiscovery` for remote `PMTiles` prefixes.
 
 mod discovery_trait;
-pub use discovery_trait::{Discovered, Discovery, Version};
+pub use discovery_trait::{BuiltSource, Discovered, Discovery, Version};
 
 #[cfg(any(
     feature = "mbtiles",

--- a/martin/src/config/file/tiles/discovery/object_store.rs
+++ b/martin/src/config/file/tiles/discovery/object_store.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use futures::stream::TryStreamExt as _;
-use martin_core::tiles::BoxedSource;
 use object_store::ObjectStore as _;
 use url::Url;
 
@@ -13,7 +12,7 @@ use crate::MartinResult;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;
-use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
+use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{
     CachePolicy, ConfigFileError, FileConfigEnum, TileSourceConfiguration as _,
 };
@@ -115,10 +114,11 @@ impl Discovery for ObjectStoreDiscovery {
         Ok(Discovered::new(out))
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {
+    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
         self.config
             .new_sources_url(id.to_owned(), args.clone(), CachePolicy::default())
             .await
+            .map(Into::into)
     }
 
     fn process(&self) -> ProcessConfig {

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -115,38 +115,6 @@ fn per_source_process(connection: &ProcessConfig, _spec: &SourceSpec) -> Process
     connection.clone()
 }
 
-#[cfg(all(test, feature = "mlt"))]
-mod process_tests {
-    use super::*;
-    use crate::config::file::postgres::TableInfo;
-    use crate::config::primitives::AutoOption;
-
-    #[test]
-    fn per_source_convert_overrides_the_connection_level() {
-        let connection = ProcessConfig {
-            convert_to_mlt: Some(AutoOption::Auto),
-            convert_to_mvt: None,
-        };
-
-        let with_override = SourceSpec::Table(TableInfo {
-            convert_to_mlt: Some(AutoOption::Disabled),
-            ..TableInfo::default()
-        });
-        assert_eq!(
-            per_source_process(&connection, &with_override).convert_to_mlt,
-            Some(AutoOption::Disabled),
-            "a per-table convert_to_mlt must win over the connection-level setting"
-        );
-
-        let without_override = SourceSpec::Table(TableInfo::default());
-        assert_eq!(
-            per_source_process(&connection, &without_override),
-            connection,
-            "a table without overrides must inherit the connection-level setting"
-        );
-    }
-}
-
 #[cfg(all(test, feature = "test-pg"))]
 mod tests {
     use std::collections::BTreeMap;
@@ -287,6 +255,34 @@ mod tests {
         assert!(
             discovery.discover().await.is_err(),
             "a bad connection string must surface as Err, not panic"
+        );
+    }
+
+    #[cfg(feature = "mlt")]
+    #[test]
+    fn per_source_convert_overrides_the_connection_level() {
+        use crate::config::file::postgres::TableInfo;
+        use crate::config::primitives::AutoOption;
+        let connection = ProcessConfig {
+            convert_to_mlt: Some(AutoOption::Auto),
+            convert_to_mvt: None,
+        };
+
+        let with_override = SourceSpec::Table(TableInfo {
+            convert_to_mlt: Some(AutoOption::Disabled),
+            ..TableInfo::default()
+        });
+        assert_eq!(
+            per_source_process(&connection, &with_override).convert_to_mlt,
+            Some(AutoOption::Disabled),
+            "a per-table convert_to_mlt must win over the connection-level setting"
+        );
+
+        let without_override = SourceSpec::Table(TableInfo::default());
+        assert_eq!(
+            per_source_process(&connection, &without_override),
+            connection,
+            "a table without overrides must inherit the connection-level setting"
         );
     }
 }

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -2,11 +2,10 @@
 
 use std::time::Duration;
 
-use martin_core::tiles::BoxedSource;
 use tokio::sync::OnceCell;
 
 use crate::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig, SourceSpec};
-use crate::config::file::tiles::discovery::{Discovered, Discovery, Version};
+use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{CachePolicy, ProcessConfig};
 use crate::config::primitives::IdResolver;
 use crate::{MartinError, MartinResult};
@@ -80,13 +79,71 @@ impl Discovery for PostgresDiscovery {
         })
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BoxedSource> {
-        let (source, _spec) = self.builder().await?.instantiate(id, args.clone()).await?;
-        Ok(source)
+    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
+        let (source, spec) = self.builder().await?.instantiate(id, args.clone()).await?;
+        Ok(BuiltSource {
+            source,
+            process: Some(per_source_process(&self.process, &spec)),
+        })
     }
 
     fn process(&self) -> ProcessConfig {
         self.process.clone()
+    }
+}
+
+/// Per-source `convert_to_*` settings override the connection-level [`ProcessConfig`].
+#[cfg(feature = "mlt")]
+fn per_source_process(connection: &ProcessConfig, spec: &SourceSpec) -> ProcessConfig {
+    use crate::config::file::resolve_process_config;
+
+    let per_source = match spec {
+        SourceSpec::Table(info) => ProcessConfig {
+            convert_to_mlt: info.convert_to_mlt.clone(),
+            convert_to_mvt: info.convert_to_mvt.clone(),
+        },
+        SourceSpec::Function(info, _) => ProcessConfig {
+            convert_to_mlt: info.convert_to_mlt.clone(),
+            convert_to_mvt: info.convert_to_mvt.clone(),
+        },
+    };
+    resolve_process_config(connection, &ProcessConfig::default(), &per_source)
+}
+
+#[cfg(not(feature = "mlt"))]
+fn per_source_process(connection: &ProcessConfig, _spec: &SourceSpec) -> ProcessConfig {
+    connection.clone()
+}
+
+#[cfg(all(test, feature = "mlt"))]
+mod process_tests {
+    use super::*;
+    use crate::config::file::postgres::TableInfo;
+    use crate::config::primitives::AutoOption;
+
+    #[test]
+    fn per_source_convert_overrides_the_connection_level() {
+        let connection = ProcessConfig {
+            convert_to_mlt: Some(AutoOption::Auto),
+            convert_to_mvt: None,
+        };
+
+        let with_override = SourceSpec::Table(TableInfo {
+            convert_to_mlt: Some(AutoOption::Disabled),
+            ..TableInfo::default()
+        });
+        assert_eq!(
+            per_source_process(&connection, &with_override).convert_to_mlt,
+            Some(AutoOption::Disabled),
+            "a per-table convert_to_mlt must win over the connection-level setting"
+        );
+
+        let without_override = SourceSpec::Table(TableInfo::default());
+        assert_eq!(
+            per_source_process(&connection, &without_override),
+            connection,
+            "a table without overrides must inherit the connection-level setting"
+        );
     }
 }
 
@@ -216,8 +273,8 @@ mod tests {
         let snapshot = discovery.discover().await.expect("discover").sources;
         let (_version, spec) = snapshot.get("points").expect("spec for points");
 
-        let source = discovery.build("points", spec).await.expect("build");
-        assert_eq!(source.get_id(), "points");
+        let built = discovery.build("points", spec).await.expect("build");
+        assert_eq!(built.source.get_id(), "points");
     }
 
     #[tokio::test]

--- a/martin/src/config/file/tiles/driver/reconcile.rs
+++ b/martin/src/config/file/tiles/driver/reconcile.rs
@@ -3,10 +3,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use martin_core::tiles::BoxedSource;
 use tokio::task::JoinHandle;
 
-use crate::config::file::tiles::discovery::{Discovery, Version};
+use crate::config::file::tiles::discovery::{BuiltSource, Discovery, Version};
 use crate::config::file::tiles::driver::{Sink, Trigger};
 use crate::reload::ReloadAdvisory;
 use crate::{MartinError, MartinResult};
@@ -104,7 +103,7 @@ impl<D: Discovery, S: Sink> ReloadDriver<D, S> {
         let advisory = ReloadAdvisory::from_maps(
             &prev_versions,
             &next_versions,
-            async move |id: String| -> MartinResult<BoxedSource> {
+            async move |id: String| -> MartinResult<BuiltSource> {
                 let args = args_by_id
                     .get(&id)
                     .ok_or_else(|| MartinError::SourceNotFound(id.clone()))?;
@@ -130,7 +129,7 @@ mod tests {
 
     use async_trait::async_trait;
     use martin_core::CacheZoomRange;
-    use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
+    use martin_core::tiles::{BoxedSource, MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format, TileCoord, TileData, TileInfo};
     use rstest::rstest;
     use tilejson::{TileJSON, tilejson};
@@ -247,9 +246,9 @@ mod tests {
             &self,
             id: &str,
             _args: &(),
-        ) -> impl Future<Output = MartinResult<BoxedSource>> + Send {
+        ) -> impl Future<Output = MartinResult<BuiltSource>> + Send {
             let source: BoxedSource = Box::new(TestSource::new(id));
-            std::future::ready(Ok(source))
+            std::future::ready(Ok(source.into()))
         }
 
         fn process(&self) -> ProcessConfig {

--- a/martin/src/reload.rs
+++ b/martin/src/reload.rs
@@ -4,6 +4,7 @@ use futures::stream::{self, StreamExt as _};
 use martin_core::tiles::BoxedSource;
 
 use crate::MartinResult;
+use crate::config::file::discovery::BuiltSource;
 use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ProcessConfig};
 
 /// A source to be added or updated in the [`TileSourceManager`](super::TileSourceManager).
@@ -15,6 +16,25 @@ pub struct NewSource {
     pub source: MartinResult<BoxedSource>,
     /// Resolved process config for this source (per-source > source-type > global > default).
     pub process: ProcessConfig,
+}
+
+impl NewSource {
+    /// `process` is the kind-level fallback; a per-source override carried by the
+    /// [`BuiltSource`] wins over it.
+    fn new(id: String, built: MartinResult<BuiltSource>, process: ProcessConfig) -> Self {
+        match built {
+            Ok(built) => Self {
+                id,
+                source: Ok(built.source),
+                process: built.process.unwrap_or(process),
+            },
+            Err(e) => Self {
+                id,
+                source: Err(e),
+                process,
+            },
+        }
+    }
 }
 
 /// A source to be removed from the [`TileSourceManager`](super::TileSourceManager).
@@ -48,7 +68,7 @@ impl ReloadAdvisory {
         process: ProcessConfig,
     ) -> Self
     where
-        F: AsyncFn(String) -> MartinResult<BoxedSource>,
+        F: AsyncFn(String) -> MartinResult<BuiltSource>,
     {
         let removals = previous_ids
             .difference(next_ids)
@@ -80,7 +100,7 @@ impl ReloadAdvisory {
         process: ProcessConfig,
     ) -> Self
     where
-        F: AsyncFn(String) -> MartinResult<BoxedSource>,
+        F: AsyncFn(String) -> MartinResult<BuiltSource>,
     {
         let removals = previous_map
             .keys()
@@ -119,15 +139,12 @@ async fn build_all<F>(
     process: &ProcessConfig,
 ) -> Vec<NewSource>
 where
-    F: AsyncFn(String) -> MartinResult<BoxedSource>,
+    F: AsyncFn(String) -> MartinResult<BuiltSource>,
 {
     stream::iter(ids)
         .map(|id| async move {
-            NewSource {
-                source: initializer(id.clone()).await,
-                id,
-                process: process.clone(),
-            }
+            let built = initializer(id.clone()).await;
+            NewSource::new(id, built, process.clone())
         })
         .buffered(MAX_CONCURRENT_SOURCE_INITS)
         .collect()
@@ -177,8 +194,8 @@ mod tests {
         }
     }
 
-    async fn make_source(id: String) -> MartinResult<BoxedSource> {
-        Ok(Box::new(TestSource {
+    async fn make_source(id: String) -> MartinResult<BuiltSource> {
+        let source: BoxedSource = Box::new(TestSource {
             id,
             tj: tilejson! {
                 tilejson: "3.0.0".to_owned(),
@@ -187,7 +204,8 @@ mod tests {
                 name: "test_json".to_owned(),
                 scheme: "xyz".to_owned(),
             },
-        }))
+        });
+        Ok(source.into())
     }
 
     #[derive(serde::Serialize)]

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -312,6 +312,7 @@ mod tests {
         use tempfile::TempDir;
 
         use crate::MartinError;
+        use crate::config::file::discovery::BuiltSource;
         use crate::config::file::{ConfigFileError, ProcessConfig};
 
         const BAD_PREFIX: &str = "bad_";
@@ -337,16 +338,17 @@ mod tests {
             clippy::unused_async,
             reason = "must satisfy AsyncFn for ReloadAdvisory::from_maps"
         )]
-        async fn build(id: String, dir: PathBuf) -> MartinResult<BoxedSource> {
+        async fn build(id: String, dir: PathBuf) -> MartinResult<BuiltSource> {
             if id.starts_with(BAD_PREFIX) {
                 return Err(MartinError::from(ConfigFileError::InvalidFilePath(
                     dir.join(format!("{id}.tiles")),
                 )));
             }
-            Ok(Box::new(TestSource {
+            let source: BoxedSource = Box::new(TestSource {
                 id,
                 tj: tilejson! { tiles: vec![] },
-            }))
+            });
+            Ok(source.into())
         }
 
         let dir = TempDir::new().expect("create tempdir");


### PR DESCRIPTION
Third piece split out of #3130; a fix rather than a refactor. Builds on #3142 and #3143, both merged.

Startup resolution honors per-table and per-function `convert_to_mlt`/`convert_to_mvt` overrides. The reload path didn't: when the reloader added or rebuilt a postgres source, its process config came from the connection level only, so a reload of the same table silently dropped its overrides.

`Discovery::build` now returns `BuiltSource { source, process }`. The postgres discovery fills `process` from the instantiated spec (per-source > connection); kinds without per-source settings convert with `From<BoxedSource>` and keep the kind-level fallback. A unit test pins the override behavior.

After this, #3130 rebases down to the lifecycle change itself.
