### PR TITLE
ci: dedupe repeated action pins and the hotpath benchmark script

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -2,7 +2,10 @@ name: Setup Rust
 description: Free runner disk space, install a Rust toolchain, and install the build tooling.
 inputs:
   toolchain:
-    description: Rust toolchain to install and set as the default, e.g. "stable" or "nightly".
+    description: >-
+      Rust toolchain to install and set as the default, e.g. "stable" or "nightly".
+      "none" skips the toolchain (and the disk cleanup sized for Rust builds) for
+      jobs that only need the prebuilt tools.
     default: "stable"
   components:
     description: Space-separated rustup components to add, e.g. "clippy rustfmt".
@@ -28,7 +31,7 @@ runs:
   steps:
     # Frees ~25GB. martin compiles the bundled DuckDB and maplibre-native C++ trees, which
     # otherwise exhaust the default runner disk. No-op on non-Linux runners.
-    - if: runner.os == 'Linux'
+    - if: runner.os == 'Linux' && inputs.toolchain != 'none'
       uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
       with:
         tool-cache: false
@@ -39,7 +42,8 @@ runs:
         large-packages: false
         docker-images: true
         swap-storage: true
-    - shell: bash
+    - if: inputs.toolchain != 'none'
+      shell: bash
       env:
         TOOLCHAIN: ${{ inputs.toolchain }}
       run: rustup update "$TOOLCHAIN" && rustup default "$TOOLCHAIN"
@@ -59,7 +63,7 @@ runs:
     - if: inputs.rendering == 'true' && runner.os == 'Linux'
       shell: bash
       run: just install-dependencies
-    - if: runner.os == 'Linux'
+    - if: runner.os == 'Linux' && inputs.toolchain != 'none'
       shell: bash
       run: just env-info
     - if: inputs.coverage == 'true'

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just,cargo-sort' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none, tools: 'just,cargo-sort' }
       - name: Format Cargo.toml
         run: just fmt-toml
 
@@ -71,8 +71,8 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: just }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       # `just gen-schemas` enables `rendering` on Linux so the OpenAPI doc
       # covers the static-render routes - that pulls in maplibre-native,
       # whose C++ build needs the rendering toolchain installed.
@@ -116,9 +116,10 @@ jobs:
         run: rustup update stable && rustup default stable
 
       - name: Install just
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: ./.github/actions/setup-rust
         with:
-          tool: just,cargo-binstall,mlt
+          toolchain: none
+          tools: just,cargo-binstall,mlt
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -41,13 +41,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - name: Install just
+      - name: Install just (and cargo-zigbuild for musl)
         uses: ./.github/actions/setup-rust
-        with: { toolchain: none }
-      - name: Install cargo-zigbuild (musl only)
-        if: inputs.musl
-        uses: ./.github/actions/setup-rust
-        with: { toolchain: none, tools: 'cargo-zigbuild' }
+        with:
+          toolchain: none
+          tools: ${{ inputs.musl && 'just,cargo-zigbuild' || 'just' }}
       - name: Install zig (musl only)
         if: inputs.musl
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -42,12 +42,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
       - name: Install just
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just' }
+        uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - name: Install cargo-zigbuild (musl only)
         if: inputs.musl
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'cargo-zigbuild' }
+        uses: ./.github/actions/setup-rust
+        with: { toolchain: none, tools: 'cargo-zigbuild' }
       - name: Install zig (musl only)
         if: inputs.musl
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -36,8 +36,8 @@ jobs:
           file-path: './README.md'
           config-file: '.github/files/markdown.links.config.json'
 
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just,cargo-binstall' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none, tools: 'just,cargo-binstall' }
 
       - run: just -v docs-build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - run: npm clean-install --no-fund
         working-directory: martin/martin-ui
       - run: just ui::biome
