### PR TITLE
fix(reload): keep per-source convert_to_* overrides for file-backed sources

### DIFF
--- a/martin/src/config/file/mod.rs
+++ b/martin/src/config/file/mod.rs
@@ -15,10 +15,7 @@ pub use error::{ConfigFileError, ConfigFileResult};
 
 pub mod process;
 pub use process::ProcessConfig;
-#[cfg(all(
-    feature = "mlt",
-    any(feature = "mbtiles", feature = "pmtiles", feature = "postgres")
-))]
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
 pub(crate) use process::resolve_process_config;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 pub use process::{MltEncoderConfig, MltProcessConfig, MvtEncoderConfig, MvtProcessConfig};

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -9,6 +9,8 @@ use futures::future::BoxFuture;
 use martin_core::tiles::BoxedSource;
 use tokio::fs::{self, DirEntry};
 
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::FileConfigSrc;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{CachePolicy, FileConfigEnum, ProcessConfig};
@@ -30,12 +32,21 @@ type BuildFuture = BoxFuture<'static, MartinResult<BoxedSource>>;
 /// The cost is a single heap allocation per reloader at startup.
 pub type FsSourceBuilder = Box<dyn Fn(String, PathBuf, CachePolicy) -> BuildFuture + Send + Sync>;
 
+/// What the config says about one explicitly-configured source, so a discovered file with the
+/// same canonical path keeps its policy and per-source process settings.
+struct ConfiguredSource {
+    policy: CachePolicy,
+    /// Per-source `convert_to_*` override, already resolved against the kind level.
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    process: Option<ProcessConfig>,
+}
+
 /// A [`Discovery`] that enumerates source files under the watched directories.
 pub struct FsDiscovery {
     directories: Vec<PathBuf>,
     extensions: &'static [&'static str],
-    /// Canonical path -> policy for configured sources, so discovered files inherit their policy.
-    path_cache: BTreeMap<PathBuf, CachePolicy>,
+    /// Canonical path -> configured entry for explicitly-configured sources.
+    configured: BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: IdResolver,
     process: ProcessConfig,
     build: FsSourceBuilder,
@@ -51,7 +62,7 @@ impl FsDiscovery {
         build: FsSourceBuilder,
     ) -> Self {
         let mut directories: Vec<PathBuf> = vec![];
-        let mut path_cache: BTreeMap<PathBuf, CachePolicy> = BTreeMap::new();
+        let mut configured: BTreeMap<PathBuf, ConfiguredSource> = BTreeMap::new();
 
         if let FileConfigEnum::Config(cfg) = config
             && let Some(sources) = &cfg.sources
@@ -65,7 +76,14 @@ impl FsDiscovery {
                     tracing::warn!(source.id = %id, path = ?path, "failed to canonicalize tile source path");
                     continue;
                 };
-                path_cache.insert(canonical, src.cache_zoom());
+                configured.insert(
+                    canonical,
+                    ConfiguredSource {
+                        policy: src.cache_zoom(),
+                        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                        process: per_source_process(&process, src),
+                    },
+                );
             }
         }
 
