### PR TITLE
test(cache-control): cover the cache_control setting end-to-end and document it

### DIFF
--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -147,4 +147,5 @@ AWS Lambda support is preliminary; there are features to add to Martin, configur
 * Set up a CloudFront CDN, this is a whole thing, but explain the motivation and the basics.
 * Grant the execution role permission to read objects from an S3 bucket, and teach Martin how to make authenticated requests to S3.
 * Teach Martin how to serve all PMTiles files from an S3 bucket rather than having to list them at startup.
-* Teach Martin how to set the Cache-Control and Etag headers for better defaults.
+
+Martin already sets an `Etag` header on tile responses, and the `cache_control` option in the [configuration file](config-file/index.md) sets a default `Cache-Control` header - useful when running behind CloudFront.

--- a/docs/content/run-with-reverse-proxy/index.md
+++ b/docs/content/run-with-reverse-proxy/index.md
@@ -19,6 +19,8 @@ Doing so has a few downsides:
     - [Nginx](https://nginx.org/)
     - [Varnish](https://varnish-cache.org/)
     - [Apache](https://httpd.apache.org/)
+
+  For client- and CDN-side caching, Martin can set a default `Cache-Control` response header itself via the `cache_control` option in the [configuration file](../config-file/index.md).
 - You may need to host more than just tiles/resources on the domain name.
 - Martin has a fixed public API, but your site may require a different structure.
   For example, you may want to serve tiles from `/{sourceID}/tiles?z={z}&x={x}&y={y}` instead of `/{sourceID}/{z}/{x}/{y}`.

--- a/e2e-tests/tests/cache_control.rs
+++ b/e2e-tests/tests/cache_control.rs
@@ -1,0 +1,104 @@
+//! The `cache_control` server setting.
+
+use martin_e2e_tests::{Martin, StartError};
+
+const CONFIG: &str = "
+cache_control: public, max-age=3600
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+sprites:
+  paths: tests/fixtures/sprites/src1
+fonts:
+  - tests/fixtures/fonts/overpass-mono-regular.ttf
+styles:
+  sources:
+    maplibre: tests/fixtures/styles/maplibre_demo.json
+";
+
+#[tokio::test]
+async fn the_configured_cache_control_is_sent_on_every_content_endpoint() {
+    let mut martin = Martin::builder()
+        .config(CONFIG)
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    for path in [
+        "/pmt/0/0/0",
+        "/pmt",
+        "/catalog",
+        "/sprite/src1.json",
+        "/font/Overpass Mono Regular/0-255",
+        "/style/maplibre",
+    ] {
+        let response = martin.get(path).await;
+        assert_eq!(response.status(), 200, "GET {path}");
+        assert_eq!(
+            response.header("cache-control"),
+            Some("public, max-age=3600"),
+            "GET {path} must carry the configured Cache-Control header"
+        );
+    }
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn the_health_endpoint_keeps_its_no_cache_policy() {
+    let mut martin = Martin::builder()
+        .config(CONFIG)
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let response = martin.get("/health").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.header("cache-control"), Some("no-cache"));
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn no_cache_control_is_sent_unless_configured() {
+    let mut martin = Martin::builder()
+        .config(
+            "
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+",
+        )
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let response = martin.get("/pmt/0/0/0").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.header("cache-control"), None);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_invalid_cache_control_value_fails_startup() {
+    let error = Martin::builder()
+        .config("cache_control: max-age=invalid")
+        .start()
+        .await
+        .expect_err("martin must reject an invalid Cache-Control value");
+    let StartError::EarlyExit { status, log } = error else {
+        panic!("expected an early exit, got: {error}");
+    };
+    assert!(!status.success(), "exit status must be a failure: {status}");
+    assert!(
+        log.contains("invalid Cache-Control header value 'max-age=invalid'"),
+        "log must name the invalid value; log:\n{log}"
+    );
+}

--- a/e2e-tests/tests/save_config.rs
+++ b/e2e-tests/tests/save_config.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 const CONFIG: &str = "
 keep_alive: 75
+cache_control: public, max-age=3600
 cache:
   size_mb: 8
   minzoom: 0

--- a/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
+++ b/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
@@ -9,6 +9,7 @@ cache:
 keep_alive: 75
 listen_addresses: 127.0.0.1:0
 worker_processes: 1
+cache_control: public, max-age=3600
 cors:
   origin:
   - "*"


### PR DESCRIPTION
### Overview

Refs #749. #3042 added the server-level `cache_control` setting, but #3105's e2e migration dropped its only test fixtures, so the setting currently ships with zero coverage. This PR restores coverage and documents the setting; no behavior changes.

Per [the plan I posted on #749](https://github.com/maplibre/martin/issues/749#issuecomment-5383685995): this is PR 1 of 2. The per-source override half is built on top of this branch and follows separately.

### Testing

- New `e2e-tests/tests/cache_control.rs`: the configured header is sent on every content endpoint (tiles, tilejson, catalog, sprites, fonts, styles), `/health` keeps its `no-cache` policy, nothing is sent unless configured, and an invalid value fails startup naming the bad value
- Save-config round-trip fixture + snapshot re-cover the setting
- `cargo test --workspace --lib` and the full `cargo test -p martin-e2e-tests` suite pass; deny-warnings clippy clean

### Docs

- reverse-proxy page notes Martin can set the header itself
- The Lambda page's "Teach Martin how to set the Cache-Control and Etag headers" TODO is resolved with a pointer to the setting