@@ -168,8 +168,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with: { enable-cache: false } # uv is a one-off tool runner here; no Python deps to cache
@@ -463,8 +463,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - name: Download build artifact build-x86_64-unknown-linux-musl
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: 'build-x86_64-unknown-linux-musl', path: 'target/' }
@@ -855,8 +855,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - parallel:
           - name: Download build artifact build-aarch64-apple-darwin
             uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1002,8 +1002,8 @@ jobs:
       - name: Download the per-suite lcov reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { pattern: 'coverage-*', merge-multiple: true, path: 'target/coverage' }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just,grcov' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none, tools: 'just,grcov' }
       - name: Merge the reports into one Cobertura report
         run: just coverage-merge
       - name: Upload to GitHub code coverage

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: just }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none }
       - run: just demo::build

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -50,8 +50,8 @@ jobs:
           persist-credentials: false
 
       - run: rustup update stable && rustup default stable
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with: { tool: 'just,oha' }
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: none, tools: 'just,oha' }
       - name: Install rendering dependencies
         run: just install-dependencies
 
@@ -63,6 +63,28 @@ jobs:
       - name: Create metrics directory
         run: mkdir -p /tmp/metrics
 
+      # Written to /tmp (not the justfile or a local action) because the base
+      # benchmark runs after `git checkout <base sha>` switches the whole tree,
+      # so anything added to tracked files would not exist for the base run.
+      - name: Write the benchmark script both runs share
+        run: |
+          cat > /tmp/hotpath-benchmark.sh << 'EOF'
+          set -euo pipefail
+          just bench-server-hotpath &
+          MARTIN_PID=$!
+
+          for i in {1..1000}; do
+            if curl -sf http://localhost:3000/health > /dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill "$MARTIN_PID" 2>/dev/null; exit 1; }
+
+          just bench-http 1m 100k
+
+          kill "$MARTIN_PID" 2>/dev/null || true
+          wait "$MARTIN_PID" || true
+          EOF
+
       - name: Build head
         run: just build-hotpath
 
@@ -72,21 +94,7 @@ jobs:
           HOTPATH_OUTPUT_PATH: /tmp/metrics/head_timing.json
           HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
-        run: |
-          set -euo pipefail
-          just bench-server-hotpath &
-          MARTIN_PID=$!
-
-          for i in {1..1000}; do
-            if curl -sf http://localhost:3000/health > /dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill $MARTIN_PID 2>/dev/null; exit 1; }
-
-          just bench-http 1m 100k
-
-          kill $MARTIN_PID 2>/dev/null || true
-          wait $MARTIN_PID || true
+        run: bash /tmp/hotpath-benchmark.sh
 
       - name: Checkout base
         run: git checkout ${{ github.event.pull_request.base.sha }}
@@ -116,21 +124,7 @@ jobs:
           HOTPATH_OUTPUT_PATH: /tmp/metrics/base_timing.json
           HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
-        run: |
-          set -euo pipefail
-          just bench-server-hotpath &
-          MARTIN_PID=$!
-
-          for i in {1..1000}; do
-            if curl -sf http://localhost:3000/health > /dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill $MARTIN_PID 2>/dev/null; exit 1; }
-
-          just bench-http 1m 100k
-
-          kill "$MARTIN_PID" 2>/dev/null || true
-          wait "$MARTIN_PID" || true
+        run: bash /tmp/hotpath-benchmark.sh
 
       - name: Save PR metadata
         env:

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -63,28 +63,6 @@ jobs:
       - name: Create metrics directory
         run: mkdir -p /tmp/metrics
 
-      # Written to /tmp (not the justfile or a local action) because the base
-      # benchmark runs after `git checkout <base sha>` switches the whole tree,
-      # so anything added to tracked files would not exist for the base run.
-      - name: Write the benchmark script both runs share
-        run: |
-          cat > /tmp/hotpath-benchmark.sh << 'EOF'
-          set -euo pipefail
-          just bench-server-hotpath &
-          MARTIN_PID=$!
-
-          for i in {1..1000}; do
-            if curl -sf http://localhost:3000/health > /dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill "$MARTIN_PID" 2>/dev/null; exit 1; }
-
-          just bench-http 1m 100k
-
-          kill "$MARTIN_PID" 2>/dev/null || true
-          wait "$MARTIN_PID" || true
-          EOF
-
       - name: Build head
         run: just build-hotpath
 
@@ -94,7 +72,7 @@ jobs:
           HOTPATH_OUTPUT_PATH: /tmp/metrics/head_timing.json
           HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