@@ -98,7 +116,7 @@ impl FsDiscovery {
         Self {
             directories,
             extensions,
-            path_cache,
+            configured,
             id_resolver,
             process,
             build,
@@ -112,6 +130,28 @@ impl FsDiscovery {
     }
 }
 
+/// Per-source `convert_to_*` settings override the kind-level [`ProcessConfig`].
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+fn per_source_process(kind_level: &ProcessConfig, src: &FileConfigSrc) -> Option<ProcessConfig> {
+    use crate::config::file::resolve_process_config;
+
+    let FileConfigSrc::Obj(obj) = src else {
+        return None;
+    };
+    if obj.convert_to_mlt.is_none() && obj.convert_to_mvt.is_none() {
+        return None;
+    }
+    let per_source = ProcessConfig {
+        convert_to_mlt: obj.convert_to_mlt.clone(),
+        convert_to_mvt: obj.convert_to_mvt.clone(),
+    };
+    Some(resolve_process_config(
+        kind_level,
+        &ProcessConfig::default(),
+        &per_source,
+    ))
+}
+
 impl Discovery for FsDiscovery {
     type Args = (PathBuf, CachePolicy);
 
@@ -119,7 +159,7 @@ impl Discovery for FsDiscovery {
         let discovered = discover_sources_by_ext(
             &self.directories,
             self.extensions,
-            &self.path_cache,
+            &self.configured,
             &self.id_resolver,
         )
         .await?;
@@ -135,9 +175,15 @@ impl Discovery for FsDiscovery {
     }
 
     async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
-        (self.build)(id.to_owned(), args.0.clone(), args.1)
-            .await
-            .map(Into::into)
+        let source = (self.build)(id.to_owned(), args.0.clone(), args.1).await?;
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        let process = self
+            .configured
+            .get(&args.0)
+            .and_then(|cfg| cfg.process.clone());
+        #[cfg(not(all(feature = "mlt", feature = "_tiles")))]
+        let process = None;
+        Ok(BuiltSource { source, process })
     }
 
     fn process(&self) -> ProcessConfig {
@@ -203,7 +249,7 @@ fn resolve_dir_entry(entry: &DirEntry) -> Option<ResolvedEntry> {
 async fn discover_sources_by_ext(
     directories: &[PathBuf],
     extensions: &[&str],
-    path_cache: &BTreeMap<PathBuf, CachePolicy>,
+    configured: &BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: &IdResolver,
 ) -> MartinResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
     let mut out = BTreeMap::new();
@@ -222,7 +268,10 @@ async fn discover_sources_by_ext(
             {
                 continue;
             }
-            let policy = path_cache.get(&e.path).copied().unwrap_or_default();
+            let policy = configured
+                .get(&e.path)
+                .map(|cfg| cfg.policy)
+                .unwrap_or_default();
             let id = id_resolver.resolve(&e.stem, e.path_str.clone());
             out.insert(id, (e.path, e.modified_ms, policy));
         }
@@ -268,5 +317,61 @@ mod tests {
                 .all(|(v, _)| matches!(v, Version::Tracked(_))),
             "file sources carry a Tracked mtime version"
         );
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[test]
+    fn configured_sources_keep_their_convert_override() {
+        use crate::config::file::{FileConfig, FileConfigSource};
+        use crate::config::primitives::AutoOption;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let overridden = dir.path().join("overridden.mbtiles");
+        let plain = dir.path().join("plain.mbtiles");
+        File::create(&overridden).expect("create overridden");
+        File::create(&plain).expect("create plain");
+
+        let config = FileConfigEnum::Config(FileConfig {
+            sources: Some(BTreeMap::from([
+                (
+                    "overridden".to_owned(),
+                    FileConfigSrc::Obj(FileConfigSource {
+                        path: overridden.clone(),
+                        convert_to_mlt: Some(AutoOption::Disabled),
+                        convert_to_mvt: None,
+                        cache: CachePolicy::default(),
+                    }),
+                ),
+                ("plain".to_owned(), FileConfigSrc::Path(plain.clone())),
+            ])),
+            ..FileConfig::<()>::default()
+        });
+        let kind_level = ProcessConfig {
+            convert_to_mlt: Some(AutoOption::Auto),
+            convert_to_mvt: None,
+        };
+        let discovery = FsDiscovery::from_config(
+            &config,
+            &["mbtiles"],
+            IdResolver::new(&[]),
+            kind_level,
+            unreachable_builder(),
+        );
+
+        let configured = |path: &PathBuf| {
+            let canonical = path.canonicalize().expect("canonicalize");
+            discovery
+                .configured
+                .get(&canonical)
+                .expect("configured path")
+        };
+        assert_eq!(
+            configured(&overridden)
+                .process
+                .as_ref()
+                .and_then(|p| p.convert_to_mlt.clone()),
+            Some(AutoOption::Disabled)
+        );
+        assert_eq!(configured(&plain).process, None);
     }
 }


### PR DESCRIPTION
Companion to #3144, which fixed this for Postgres. The file-backed kinds (mbtiles, pmtiles, geojson, cog) have the same gap: `FsDiscovery` only remembers each configured path's cache policy, so when the reload path rebuilds a source, its per-source `convert_to_*` settings are dropped and it falls back to the kind-level `ProcessConfig`.

The fix mirrors the Postgres one. `FsDiscovery` now keeps the whole configured entry per canonical path (cache policy plus the per-source process, resolved against the kind level at construction), and `build()` returns the override through `BuiltSource`. `NewSource` already prefers that over the kind level, so nothing downstream needed to change. A unit test builds an `FsDiscovery` from a config with one overridden and one plain source on disk and checks what it kept for each.

One small side fix: the `resolve_process_config` re-export was gated on `mlt` plus a hand-listed set of kinds that missed `geojson`, which enables `mlt` without any of them. The gate is now `mlt` + `_tiles`, matching the actual use sites.

Verified: workspace lib tests (720 pass), the full e2e suite (250 pass), and `just check` (cargo hack each-feature, 51 combos) under `CARGO_BUILD_WARNINGS=deny`; fmt + clippy + pre-commit clean.
