### PR TITLE
docs: fix typo explicitely -> explicitly (source + generated), recomend -> recommend

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -71,7 +71,7 @@ cache_control: null
 # Can be either:
 # - (default) `auto` - we choose defaults which we think work best for most users
 # - `disabled` - no conversion
-# - explicitely configured
+# - explicitly configured
 convert_to_mlt:
   # Allow `FastPFOR` integer compression.
   allow_fastpfor: null
@@ -334,7 +334,7 @@ postgres:
   # - `null` (default) - defer to the global setting
   # - `auto` - we choose defaults which we think work best for most users
   # - `disabled` - no conversion
-  # - explicitely configured
+  # - explicitly configured
   convert_to_mlt:
     # Allow `FastPFOR` integer compression.
     allow_fastpfor: null

--- a/docs/content/sources-geojson.md
+++ b/docs/content/sources-geojson.md
@@ -31,7 +31,7 @@ The config file can then be used via the `--config my-config.yaml` option.
     - encode them as MVT
 
     To improve performance, we currently assume that each file fits into RAM.
-    If you want to want and can convert your geojson files to [mbtiles/ pmtiles](sources-files/index.md), we recomend tooling like [`tippecanoe`](https://github.com/felt/tippecanoe).
+    If you want to want and can convert your geojson files to [mbtiles/ pmtiles](sources-files/index.md), we recommend tooling like [`tippecanoe`](https://github.com/felt/tippecanoe).
 
 ## Run Martin with configuration file
 

--- a/martin/src/config/file/main/config.rs
+++ b/martin/src/config/file/main/config.rs
@@ -172,7 +172,7 @@ pub struct Config {
     /// Can be either:
     /// - (default) `auto` - we choose defaults which we think work best for most users
     /// - `disabled` - no conversion
-    /// - explicitely configured
+    /// - explicitly configured
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     #[serde(default)]
     pub convert_to_mlt: Option<MltProcessConfig>,

--- a/martin/src/config/file/tiles/postgres/config.rs
+++ b/martin/src/config/file/tiles/postgres/config.rs
@@ -134,7 +134,7 @@ pub struct PostgresConfig {
     /// - `null` (default) - defer to the global setting
     /// - `auto` - we choose defaults which we think work best for most users
     /// - `disabled` - no conversion
-    /// - explicitely configured
+    /// - explicitly configured
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     #[serde(default)]
     pub convert_to_mlt: Option<MltProcessConfig>,

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -998,7 +998,7 @@
               "type": "null"
             }
           ],
-          "description": "MVT->MLT encoder settings for all sources from this connection.\nOverrides global; overridden by per-source `convert_to_mlt`.\n\nCan be either:\n- `null` (default) - defer to the global setting\n- `auto` - we choose defaults which we think work best for most users\n- `disabled` - no conversion\n- explicitely configured"
+          "description": "MVT->MLT encoder settings for all sources from this connection.\nOverrides global; overridden by per-source `convert_to_mlt`.\n\nCan be either:\n- `null` (default) - defer to the global setting\n- `auto` - we choose defaults which we think work best for most users\n- `disabled` - no conversion\n- explicitly configured"
         },
         "convert_to_mvt": {
           "anyOf": [
@@ -1237,7 +1237,7 @@
           "type": "null"
         }
       ],
-      "description": "Encoder settings for MVT->MLT conversion (global level).\nOverridden by source-type or per-source `convert_to_mlt` keys.\n\nCan be either:\n- (default) `auto` - we choose defaults which we think work best for most users\n- `disabled` - no conversion\n- explicitely configured"
+      "description": "Encoder settings for MVT->MLT conversion (global level).\nOverridden by source-type or per-source `convert_to_mlt` keys.\n\nCan be either:\n- (default) `auto` - we choose defaults which we think work best for most users\n- `disabled` - no conversion\n- explicitly configured"
     },
     "convert_to_mvt": {
       "anyOf": [


### PR DESCRIPTION
Two typo fixes.

**`explicitely` → `explicitly`.** The text lives in Rust doc comments:

- `martin/src/config/file/tiles/postgres/config.rs:137`
- `martin/src/config/file/main/config.rs:175`

`docs/content/files/generated_config.md` carries the header *"This file is auto-generated by `just gen-schemas`. Don't edit it, edit the code's doc comments instead"*, so the source comments are the real fix. I've also applied the same one-word substitution to the two derived artifacts (`generated_config.md` and `schemas/config.json`) so the committed tree matches what the generator would now produce — otherwise a generated-file check in CI would flag them as stale. The change is a pure string replacement, so the result is byte-identical to regenerating.

**`recomend` → `recommend`** in `docs/content/sources-geojson.md:34` (a hand-written page).

Happy to drop the generated-file half of the diff if you'd rather regenerate them yourselves.