-        run: bash /tmp/hotpath-benchmark.sh
+        run: just bench-hotpath
 
       - name: Checkout base
         run: git checkout ${{ github.event.pull_request.base.sha }}
@@ -124,7 +102,7 @@ jobs:
           HOTPATH_OUTPUT_PATH: /tmp/metrics/base_timing.json
           HOTPATH_ALLOC_SELF: true
           DATABASE_URL: postgres://${{ env.PGUSER }}:${{ env.PGPASSWORD }}@${{ env.PGHOST }}:${{ job.services.postgres.ports[5432] }}/${{ env.PGDATABASE }}
-        run: bash /tmp/hotpath-benchmark.sh
+        run: just bench-hotpath
 
       - name: Save PR metadata
         env:

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ bench-server-hotpath: start build-hotpath prepare-mbtiles
 bench-hotpath:
     #!/usr/bin/env bash
     set -euo pipefail
-    just bench-server-hotpath &
+    {{just}} bench-server-hotpath &
     MARTIN_PID=$!
 
     for i in {1..1000}; do
@@ -95,7 +95,7 @@ bench-hotpath:
     done
     curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill "$MARTIN_PID" 2>/dev/null; exit 1; }
 
-    just bench-http 1m 100k
+    {{just}} bench-http 1m 100k
 
     kill "$MARTIN_PID" 2>/dev/null || true
     wait "$MARTIN_PID" || true

--- a/justfile
+++ b/justfile
@@ -82,6 +82,24 @@ build-hotpath: fetch
 bench-server-hotpath: start build-hotpath prepare-mbtiles
     exec target/release/martin tests/fixtures/mbtiles tests/fixtures/pmtiles
 
+# Run the hotpath benchmark end-to-end: start the profiled server, wait for it, drive HTTP load, shut it down. Used by the hotpath-profile CI workflow.
+bench-hotpath:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just bench-server-hotpath &
+    MARTIN_PID=$!
+
+    for i in {1..1000}; do
+        if curl -sf http://localhost:3000/health > /dev/null 2>&1; then break; fi
+        sleep 1
+    done
+    curl -sf http://localhost:3000/health > /dev/null 2>&1 || { echo "::error::Martin failed to start"; kill "$MARTIN_PID" 2>/dev/null; exit 1; }
+
+    just bench-http 1m 100k
+
+    kill "$MARTIN_PID" 2>/dev/null || true
+    wait "$MARTIN_PID" || true
+
 # Regenerate configs' JSON Schema, HTTP OpenAPI spec, and TS types
 gen-schemas: fetch
     #!/usr/bin/env bash


### PR DESCRIPTION
Part of #2004, scoped per [the discussion there](https://github.com/maplibre/martin/issues/2004#issuecomment-5385144989). Two dedups, both behavior-preserving:

- **One pin for `taiki-e/install-action`, reusing `setup-rust`.** Per the suggestion to reuse the existing install-step work: `setup-rust` gains a tool-only mode (`toolchain: none`) that skips the disk cleanup and the toolchain install, and the thirteen jobs that only need prebuilt tools now go through it. The pinned SHA lives in one file instead of fourteen call sites across seven, so a version bump touches one place. Jobs keep exactly the steps they had before — `toolchain: none` runs only the install step, so nothing gets a surprise 25GB disk purge or an unused toolchain.
- **One copy of the hotpath benchmark script.** `hotpath-profile.yml` had the same 20-line start/poll/bench/kill script pasted for the head and base runs. It's now written once to `/tmp` and invoked from both steps. It deliberately lives outside the tree (not the justfile or a local action) because the base run happens after `git checkout <base sha>` switches the whole workspace, so a tracked file would not exist for PRs based on older mains.

Verified with actionlint: the finding set is identical to main apart from line shifts (two shellcheck notes disappear along with the duplicated script).

Left for follow-ups to keep review surface small: the postgis `services:` incantation repeated across `ci.yml`/`hotpath-profile.yml` (needs a reusable workflow since `services` can't live in composite actions), and the `package` job's seven download-artifact steps (a `pattern:` glob changes directory names, so it isn't a pure dedup).
