### PR TITLE
ci: stop caching the macOS unit-test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           rendering: true
-          cache: true
+          # The 10GB cache quota only has room for the Linux entry; a macOS entry
+          # gets evicted before the next run can restore it (see #3156).
+          cache: ${{ matrix.os == 'ubuntu-latest' }}
           coverage: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Run cargo test
         run: just test-packages-ci


### PR DESCRIPTION
Follow-up to #3156.

`unit-test-rust` on macOS has `cache: true`, but the entry never survives: every main run saves a 1.6GB macOS cache (run [32784905315](https://github.com/maplibre/martin/actions/runs/32784905315) logs `Sent … of 1682472840`), and every restore since logs `No cache found`. The quota is full at 9.8GB, so the save gets evicted before the next run needs it, and on its way out it pushes out entries other jobs would have hit. That's a flag costing time twice and saving none.

This gates `cache` on the Linux leg the same way `coverage` already is. No expected timing change on macOS (it wasn't hitting anyway); the win is 1.6GB less churn against the quota on every push to main.

Where #3157 landed, for the record: the multi-os entries came in at 693MB (Linux) + 599MB (Windows), and the first full-match warm run ([#3160's](https://github.com/maplibre/martin/actions/runs/32794860516)) took the Windows e2e step from 12.9–13.7 to 10.4 minutes and the Ubuntu one from 3.4 to 2.0. Quota is 9.8GB either way, which is why this PR removes a flag instead of adding one: the 4.7GB DuckDB-coverage entry is what would need to shrink before `unit-test-svc-pg` or `test-publish` can be cached, and I'd rather measure that on my fork than guess.

Ref #3156
