### PR TITLE
ci: tune which jobs use the Rust build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
       - uses: ./.github/actions/setup-rust
-        with: { cache: true, coverage: true }
+        with: { coverage: true }
       - name: Run COG tests
         run: just test-cog
       - uses: ./.github/actions/upload-coverage
@@ -506,7 +506,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y sqlite3-tools
       - uses: ./.github/actions/setup-rust
-        with: { tools: 'just,fast-mvt', rendering: true }
+        with: { tools: 'just,fast-mvt', rendering: true, cache: true }
       - name: Install sqlite3 and sqldiff on Windows
         if: matrix.os == 'windows-latest'
         run: choco install sqlite --yes


### PR DESCRIPTION
The COG job spends 1.1GB of the shared 10GB cache quota to speed up a job that only takes 1.6 minutes; drop its cache and spend the quota on the multi-OS end-to-end job instead, which compiles the e2e test crate from scratch on every run (13.7 minutes of its Windows leg).