### PR TITLE
feat(postgres): add --ssl-cert and --ssl-key CLI flags

### DIFF
--- a/docs/content/help/martin-cp.txt
+++ b/docs/content/help/martin-cp.txt
@@ -91,6 +91,12 @@ Options:
 
           Can be either a positive integer or unlimited if omitted.
 
+      --ssl-cert <SSL_CERT>
+          A file with a client SSL certificate
+
+      --ssl-key <SSL_KEY>
+          A file with the key for the client SSL certificate
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/docs/content/help/martin.txt
+++ b/docs/content/help/martin.txt
@@ -80,6 +80,12 @@ Options:
 
           Can be either a positive integer or unlimited if omitted.
 
+      --ssl-cert <SSL_CERT>
+          A file with a client SSL certificate
+
+      --ssl-key <SSL_KEY>
+          A file with the key for the client SSL certificate
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -347,8 +347,6 @@ mod tests {
         args.check().unwrap();
     }
 
-    /// `--ssl-cert`/`--ssl-key` win over `PGSSLCERT`/`PGSSLKEY`, the same way `--ca-root-file`
-    /// already wins over `PGSSLROOTCERT`.
     #[test]
     fn cli_ssl_cert_and_key_override_env() {
         let mut args = Arguments::new(vec![]);
@@ -382,8 +380,6 @@ mod tests {
         args.check().unwrap();
     }
 
-    /// A config file's SSL values must survive; `--ssl-cert`/`--ssl-key` override them like
-    /// `--ca-root-file` already does for `ssl_root_cert`.
     #[test]
     fn override_config_applies_ssl_cli_flags() {
         let mut config = OptOneMany::One(PostgresConfig {

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -35,6 +35,12 @@ pub struct PostgresArgs {
     /// Can be either a positive integer or unlimited if omitted.
     #[arg(short, long)]
     pub max_feature_count: Option<usize>,
+    /// A file with a client SSL certificate.
+    #[arg(long)]
+    pub ssl_cert: Option<std::path::PathBuf>,
+    /// A file with the key for the client SSL certificate.
+    #[arg(long)]
+    pub ssl_key: Option<std::path::PathBuf>,
 }
 
 impl PostgresArgs {
@@ -84,6 +90,8 @@ impl PostgresArgs {
             auto_bounds,
             max_feature_count,
             ca_root_file,
+            ssl_cert,
+            ssl_key,
         } = self;
 
         if let Some(value) = default_srid {
@@ -125,6 +133,24 @@ impl PostgresArgs {
             );
             pg_config.iter_mut().for_each(|c| {
                 c.ssl_certificates.ssl_root_cert.clone_from(&ca_root_file);
+            });
+        }
+        if let Some(ref value) = ssl_cert {
+            info!(
+                "Overriding client SSL certificate to {} on all Postgres connections because of a CLI parameter",
+                value.display()
+            );
+            pg_config.iter_mut().for_each(|c| {
+                c.ssl_certificates.ssl_cert.clone_from(&ssl_cert);
+            });
+        }
+        if let Some(ref value) = ssl_key {
+            info!(
+                "Overriding client SSL key to {} on all Postgres connections because of a CLI parameter",
+                value.display()
+            );
+            pg_config.iter_mut().for_each(|c| {
+                c.ssl_certificates.ssl_key.clone_from(&ssl_key);
             });
         }
     }
@@ -170,11 +196,17 @@ impl PostgresArgs {
 
     fn get_certs(&self, env: &impl Env) -> PostgresSslCerts {
         let mut result = PostgresSslCerts {
-            ssl_cert: Self::parse_env_var(env, "PGSSLCERT", "ssl certificate"),
-            ssl_key: Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate"),
+            ssl_cert: self.ssl_cert.clone(),
+            ssl_key: self.ssl_key.clone(),
             ssl_root_cert: self.ca_root_file.clone(),
             unrecognized: UnrecognizedValues::default(),
         };
+        if result.ssl_cert.is_none() {
+            result.ssl_cert = Self::parse_env_var(env, "PGSSLCERT", "ssl certificate");
+        }
+        if result.ssl_key.is_none() {
+            result.ssl_key = Self::parse_env_var(env, "PGSSLKEY", "ssl key for certificate");
+        }
         if result.ssl_root_cert.is_none() {
             result.ssl_root_cert = Self::parse_env_var(env, "PGSSLROOTCERT", "root certificate(s)");
         }
@@ -313,5 +345,71 @@ mod tests {
             })
         );
         args.check().unwrap();
+    }
+
+    /// `--ssl-cert`/`--ssl-key` win over `PGSSLCERT`/`PGSSLKEY`, the same way `--ca-root-file`
+    /// already wins over `PGSSLROOTCERT`.
+    #[test]
+    fn cli_ssl_cert_and_key_override_env() {
+        let mut args = Arguments::new(vec![]);
+        let env = FauxEnv(
+            vec![
+                ("DATABASE_URL", OsString::from("postgres://localhost:5432")),
+                ("PGSSLCERT", OsString::from("env-cert")),
+                ("PGSSLKEY", OsString::from("env-key")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let pg_args = PostgresArgs {
+            ssl_cert: Some(PathBuf::from("cli-cert")),
+            ssl_key: Some(PathBuf::from("cli-key")),
+            ..Default::default()
+        };
+        let config = pg_args.into_config(&mut args, &env);
+        assert_eq!(
+            config,
+            OptOneMany::One(PostgresConfig {
+                connection_string: Some("postgres://localhost:5432".to_owned()),
+                ssl_certificates: PostgresSslCerts {
+                    ssl_cert: Some(PathBuf::from("cli-cert")),
+                    ssl_key: Some(PathBuf::from("cli-key")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+        );
+        args.check().unwrap();
+    }
+
+    /// A config file's SSL values must survive; `--ssl-cert`/`--ssl-key` override them like
+    /// `--ca-root-file` already does for `ssl_root_cert`.
+    #[test]
+    fn override_config_applies_ssl_cli_flags() {
+        let mut config = OptOneMany::One(PostgresConfig {
+            connection_string: Some("postgres://localhost:5432".to_owned()),
+            ssl_certificates: PostgresSslCerts {
+                ssl_cert: Some(PathBuf::from("from-config")),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        PostgresArgs {
+            ssl_cert: Some(PathBuf::from("from-cli")),
+            ssl_key: Some(PathBuf::from("key-from-cli")),
+            ..Default::default()
+        }
+        .override_config(&mut config);
+        let OptOneMany::One(cfg) = config else {
+            panic!("expected exactly one postgres config");
+        };
+        assert_eq!(
+            cfg.ssl_certificates.ssl_cert,
+            Some(PathBuf::from("from-cli"))
+        );
+        assert_eq!(
+            cfg.ssl_certificates.ssl_key,
+            Some(PathBuf::from("key-from-cli"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `--ssl-cert` and `--ssl-key` CLI flags for the Postgres source, mirroring the existing `--ca-root-file` flag. This split out of #3141 following review from @CommanderStorm, who asked for the SSL flags, the legacy env var warnings, and the breaking removal of implicit env var reads to be separated into independent PRs.

This PR is the narrow, non-breaking part: two new flags only.

- `--ssl-cert <FILE>` / `--ssl-key <FILE>` set the client SSL certificate/key for Postgres connections.
- CLI flags override the config file, the same way `--ca-root-file` already overrides `ssl_root_cert`.
- Existing `PGSSLCERT`/`PGSSLKEY` env var fallback behavior is unchanged.

## Testing

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p martin --lib config::args::postgres` (7 passed)
- `cargo clippy -p martin --all-targets -- -D warnings` — passes for the changed crate; a pre-existing `result_large_err` clippy failure in `martin-core::tiles::postgres::errors` (unrelated file, present on `main`) blocks a full clean workspace clippy run.