### PR TITLE
test(cache): fix some CI flakes by widening font + sprite cache expiry margins

### DIFF
--- a/martin-core/tests/fonts_test.rs
+++ b/martin-core/tests/fonts_test.rs
@@ -8,10 +8,12 @@ use std::time::Duration;
 use martin_core::fonts::{FontCache, FontCacheKey};
 
 const CACHE_SIZE: u64 = 10 * 1024 * 1024;
+/// Extra time to wait after an expiry deadline so slow CI runners do not flake
+const EXPIRY_BUFFER: Duration = Duration::from_secs(1);
 
 #[tokio::test]
 async fn cache_entry_available_before_ttl_expires() {
-    let ttl = Duration::from_millis(200);
+    let ttl = Duration::from_secs(60);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"glyph-data").await;
@@ -22,44 +24,44 @@ async fn cache_entry_available_before_ttl_expires() {
 
 #[tokio::test]
 async fn cache_entry_evicted_after_ttl_expires() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"original").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"refreshed").await;
 }
 
 #[tokio::test]
 async fn ttl_evicts_even_with_frequent_access() {
-    let ttl = Duration::from_millis(80);
+    let ttl = Duration::from_secs(5);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"data").await;
 
     // Access repeatedly - this should NOT extend the TTL
     for _ in 0..3 {
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        tokio::time::sleep(Duration::from_millis(40)).await;
         assert_hit(&cache, "font-a", 0, 255).await;
     }
 
-    wait_and_flush(&cache, Duration::from_millis(30)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"new").await;
 }
 
 #[tokio::test]
 async fn cache_entry_survives_when_accessed_within_tti() {
-    let tti = Duration::from_millis(60);
+    let tti = Duration::from_secs(5);
     let cache = FontCache::new(CACHE_SIZE, None, Some(tti));
 
     insert(&cache, "font-a", 0, 255, b"data").await;
 
     // Each access resets the idle timer, keeping the entry alive past the total TTI
     for _ in 0..3 {
-        tokio::time::sleep(Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
         let hit = assert_hit(&cache, "font-a", 0, 255).await;
         assert_eq!(hit, b"data");
     }
@@ -67,44 +69,44 @@ async fn cache_entry_survives_when_accessed_within_tti() {
 
 #[tokio::test]
 async fn cache_entry_evicted_after_idle_timeout() {
-    let tti = Duration::from_millis(25);
+    let tti = Duration::from_secs(2);
     let cache = FontCache::new(CACHE_SIZE, None, Some(tti));
 
     insert(&cache, "font-a", 0, 255, b"data").await;
 
-    wait_and_flush(&cache, tti + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, tti + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"new").await;
 }
 
 #[tokio::test]
 async fn tti_evicts_before_ttl_when_idle() {
-    let ttl = Duration::from_millis(200);
-    let tti = Duration::from_millis(25);
+    let ttl = Duration::from_secs(60);
+    let tti = Duration::from_secs(2);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), Some(tti));
 
     insert(&cache, "font-a", 0, 255, b"data").await;
 
     // Wait past TTI but within TTL
-    wait_and_flush(&cache, tti + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, tti + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"new").await;
 }
 
 #[tokio::test]
 async fn ttl_evicts_despite_access_when_both_set() {
-    let ttl = Duration::from_millis(80);
-    let tti = Duration::from_millis(60);
+    let ttl = Duration::from_secs(5);
+    let tti = Duration::from_secs(3);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), Some(tti));
 
     insert(&cache, "font-a", 0, 255, b"data").await;
 
     // Keep accessing within TTI to prevent idle eviction
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
     assert_hit(&cache, "font-a", 0, 255).await;
 
     // Wait until TTL has passed since original insertion
-    wait_and_flush(&cache, Duration::from_millis(60)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"new").await;
 }
@@ -123,16 +125,16 @@ async fn cache_entry_persists_without_ttl_or_tti() {
 
 #[tokio::test]
 async fn ttl_applies_independently_per_entry() {
-    let ttl = Duration::from_millis(80);
+    let ttl = Duration::from_secs(3);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"first").await;
 
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
     insert(&cache, "font-a", 256, 511, b"second").await;
 
     // First entry's TTL has expired, second has not
-    wait_and_flush(&cache, Duration::from_millis(60)).await;
+    wait_and_flush(&cache, Duration::from_secs(2)).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"first-new").await;
 
@@ -142,13 +144,13 @@ async fn ttl_applies_independently_per_entry() {
 
 #[tokio::test]
 async fn different_fonts_share_ttl_policy() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"a").await;
     insert(&cache, "font-b", 0, 255, b"b").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"a-new").await;
     assert_miss(&cache, "font-b", 0, 255, b"b-new").await;
@@ -156,13 +158,13 @@ async fn different_fonts_share_ttl_policy() {
 
 #[tokio::test]
 async fn different_ranges_create_separate_cache_entries_with_same_ttl() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = FontCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "font-a", 0, 255, b"range-0").await;
     insert(&cache, "font-a", 256, 511, b"range-1").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "font-a", 0, 255, b"range-0-new").await;
     assert_miss(&cache, "font-a", 256, 511, b"range-1-new").await;

--- a/martin-core/tests/sprites_test.rs
+++ b/martin-core/tests/sprites_test.rs
@@ -9,10 +9,12 @@ use actix_web::web::Bytes;
 use martin_core::sprites::{SpriteCache, SpriteCacheKey};
 
 const CACHE_SIZE: u64 = 10 * 1024 * 1024;
+/// Extra time to wait after an expiry deadline so slow CI runners do not flake
+const EXPIRY_BUFFER: Duration = Duration::from_secs(1);
 
 #[tokio::test]
 async fn cache_entry_available_before_ttl_expires() {
-    let ttl = Duration::from_millis(200);
+    let ttl = Duration::from_secs(60);
     let cache = SpriteCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "sprite-a", false, false, b"sprite-data").await;
@@ -23,38 +25,38 @@ async fn cache_entry_available_before_ttl_expires() {
 
 #[tokio::test]
 async fn cache_entry_evicted_after_ttl_expires() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = SpriteCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "sprite-a", false, false, b"original").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "sprite-a", false, false, b"refreshed").await;
 }
 
 #[tokio::test]
 async fn cache_entry_evicted_after_idle_timeout() {
-    let tti = Duration::from_millis(25);
+    let tti = Duration::from_secs(2);
     let cache = SpriteCache::new(CACHE_SIZE, None, Some(tti));
 
     insert(&cache, "sprite-a", false, false, b"data").await;
 
-    wait_and_flush(&cache, tti + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, tti + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "sprite-a", false, false, b"new").await;
 }
 
 #[tokio::test]
 async fn tti_evicts_before_ttl_when_idle() {
-    let ttl = Duration::from_millis(200);
-    let tti = Duration::from_millis(25);
+    let ttl = Duration::from_secs(60);
+    let tti = Duration::from_secs(2);
     let cache = SpriteCache::new(CACHE_SIZE, Some(ttl), Some(tti));
 
     insert(&cache, "sprite-a", false, false, b"data").await;
 
     // Wait past TTI but within TTL
-    wait_and_flush(&cache, tti + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, tti + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "sprite-a", false, false, b"new").await;
 }
@@ -73,13 +75,13 @@ async fn cache_entry_persists_without_ttl_or_tti() {
 
 #[tokio::test]
 async fn different_sources_share_ttl_policy() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = SpriteCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "source_a", false, false, b"a").await;
     insert(&cache, "source_b", false, false, b"b").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "source_a", false, false, b"a-new").await;
     assert_miss(&cache, "source_b", false, false, b"b-new").await;
@@ -87,13 +89,13 @@ async fn different_sources_share_ttl_policy() {
 
 #[tokio::test]
 async fn json_and_image_create_separate_cache_entries_with_same_ttl() {
-    let ttl = Duration::from_millis(25);
+    let ttl = Duration::from_secs(2);
     let cache = SpriteCache::new(CACHE_SIZE, Some(ttl), None);
 
     insert(&cache, "sprite-a", false, true, b"json-data").await;
     insert(&cache, "sprite-a", false, false, b"image-data").await;
 
-    wait_and_flush(&cache, ttl + Duration::from_millis(25)).await;
+    wait_and_flush(&cache, ttl + EXPIRY_BUFFER).await;
 
     assert_miss(&cache, "sprite-a", false, true, b"json-new").await;
     assert_miss(&cache, "sprite-a", false, false, b"image-new").await;


### PR DESCRIPTION
The `unit testing the server on macos` job flaked on the #3144 merge run: `cache_entry_survives_when_accessed_within_tti` in `martin-core/tests/fonts_test.rs` panicked with "expected cache hit, but compute was called".

The font and sprite cache TTL/TTI tests use 25–80ms expiry windows against a real clock, with as little as 2× headroom between an access and the idle deadline (30ms sleeps against a 60ms TTI). A scheduling stall on a slow runner legitimately evicts the entry mid-test and the hit assertion fails. Moka uses a real clock, so `tokio::time::pause()` can't help here.

This adopts the seconds-scale timings and `EXPIRY_BUFFER` idiom the pmtiles directory cache tests already use for exactly this reason. No behavior under test changes; the suites still cover the same TTL/TTI semantics, just with margins a busy CI runner can't blow through.

Verified locally: both suites pass (`cargo test -p martin-core --test fonts_test --test sprites_test --features fonts,sprites`), fmt and clippy clean.
