### PR TITLE
refactor(errors): split MartinError into different error types

### DIFF
--- a/docs/content/getting-involved.md
+++ b/docs/content/getting-involved.md
@@ -131,11 +131,11 @@ use clap::Parser;
 use tracing::{error, info};
 use martin::args::{Args, OsEnv};
 use martin::srv::new_server;
-use martin::{read_config, Config, MartinResult};
+use martin::{read_config, Config, StartupResult};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-async fn start(args: Args) -> MartinResult<()> {
+async fn start(args: Args) -> StartupResult<()> {
     info!("Starting Martin v{VERSION}");
 ```
 

--- a/martin-core/src/error.rs
+++ b/martin-core/src/error.rs
@@ -1,0 +1,30 @@
+//! Transport-independent classification of failures.
+//!
+//! Errors here describe *what went wrong* in the vocabulary of the subsystem that failed.
+//! A transport edge needs a different question answered: *whose fault was it, and is a
+//! retry worth trying?* [`ErrorKind`] is that second axis, so an edge maps one small enum
+//! instead of re-matching every subsystem's variants.
+
+/// How a caller should treat a failure, independent of which subsystem produced it.
+///
+/// Deliberately not `#[non_exhaustive]`: adding a kind should break every edge that maps it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ErrorKind {
+    /// The requested resource does not exist.
+    NotFound,
+    /// The request was malformed, out of range, or asked for something unsupported.
+    InvalidInput,
+    /// A dependency was reachable but failed to serve the request; a retry may succeed.
+    Unavailable,
+    /// A defect in martin, or a failure that callers cannot act on.
+    Internal,
+}
+
+/// Answers [`ErrorKind`] for an error type.
+///
+/// Prefer widening to [`ErrorKind::Internal`] over guessing: a misclassified
+/// [`ErrorKind::NotFound`] hides a real defect behind a 404.
+pub trait Classify {
+    /// Classifies this failure for a caller that must map it onto a transport.
+    fn kind(&self) -> ErrorKind;
+}

--- a/martin-core/src/lib.rs
+++ b/martin-core/src/lib.rs
@@ -3,6 +3,9 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
+mod error;
+pub use error::{Classify, ErrorKind};
+
 /// Generic resource cache shared by sprite, font, and tile caches.
 pub mod cache;
 

--- a/martin-core/src/resources/fonts/error.rs
+++ b/martin-core/src/resources/fonts/error.rs
@@ -76,3 +76,18 @@ pub enum FontError {
     #[error(transparent)]
     ErrorSerializingProtobuf(#[from] pbf_font_tools::prost::DecodeError),
 }
+
+impl crate::Classify for FontError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, InvalidInput, NotFound};
+        match self {
+            Self::FontNotFound(_) => NotFound,
+            Self::TooManyFontIds { .. }
+            | Self::InvalidFontRangeStartEnd { .. }
+            | Self::InvalidFontRangeStart(_)
+            | Self::InvalidFontRangeEnd(_)
+            | Self::InvalidFontRange(_, _) => InvalidInput,
+            _ => Internal,
+        }
+    }
+}

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -58,3 +58,14 @@ pub enum SpriteError {
     #[error("Unable to create a sprite from file {0}")]
     SpriteInstError(PathBuf),
 }
+
+impl crate::Classify for SpriteError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, InvalidInput, NotFound};
+        match self {
+            Self::SpriteNotFound(_) => NotFound,
+            Self::TooManySpriteIds { .. } => InvalidInput,
+            _ => Internal,
+        }
+    }
+}

--- a/martin-core/src/tiles/cog/errors.rs
+++ b/martin-core/src/tiles/cog/errors.rs
@@ -99,3 +99,9 @@ pub enum CogError {
     #[error("The size of each tile is not consistent.")]
     InconsistentTiling(PathBuf),
 }
+
+impl crate::Classify for CogError {
+    fn kind(&self) -> crate::ErrorKind {
+        crate::ErrorKind::Internal
+    }
+}

--- a/martin-core/src/tiles/duckdb/errors.rs
+++ b/martin-core/src/tiles/duckdb/errors.rs
@@ -114,3 +114,13 @@ pub enum DuckDBError {
         Option<UrlQuery>,
     ),
 }
+
+impl crate::Classify for DuckDBError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, Unavailable};
+        match self {
+            Self::DuckDBPoolConnError(..) => Unavailable,
+            _ => Internal,
+        }
+    }
+}

--- a/martin-core/src/tiles/error.rs
+++ b/martin-core/src/tiles/error.rs
@@ -63,3 +63,25 @@ pub enum MartinCoreError {
 
 /// A convenience [`Result`] for tiles coming from `martin-core`.
 pub type MartinCoreResult<T> = Result<T, MartinCoreError>;
+
+impl crate::Classify for MartinCoreError {
+    fn kind(&self) -> crate::ErrorKind {
+        match self {
+            #[cfg(feature = "mbtiles")]
+            Self::MbtilesError(e) => e.kind(),
+            #[cfg(feature = "postgres")]
+            Self::PostgresError(e) => e.kind(),
+            #[cfg(feature = "unstable-duckdb")]
+            Self::DuckDBError(e) => e.kind(),
+            #[cfg(feature = "pmtiles")]
+            Self::PmtilesError(e) => e.kind(),
+            #[cfg(feature = "passthrough")]
+            Self::PassthroughError(e) => e.kind(),
+            #[cfg(feature = "unstable-cog")]
+            Self::CogError(e) => e.kind(),
+            #[cfg(feature = "geojson")]
+            Self::GeoJsonError(e) => e.kind(),
+            Self::SourceNeedsReload | Self::OtherError(_) => crate::ErrorKind::Internal,
+        }
+    }
+}

--- a/martin-core/src/tiles/geojson/error.rs
+++ b/martin-core/src/tiles/geojson/error.rs
@@ -26,3 +26,9 @@ pub enum GeoJsonError {
     #[error("GeoJSON has too many features to index: {0} exceeds u32::MAX")]
     TooManyFeatures(usize),
 }
+
+impl crate::Classify for GeoJsonError {
+    fn kind(&self) -> crate::ErrorKind {
+        crate::ErrorKind::Internal
+    }
+}

--- a/martin-core/src/tiles/mbtiles/error.rs
+++ b/martin-core/src/tiles/mbtiles/error.rs
@@ -22,3 +22,13 @@ pub enum MbtilesError {
     #[error(r"Unable to parse metadata in file {1}: {0}")]
     InvalidMetadata(String, PathBuf),
 }
+
+impl crate::Classify for MbtilesError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, Unavailable};
+        match self {
+            Self::AcquireConnError(..) => Unavailable,
+            _ => Internal,
+        }
+    }
+}

--- a/martin-core/src/tiles/passthrough/error.rs
+++ b/martin-core/src/tiles/passthrough/error.rs
@@ -84,3 +84,17 @@ pub enum PassthroughError {
         status: u16,
     },
 }
+
+impl crate::Classify for PassthroughError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, Unavailable};
+        match self {
+            Self::Http(_)
+            | Self::TileJsonFetch { .. }
+            | Self::TileJsonStatus { .. }
+            | Self::TileJsonParse { .. }
+            | Self::UnexpectedStatus { .. } => Unavailable,
+            _ => Internal,
+        }
+    }
+}

--- a/martin-core/src/tiles/pmtiles/error.rs
+++ b/martin-core/src/tiles/pmtiles/error.rs
@@ -29,3 +29,9 @@ pub enum PmtilesError {
         path: String,
     },
 }
+
+impl crate::Classify for PmtilesError {
+    fn kind(&self) -> crate::ErrorKind {
+        crate::ErrorKind::Internal
+    }
+}

--- a/martin-core/src/tiles/postgres/errors.rs
+++ b/martin-core/src/tiles/postgres/errors.rs
@@ -132,3 +132,13 @@ pub enum PostgresError {
         Option<UrlQuery>,
     ),
 }
+
+impl crate::Classify for PostgresError {
+    fn kind(&self) -> crate::ErrorKind {
+        use crate::ErrorKind::{Internal, Unavailable};
+        match self {
+            Self::PostgresPoolConnError(..) => Unavailable,
+            _ => Internal,
+        }
+    }
+}

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -23,9 +23,10 @@ use futures::TryStreamExt as _;
 use futures::future::{Either, select as select_future};
 use futures::stream::{self, StreamExt as _};
 use hotpath::wrap::tokio::sync::mpsc::{Receiver, Sender};
+use martin::StartupError;
 #[cfg(feature = "postgres")]
 use martin::config::args::PostgresArgs;
-use martin::config::args::{Args, ExtraArgs, MetaArgs, SrvArgs};
+use martin::config::args::{Args, ArgsError, ExtraArgs, MetaArgs, SrvArgs};
 use martin::config::file::{Config, ServerState, read_config};
 #[cfg(feature = "_tiles")]
 use martin::config::primitives::IdResolver;
@@ -35,7 +36,6 @@ use martin::logging::{LogFormat, ensure_martin_core_log_level_matches, init_trac
 #[cfg(feature = "_tiles")]
 use martin::srv::RESERVED_KEYWORDS;
 use martin::srv::{DynTileSource, TileRequestHeaders, merge_tilejson};
-use martin::{MartinError, MartinResult};
 use martin_core::tiles::BoxedSource;
 use martin_core::tiles::mbtiles::MbtilesError;
 #[cfg(feature = "postgres")]
@@ -185,7 +185,7 @@ async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     let save_config = copy_args.meta.save_config.clone();
     let mut config = if let Some(ref cfg_filename) = copy_args.meta.config {
         info!("Using {}", cfg_filename.display());
-        read_config(cfg_filename, &env).map_err(MartinError::from)?
+        read_config(cfg_filename, &env).map_err(StartupError::from)?
     } else {
         info!("Config file is not specified, auto-detecting sources");
         Config::default()
@@ -220,7 +220,7 @@ async fn start(copy_args: CopierArgs) -> MartinCpResult<()> {
     if let Some(file_name) = save_config {
         config
             .save_to_file(file_name.as_path())
-            .map_err(MartinError::from)?;
+            .map_err(StartupError::from)?;
     } else {
         info!("Use --save-config to save or print configuration.");
     }
@@ -292,13 +292,17 @@ type MartinCpResult<T> = Result<T, MartinCpError>;
 #[derive(thiserror::Error, Debug)]
 enum MartinCpError {
     #[error(transparent)]
-    Martin(#[from] MartinError),
+    Martin(#[from] StartupError),
+    #[error(transparent)]
+    Args(#[from] ArgsError),
     #[error("Unable to parse encodings argument: {0}")]
     EncodingParse(#[from] ParseError),
     #[error(transparent)]
     Actix(#[from] actix_web::Error),
     #[error(transparent)]
     Mbt(#[from] MbtError),
+    #[error(transparent)]
+    Mbtiles(#[from] MbtilesError),
     #[error("No sources found")]
     NoSources,
     #[error(
@@ -394,8 +398,7 @@ async fn write_tiles_to_mbtiles(
             ));
             if batch.len() >= BATCH_SIZE || last_saved.elapsed() > SAVE_EVERY {
                 mbt.insert_tiles(&mut conn, mbt_type, on_duplicate, &batch)
-                    .await
-                    .map_err(MbtilesError::from)?;
+                    .await?;
                 batch.clear();
                 last_saved = Instant::now();
             }
@@ -413,8 +416,7 @@ async fn write_tiles_to_mbtiles(
     // Flush whatever is left once the channel closes (all senders dropped).
     if !batch.is_empty() {
         mbt.insert_tiles(&mut conn, mbt_type, on_duplicate, &batch)
-            .await
-            .map_err(MbtilesError::from)?;
+            .await?;
     }
     Ok(conn)
 }
@@ -425,16 +427,13 @@ async fn produce_tiles(
     tiles: Vec<TileRect>,
     concurrency: usize,
     tx: Sender<TileXyz>,
-) -> MartinResult<()> {
+) -> MartinCpResult<()> {
     stream::iter(iterate_tiles(tiles))
-        .map(MartinResult::Ok)
+        .map(MartinCpResult::Ok)
         .try_for_each_concurrent(concurrency, |xyz| {
             let tx = tx.clone();
             async move {
-                let tile = src
-                    .get_tile_content(xyz)
-                    .await
-                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                let tile = src.get_tile_content(xyz).await?;
                 tx.send(TileXyz {
                     xyz,
                     data: tile.data,
@@ -466,13 +465,11 @@ async fn join_consumer(
         // Normal path
         consumer_task.await
     };
-    let conn = join_result
-        .map_err(|e| {
-            MartinError::from(std::io::Error::other(format!(
-                "consumer task panicked: {e}"
-            )))
-        })?
-        .map_err(MartinError::from)?;
+    let conn = join_result.map_err(|e| {
+        StartupError::from(std::io::Error::other(format!(
+            "consumer task panicked: {e}"
+        )))
+    })??;
     Ok(Some(conn))
 }
 
@@ -638,50 +635,39 @@ async fn init_schema(
     sources: &[BoxedSource],
     tile_info: TileInfo,
     args: &CopyArgs,
-) -> Result<MbtType, MartinError> {
-    Ok(
-        if is_empty_database(&mut *conn)
-            .await
-            .map_err(MbtilesError::from)?
-        {
-            let mbt_type = match args.mbt_type.unwrap_or(MbtTypeCli::Normalized) {
-                MbtTypeCli::Flat => MbtType::Flat,
-                MbtTypeCli::FlatWithHash => MbtType::FlatWithHash,
-                MbtTypeCli::Normalized => MbtType::Normalized {
-                    hash_view: true,
-                    schema: mbtiles::NormalizedSchema::Hash,
-                },
-                MbtTypeCli::Cache => MbtType::Cache,
-            };
-            init_mbtiles_schema(&mut *conn, mbt_type, false)
-                .await
-                .map_err(MbtilesError::from)?;
-            let mut tj = merge_tilejson(sources, String::new());
-            tj.other.insert(
-                "format".to_owned(),
-                serde_json::Value::String(tile_info.format.metadata_format_value().to_owned()),
-            );
-            tj.other.insert(
-                "generator".to_owned(),
-                serde_json::Value::String(format!("martin-cp v{VERSION}")),
-            );
-            let zooms = get_zooms(args);
-            if let Some(min_zoom) = zooms.iter().min() {
-                tj.minzoom = Some(*min_zoom);
-            }
-            if let Some(max_zoom) = zooms.iter().max() {
-                tj.maxzoom = Some(*max_zoom);
-            }
-            mbt.insert_metadata(&mut *conn, &tj)
-                .await
-                .map_err(MbtilesError::from)?;
-            mbt_type
-        } else {
-            mbt.detect_type(&mut *conn)
-                .await
-                .map_err(MbtilesError::from)?
-        },
-    )
+) -> MartinCpResult<MbtType> {
+    Ok(if is_empty_database(&mut *conn).await? {
+        let mbt_type = match args.mbt_type.unwrap_or(MbtTypeCli::Normalized) {
+            MbtTypeCli::Flat => MbtType::Flat,
+            MbtTypeCli::FlatWithHash => MbtType::FlatWithHash,
+            MbtTypeCli::Normalized => MbtType::Normalized {
+                hash_view: true,
+                schema: mbtiles::NormalizedSchema::Hash,
+            },
+            MbtTypeCli::Cache => MbtType::Cache,
+        };
+        init_mbtiles_schema(&mut *conn, mbt_type, false).await?;
+        let mut tj = merge_tilejson(sources, String::new());
+        tj.other.insert(
+            "format".to_owned(),
+            serde_json::Value::String(tile_info.format.metadata_format_value().to_owned()),
+        );
+        tj.other.insert(
+            "generator".to_owned(),
+            serde_json::Value::String(format!("martin-cp v{VERSION}")),
+        );
+        let zooms = get_zooms(args);
+        if let Some(min_zoom) = zooms.iter().min() {
+            tj.minzoom = Some(*min_zoom);
+        }
+        if let Some(max_zoom) = zooms.iter().max() {
+            tj.maxzoom = Some(*max_zoom);
+        }
+        mbt.insert_metadata(&mut *conn, &tj).await?;
+        mbt_type
+    } else {
+        mbt.detect_type(&mut *conn).await?
+    })
 }
 
 #[tokio::main]

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -6,7 +6,7 @@
 use std::env;
 
 use clap::Parser as _;
-use martin::MartinResult;
+use martin::StartupResult;
 use martin::config::args::Args;
 #[cfg(all(feature = "webui", not(docsrs)))]
 use martin::config::args::WebUiMode;
@@ -36,7 +36,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[hotpath::measure]
 #[expect(clippy::too_many_lines)]
-async fn start(args: Args) -> MartinResult<()> {
+async fn start(args: Args) -> StartupResult<()> {
     info!("Starting Martin v{VERSION}");
 
     let env = OsEnv;
@@ -170,7 +170,7 @@ async fn start(args: Args) -> MartinResult<()> {
     #[cfg(not(all(feature = "webui", not(docsrs))))]
     info!("Martin server is now active. See {base_url}catalog to see available services");
 
-    server.await
+    Ok(server.await?)
 }
 
 #[tokio::main]

--- a/martin/src/config/args/connections.rs
+++ b/martin/src/config/args/connections.rs
@@ -1,4 +1,4 @@
-use crate::{MartinError, MartinResult};
+use crate::config::args::{ArgsError, ArgsResult};
 
 #[derive(Debug, Clone)]
 pub enum State<T: Clone> {
@@ -72,7 +72,7 @@ impl Arguments {
     }
 
     /// Check that all params have been claimed
-    pub fn check(self) -> MartinResult<()> {
+    pub fn check(self) -> ArgsResult<()> {
         let mut unrecognized = Vec::new();
         for (i, value) in self.values.into_iter().enumerate() {
             if let State::Ignore = self.state[i] {
@@ -82,7 +82,7 @@ impl Arguments {
         if unrecognized.is_empty() {
             Ok(())
         } else {
-            Err(MartinError::UnrecognizableConnections(unrecognized))
+            Err(ArgsError::UnrecognizableConnections(unrecognized))
         }
     }
 }

--- a/martin/src/config/args/error.rs
+++ b/martin/src/config/args/error.rs
@@ -1,0 +1,42 @@
+//! Failures from parsing and reconciling command-line arguments.
+//!
+//! Produced only by [`config::args`](crate::config::args), consumed only by `main`.
+
+use std::fmt::Write as _;
+
+/// A convenience [`Result`] for command-line argument handling.
+pub type ArgsResult<T> = Result<T, ArgsError>;
+
+/// Why the given command-line arguments could not be turned into a config.
+#[derive(thiserror::Error, Debug)]
+pub enum ArgsError {
+    #[error("The --config and the connection parameters cannot be used together. Please remove unsupported parameters '{}'", elide_vec(.0, 3, 15))]
+    ConfigAndConnections(Vec<String>),
+
+    #[error("Unrecognizable connection strings: {0:?}")]
+    UnrecognizableConnections(Vec<String>),
+}
+
+fn elide_vec(vec: &[String], max_items: usize, max_len: usize) -> String {
+    let mut s = String::new();
+    for (i, v) in vec.iter().enumerate() {
+        if i > max_items {
+            let _ = write!(s, " and {} more", vec.len() - i);
+            break;
+        }
+        if i > 0 {
+            s.push(' ');
+        }
+        if v.len() > max_len {
+            let mut bytes = 0usize;
+            s.extend(v.chars().take_while(|c| {
+                bytes += c.len_utf8();
+                bytes <= max_len
+            }));
+            s.push('…');
+        } else {
+            s.push_str(v);
+        }
+    }
+    s
+}

--- a/martin/src/config/args/mod.rs
+++ b/martin/src/config/args/mod.rs
@@ -1,3 +1,6 @@
+mod error;
+pub use error::{ArgsError, ArgsResult};
+
 mod connections;
 pub use connections::State;
 

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -235,7 +235,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::MartinError;
+    use crate::config::args::ArgsError;
     use crate::config::primitives::env::FauxEnv;
 
     #[test]
@@ -250,7 +250,7 @@ mod tests {
             vec!["postgresql://localhost:5432", "postgres://localhost:5432"]
         );
         assert!(matches!(args.check(), Err(
-            MartinError::UnrecognizableConnections(v)) if v == vec!["mysql://localhost:3306"]));
+            ArgsError::UnrecognizableConnections(v)) if v == vec!["mysql://localhost:3306"]));
     }
 
     #[test]

--- a/martin/src/config/args/root.rs
+++ b/martin/src/config/args/root.rs
@@ -6,8 +6,8 @@ use clap::builder::styling::AnsiColor;
 
 use super::connections::Arguments;
 use super::srv::SrvArgs;
-use crate::MartinError::ConfigAndConnectionsError;
-use crate::MartinResult;
+use crate::config::args::ArgsError::ConfigAndConnections;
+use crate::config::args::ArgsResult;
 #[cfg(feature = "postgres")]
 use crate::config::args::PostgresArgs;
 #[cfg(any(
@@ -102,9 +102,9 @@ impl Args {
         self,
         config: &mut Config,
         #[cfg(feature = "postgres")] env: &impl Env,
-    ) -> MartinResult<()> {
+    ) -> ArgsResult<()> {
         if self.meta.config.is_some() && !self.meta.connection.is_empty() {
-            return Err(ConfigAndConnectionsError(self.meta.connection));
+            return Err(ConfigAndConnections(self.meta.connection));
         }
 
         #[cfg(feature = "postgres")]
@@ -282,12 +282,12 @@ pub fn parse_file_args<T: ConfigurationLivecycleHooks>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::MartinError::UnrecognizableConnections;
+    use crate::config::args::ArgsError::UnrecognizableConnections;
     use crate::config::args::PreferredEncoding;
     #[cfg(feature = "postgres")]
     use crate::config::primitives::env::FauxEnv;
 
-    fn parse(args: &[&str]) -> MartinResult<(Config, MetaArgs)> {
+    fn parse(args: &[&str]) -> ArgsResult<(Config, MetaArgs)> {
         let args = Args::parse_from(args);
         let meta = args.meta.clone();
         let mut config = Config::default();
@@ -411,7 +411,7 @@ mod tests {
         let err = args
             .merge_into_config(&mut config, &FauxEnv::default())
             .unwrap_err();
-        assert!(matches!(err, ConfigAndConnectionsError(..)));
+        assert!(matches!(err, ConfigAndConnections(..)));
     }
 
     #[test]

--- a/martin/src/config/file/cors.rs
+++ b/martin/src/config/file/cors.rs
@@ -10,7 +10,6 @@ use crate::config::file::{
     CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks,
     UnrecognizedValues,
 };
-use crate::{MartinError, MartinResult};
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, CollectUnrecognizedKeys)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
@@ -133,10 +132,10 @@ impl CorsConfig {
     }
 
     /// Checks that that if cors is configured explicitly (instead of via `true`/`false`), `origin` is configured
-    pub fn validate(&self) -> MartinResult<()> {
+    pub fn validate(&self) -> ConfigFileResult<()> {
         match self {
             Self::SimpleFlag(_) => Ok(()),
-            Self::Properties(properties) => properties.validate().map_err(MartinError::from),
+            Self::Properties(properties) => properties.validate(),
         }
     }
 

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -50,6 +50,12 @@ pub enum ConfigFileError {
     #[error("At least one 'origin' must be specified in the 'cors' configuration")]
     CorsNoOriginsConfigured,
 
+    #[error("Base path must be a valid URL path, and must begin with a '/' symbol, but is '{0}'")]
+    InvalidBasePath(String),
+
+    #[error("warnings issued during tile source resolution")]
+    TileResolutionWarningsIssued,
+
     #[cfg(feature = "styles")]
     #[error("Walk directory error {0}: {1}")]
     DirectoryWalking(#[source] walkdir::Error, PathBuf),
@@ -237,6 +243,8 @@ impl Diagnostic for ConfigFileError {
             #[cfg(feature = "passthrough")]
             Self::InvalidPassthroughFormat { .. } => "martin::config::passthrough::invalid_format",
             Self::CorsNoOriginsConfigured => "martin::config::cors::no_origins",
+            Self::InvalidBasePath(_) => "martin::config::invalid_base_path",
+            Self::TileResolutionWarningsIssued => "martin::config::tile_resolution_warnings",
             #[cfg(feature = "styles")]
             Self::DirectoryWalking(..) => "martin::config::styles::walk",
             #[cfg(feature = "postgres")]

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -31,10 +31,10 @@ use crate::config::file::{MltProcessConfig, MvtProcessConfig};
 #[cfg(feature = "_tiles")]
 use crate::config::file::{ResolutionResult, TileSourceWarning};
 #[cfg(feature = "_tiles")]
+use crate::config::file::{SourceBuildError, SourceBuildResult};
+#[cfg(feature = "_tiles")]
 use crate::config::primitives::IdResolver;
 use crate::config::primitives::OptOneMany;
-#[cfg(feature = "_tiles")]
-use crate::{MartinError, MartinResult};
 
 /// Lifecycle hooks for configuring the application
 ///
@@ -71,7 +71,7 @@ pub trait TileSourceConfiguration: ConfigurationLivecycleHooks {
         id: String,
         path: PathBuf,
         cache: CachePolicy,
-    ) -> impl Future<Output = MartinResult<BoxedSource>> + Send;
+    ) -> impl Future<Output = SourceBuildResult<BoxedSource>> + Send;
 
     /// Asynchronously creates a new `BoxedSource` from a **remote** `url` using the given `id`.
     ///
@@ -82,7 +82,7 @@ pub trait TileSourceConfiguration: ConfigurationLivecycleHooks {
         id: String,
         url: Url,
         cache: CachePolicy,
-    ) -> impl Future<Output = MartinResult<BoxedSource>> + Send;
+    ) -> impl Future<Output = SourceBuildResult<BoxedSource>> + Send;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, CollectUnrecognizedKeys)]
@@ -515,7 +515,7 @@ struct Planned {
 
 #[cfg(feature = "_tiles")]
 impl Planned {
-    async fn open<T: TileSourceConfiguration>(&self, custom: &T) -> MartinResult<BoxedSource> {
+    async fn open<T: TileSourceConfiguration>(&self, custom: &T) -> SourceBuildResult<BoxedSource> {
         match &self.target {
             Target::Url { url, .. } => {
                 custom
@@ -557,7 +557,7 @@ impl Planned {
         }
     }
 
-    fn warning(&self, err: &MartinError) -> TileSourceWarning {
+    fn warning(&self, err: &SourceBuildError) -> TileSourceWarning {
         if self.from_sources {
             return TileSourceWarning::SourceError {
                 source_id: self.id.clone(),
@@ -585,7 +585,7 @@ fn plan_one_source(
     files: &mut HashMap<PathBuf, PathBuf>,
     configs: &mut BTreeMap<String, FileConfigSrc>,
     default_cache: CachePolicy,
-) -> MartinResult<Planned> {
+) -> SourceBuildResult<Planned> {
     let cache = source.cache_zoom().or(default_cache);
     if let Some(url) = parse_url(parse_urls, source.get_path())? {
         let key = source.get_path().clone();
@@ -632,7 +632,7 @@ fn plan_one_path(
     directories: &mut Vec<PathBuf>,
     configs: &mut BTreeMap<String, FileConfigSrc>,
     default_cache: CachePolicy,
-) -> MartinResult<Vec<Planned>> {
+) -> SourceBuildResult<Vec<Planned>> {
     if let Some(url) = parse_url(parse_urls, &path)? {
         let target_ext = extension.iter().find(|&e| url.to_string().ends_with(e));
         let Some(ext) = target_ext else {
@@ -680,7 +680,7 @@ fn plan_one_path(
     } else if path.is_file() {
         vec![path]
     } else {
-        return Err(MartinError::from(ConfigFileError::InvalidFilePath(
+        return Err(SourceBuildError::from(ConfigFileError::InvalidFilePath(
             path.canonicalize().unwrap_or(path),
         )));
     };
@@ -1604,7 +1604,7 @@ mod folder_source_tests {
     use tilejson::{TileJSON, tilejson};
 
     use super::*;
-    use crate::MartinError;
+    use crate::config::file::SourceBuildError;
     use crate::config::primitives::IdResolver;
 
     /// Files whose stem starts with this prefix are treated as invalid by [`FakeConfig`].
@@ -1628,13 +1628,15 @@ mod folder_source_tests {
             id: String,
             path: PathBuf,
             _cache: CachePolicy,
-        ) -> MartinResult<BoxedSource> {
+        ) -> SourceBuildResult<BoxedSource> {
             let stem = path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or_default();
             if stem.starts_with(BAD_PREFIX) {
-                Err(MartinError::from(ConfigFileError::InvalidFilePath(path)))
+                Err(SourceBuildError::from(ConfigFileError::InvalidFilePath(
+                    path,
+                )))
             } else {
                 Ok(Box::new(FakeSource {
                     id,
@@ -1651,7 +1653,7 @@ mod folder_source_tests {
             _id: String,
             _url: Url,
             _cache: CachePolicy,
-        ) -> MartinResult<BoxedSource> {
+        ) -> SourceBuildResult<BoxedSource> {
             unreachable!()
         }
     }

--- a/martin/src/config/file/main/config.rs
+++ b/martin/src/config/file/main/config.rs
@@ -17,6 +17,8 @@ use tracing::{error, instrument, warn};
     feature = "fonts",
 ))]
 use crate::config::file::FileConfigEnum;
+#[cfg(feature = "_tiles")]
+use crate::config::file::SourceBuildResult;
 #[cfg(feature = "unstable-cog")]
 use crate::config::file::cog::CogConfig;
 #[cfg(feature = "unstable-duckdb")]
@@ -40,12 +42,14 @@ use crate::config::file::sprites::SpriteConfig;
 use crate::config::file::srv::SrvConfig;
 #[cfg(feature = "styles")]
 use crate::config::file::styles::StyleConfig;
-use crate::config::file::{CollectUnrecognizedKeys, GlobalCacheConfig, UnrecognizedValues};
+use crate::config::file::{
+    CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, GlobalCacheConfig,
+    UnrecognizedValues,
+};
 #[cfg(feature = "postgres")]
 use crate::config::primitives::OptOneMany;
 #[cfg(feature = "_tiles")]
 use crate::tile_source_manager::TileSourceManager;
-use crate::{MartinError, MartinResult};
 
 /// Warnings that can occur during tile source resolution
 #[derive(thiserror::Error, Debug)]
@@ -58,7 +62,7 @@ pub enum TileSourceWarning {
 }
 
 #[cfg(feature = "_tiles")]
-pub type ResolutionResult = MartinResult<(Vec<BoxedSource>, Vec<TileSourceWarning>)>;
+pub type ResolutionResult = SourceBuildResult<(Vec<BoxedSource>, Vec<TileSourceWarning>)>;
 
 pub struct ServerState {
     #[cfg(feature = "_tiles")]
@@ -223,7 +227,7 @@ fn fmt_warnings(warnings: &[TileSourceWarning]) -> String {
 impl OnInvalid {
     /// Handle warnings based on `policy`
     #[instrument(skip_all, fields(warnings.count = warnings.len()), err(Debug))]
-    pub fn handle_tile_warnings(self, warnings: &[TileSourceWarning]) -> MartinResult<()> {
+    pub fn handle_tile_warnings(self, warnings: &[TileSourceWarning]) -> ConfigFileResult<()> {
         if warnings.is_empty() {
             return Ok(());
         }
@@ -239,20 +243,20 @@ impl OnInvalid {
         }
 
         match self {
-            Self::Abort => Err(MartinError::TileResolutionWarningsIssued),
+            Self::Abort => Err(ConfigFileError::TileResolutionWarningsIssued),
             Self::Warn => Ok(()),
         }
     }
 }
 
-pub fn parse_base_path(path: &str) -> MartinResult<String> {
+pub fn parse_base_path(path: &str) -> ConfigFileResult<String> {
     if !path.starts_with('/') {
-        return Err(MartinError::BasePathError(path.to_owned()));
+        return Err(ConfigFileError::InvalidBasePath(path.to_owned()));
     }
     if let Ok(uri) = path.parse::<actix_web::http::Uri>() {
         return Ok(uri.path().trim_end_matches('/').to_owned());
     }
-    Err(MartinError::BasePathError(path.to_owned()))
+    Err(ConfigFileError::InvalidBasePath(path.to_owned()))
 }
 
 pub fn init_aws_lc_tls() {
@@ -272,8 +276,7 @@ mod tests {
     use martin_core::CacheZoomRange;
 
     use super::*;
-    use crate::MartinError;
-    use crate::config::file::CachePolicy;
+    use crate::config::file::{CachePolicy, ConfigFileError};
     use crate::config::test_helpers::render_finalize_failure;
     use crate::logging::LogFormat;
 
@@ -282,8 +285,9 @@ mod tests {
         // For errors that don't carry source location info, JSON mode still emits a JSON
         // document so downstream tools can keep parsing rather than choking on a free-form
         // log line.
-        let envelope = MartinError::BasePathError("not-a-path".to_owned())
-            .render_diagnostic_with(LogFormat::Json);
+        let envelope =
+            crate::StartupError::from(ConfigFileError::InvalidBasePath("not-a-path".to_owned()))
+                .render_diagnostic_with(LogFormat::Json);
         let parsed: serde_json::Value =
             serde_json::from_str(&envelope).unwrap_or_else(|e| panic!("not JSON: {e}\n{envelope}"));
         let msg = parsed.get("message").and_then(|m| m.as_str()).unwrap_or("");

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -20,7 +20,7 @@ use tracing::{info, instrument, warn};
 use super::{Config, ServerState, init_aws_lc_tls, parse_base_path};
 #[cfg(feature = "_tiles")]
 use super::{ResolutionResult, TileSourceWarning};
-use crate::MartinResult;
+use crate::StartupResult;
 #[cfg(any(
     feature = "postgres",
     feature = "pmtiles",
@@ -62,7 +62,7 @@ use crate::tile_source_manager::TileSourceManager;
 
 impl Config {
     /// Apply defaults to the config, and validate if there is a connection string
-    pub async fn finalize(&mut self) -> MartinResult<()> {
+    pub async fn finalize(&mut self) -> StartupResult<()> {
         if let Some(path) = &self.srv.route_prefix {
             let normalized = parse_base_path(path)?;
             // For route_prefix, an empty normalized path (from "/") means no prefix
@@ -173,7 +173,7 @@ impl Config {
     pub async fn resolve(
         &mut self,
         #[cfg(feature = "_tiles")] idr: &IdResolver,
-    ) -> MartinResult<ServerState> {
+    ) -> StartupResult<ServerState> {
         init_aws_lc_tls();
 
         #[cfg(any(feature = "_tiles", feature = "sprites", feature = "fonts"))]
@@ -362,7 +362,7 @@ impl Config {
         &mut self,
         idr: &IdResolver,
         #[cfg(feature = "pmtiles")] pmtiles_cache: PmtCache,
-    ) -> MartinResult<(Vec<Vec<BoxedSource>>, Vec<TileSourceWarning>)> {
+    ) -> StartupResult<(Vec<Vec<BoxedSource>>, Vec<TileSourceWarning>)> {
         #[cfg_attr(
             not(any(
                 feature = "postgres",

--- a/martin/src/config/file/tiles/cog.rs
+++ b/martin/src/config/file/tiles/cog.rs
@@ -6,10 +6,9 @@ use martin_core::tiles::cog::CogSource;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::MartinResult;
 use crate::config::file::{
-    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, TileSourceConfiguration,
-    UnrecognizedValues,
+    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, SourceBuildResult,
+    TileSourceConfiguration, UnrecognizedValues,
 };
 
 #[derive(
@@ -39,7 +38,7 @@ impl TileSourceConfiguration for CogConfig {
         id: String,
         path: PathBuf,
         cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         let cog = CogSource::new(id, path, cache.zoom())?;
         Ok(Box::new(cog))
     }
@@ -49,7 +48,7 @@ impl TileSourceConfiguration for CogConfig {
         _id: String,
         _url: Url,
         _cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         unreachable!()
     }
 }

--- a/martin/src/config/file/tiles/discovery/discovery_trait.rs
+++ b/martin/src/config/file/tiles/discovery/discovery_trait.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeMap;
 
 use martin_core::tiles::BoxedSource;
 
-use crate::MartinResult;
-use crate::config::file::{ProcessConfig, TileSourceWarning};
+use crate::config::file::{ProcessConfig, SourceBuildResult, TileSourceWarning};
 
 /// Per-Source change-detection value. `Opaque` sources only diff on presence, never update.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -56,14 +55,14 @@ pub trait Discovery: Send + Sync + 'static {
     type Args: Clone + Send + Sync + 'static;
 
     /// Cheap snapshot of id -> (version, source arguments); an `Err` makes the driver retain its baseline.
-    fn discover(&self) -> impl Future<Output = MartinResult<Discovered<Self::Args>>> + Send;
+    fn discover(&self) -> impl Future<Output = SourceBuildResult<Discovered<Self::Args>>> + Send;
 
     /// Builds one source; an `Err` rides into that source's `NewSource`.
     fn build(
         &self,
         id: &str,
         args: &Self::Args,
-    ) -> impl Future<Output = MartinResult<BuiltSource>> + Send;
+    ) -> impl Future<Output = SourceBuildResult<BuiltSource>> + Send;
 
     /// `ProcessConfig` stamped onto every source this kind emits.
     fn process(&self) -> ProcessConfig;

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -13,12 +13,13 @@ use tokio::fs::{self, DirEntry};
 use crate::config::file::FileConfigSrc;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
-use crate::config::file::{CachePolicy, FileConfigEnum, ProcessConfig};
+use crate::config::file::{
+    CachePolicy, FileConfigEnum, ProcessConfig, SourceBuildError, SourceBuildResult,
+};
 use crate::config::primitives::{IdResolver, OptOneMany};
-use crate::{MartinError, MartinResult};
 
 /// The future an [`FsSourceBuilder`] returns: the freshly-built source, or an init error.
-type BuildFuture = BoxFuture<'static, MartinResult<BoxedSource>>;
+type BuildFuture = BoxFuture<'static, SourceBuildResult<BoxedSource>>;
 
 /// Opens one discovered file as a source.
 ///
@@ -155,7 +156,7 @@ fn per_source_process(kind_level: &ProcessConfig, src: &FileConfigSrc) -> Option
 impl Discovery for FsDiscovery {
     type Args = (PathBuf, CachePolicy);
 
-    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
+    async fn discover(&self) -> SourceBuildResult<Discovered<Self::Args>> {
         let discovered = discover_sources_by_ext(
             &self.directories,
             self.extensions,
@@ -174,7 +175,7 @@ impl Discovery for FsDiscovery {
         ))
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
+    async fn build(&self, id: &str, args: &Self::Args) -> SourceBuildResult<BuiltSource> {
         let source = (self.build)(id.to_owned(), args.0.clone(), args.1).await?;
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
         let process = self
@@ -251,13 +252,13 @@ async fn discover_sources_by_ext(
     extensions: &[&str],
     configured: &BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: &IdResolver,
-) -> MartinResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
+) -> SourceBuildResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
     let mut out = BTreeMap::new();
     for directory in directories {
         let mut entries = fs::read_dir(directory)
             .await
-            .map_err(MartinError::IoError)?;
-        while let Some(entry) = entries.next_entry().await.map_err(MartinError::IoError)? {
+            .map_err(SourceBuildError::Io)?;
+        while let Some(entry) = entries.next_entry().await.map_err(SourceBuildError::Io)? {
             let Some(e) = resolve_dir_entry(&entry) else {
                 continue;
             };

--- a/martin/src/config/file/tiles/discovery/object_store.rs
+++ b/martin/src/config/file/tiles/discovery/object_store.rs
@@ -8,13 +8,12 @@ use futures::stream::TryStreamExt as _;
 use object_store::ObjectStore as _;
 use url::Url;
 
-use crate::MartinResult;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{
-    CachePolicy, ConfigFileError, FileConfigEnum, TileSourceConfiguration as _,
+    CachePolicy, ConfigFileError, FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _,
 };
 use crate::config::primitives::{IdResolver, OptOneMany};
 
@@ -94,7 +93,7 @@ impl ObjectStoreDiscovery {
 impl Discovery for ObjectStoreDiscovery {
     type Args = Url;
 
-    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
+    async fn discover(&self) -> SourceBuildResult<Discovered<Self::Args>> {
         // Per-prefix failures are logged and skipped so a transient outage doesn't flap the catalog.
         let mut out: BTreeMap<String, (Version, Url)> = BTreeMap::new();
         for prefix in &self.remote_prefixes {
@@ -114,7 +113,7 @@ impl Discovery for ObjectStoreDiscovery {
         Ok(Discovered::new(out))
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
+    async fn build(&self, id: &str, args: &Self::Args) -> SourceBuildResult<BuiltSource> {
         self.config
             .new_sources_url(id.to_owned(), args.clone(), CachePolicy::default())
             .await
@@ -144,7 +143,7 @@ async fn list_remote_prefix(
     prefix: &Url,
     config: &PmtConfig,
     id_resolver: &IdResolver,
-) -> MartinResult<Vec<(String, Url, Version)>> {
+) -> SourceBuildResult<Vec<(String, Url, Version)>> {
     let (store, base) = config
         .parse_url_opts(prefix)
         .map_err(|e| ConfigFileError::ObjectStoreUrlParsing(e, prefix.to_string()))?;

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -120,7 +120,9 @@ mod tests {
 
     use super::*;
     use crate::config::file::CachePolicy;
-    use crate::config::file::discovery::{Discovery as _, PostgresDiscovery, Version};
+    #[cfg(feature = "mlt")]
+    use crate::config::file::discovery::Discovery as _;
+    use crate::config::file::discovery::{PostgresDiscovery, Version};
     use crate::config::file::postgres::{PostgresConfig, SourceSpec};
     use crate::config::file::process::ProcessConfig;
     use crate::config::primitives::IdResolver;

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -6,9 +6,8 @@ use tokio::sync::OnceCell;
 
 use crate::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig, SourceSpec};
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
-use crate::config::file::{CachePolicy, ProcessConfig};
+use crate::config::file::{CachePolicy, ProcessConfig, SourceBuildError, SourceBuildResult};
 use crate::config::primitives::IdResolver;
-use crate::{MartinError, MartinResult};
 
 /// A [`Discovery`] over one `PostgreSQL` connection.
 ///
@@ -50,7 +49,7 @@ impl PostgresDiscovery {
 
     /// The builder, created on first use. A bad connection string surfaces here as an `Err`,
     /// which the driver treats like any other discovery failure (retain the baseline, retry).
-    async fn builder(&self) -> MartinResult<&PostgresAutoDiscoveryBuilder> {
+    async fn builder(&self) -> SourceBuildResult<&PostgresAutoDiscoveryBuilder> {
         self.builder
             .get_or_try_init(|| async {
                 PostgresAutoDiscoveryBuilder::new(
@@ -59,7 +58,7 @@ impl PostgresDiscovery {
                     self.default_cache,
                 )
                 .await
-                .map_err(MartinError::from)
+                .map_err(SourceBuildError::from)
             })
             .await
     }
@@ -68,7 +67,7 @@ impl PostgresDiscovery {
 impl Discovery for PostgresDiscovery {
     type Args = SourceSpec;
 
-    async fn discover(&self) -> MartinResult<Discovered<Self::Args>> {
+    async fn discover(&self) -> SourceBuildResult<Discovered<Self::Args>> {
         let (specs, warnings) = self.builder().await?.discover().await?;
         Ok(Discovered {
             sources: specs
@@ -79,7 +78,7 @@ impl Discovery for PostgresDiscovery {
         })
     }
 
-    async fn build(&self, id: &str, args: &Self::Args) -> MartinResult<BuiltSource> {
+    async fn build(&self, id: &str, args: &Self::Args) -> SourceBuildResult<BuiltSource> {
         let (source, spec) = self.builder().await?.instantiate(id, args.clone()).await?;
         Ok(BuiltSource {
             source,
@@ -119,6 +118,7 @@ fn per_source_process(connection: &ProcessConfig, _spec: &SourceSpec) -> Process
 mod tests {
     use std::collections::BTreeMap;
 
+    use super::per_source_process;
     use crate::config::file::CachePolicy;
     use crate::config::file::discovery::{Discovery as _, PostgresDiscovery, Version};
     use crate::config::file::postgres::{PostgresConfig, SourceSpec};

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -118,7 +118,7 @@ fn per_source_process(connection: &ProcessConfig, _spec: &SourceSpec) -> Process
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::per_source_process;
+    use super::*;
     use crate::config::file::CachePolicy;
     use crate::config::file::discovery::{Discovery as _, PostgresDiscovery, Version};
     use crate::config::file::postgres::{PostgresConfig, SourceSpec};

--- a/martin/src/config/file/tiles/driver/reconcile.rs
+++ b/martin/src/config/file/tiles/driver/reconcile.rs
@@ -7,8 +7,8 @@ use tokio::task::JoinHandle;
 
 use crate::config::file::tiles::discovery::{BuiltSource, Discovery, Version};
 use crate::config::file::tiles::driver::{Sink, Trigger};
+use crate::config::file::{SourceBuildError, SourceBuildResult};
 use crate::reload::ReloadAdvisory;
-use crate::{MartinError, MartinResult};
 
 /// What the catalog already holds for a driver's sources when it starts.
 ///
@@ -103,10 +103,10 @@ impl<D: Discovery, S: Sink> ReloadDriver<D, S> {
         let advisory = ReloadAdvisory::from_maps(
             &prev_versions,
             &next_versions,
-            async move |id: String| -> MartinResult<BuiltSource> {
+            async move |id: String| -> SourceBuildResult<BuiltSource> {
                 let args = args_by_id
                     .get(&id)
-                    .ok_or_else(|| MartinError::SourceNotFound(id.clone()))?;
+                    .ok_or_else(|| SourceBuildError::SourceNotFound(id.clone()))?;
                 discovery.build(&id, args).await
             },
             process,
@@ -218,11 +218,11 @@ mod tests {
 
     /// Replays a scripted sequence of `discover()` results.
     struct FakeDiscovery {
-        snapshots: Mutex<VecDeque<MartinResult<Snapshot>>>,
+        snapshots: Mutex<VecDeque<SourceBuildResult<Snapshot>>>,
     }
 
     impl FakeDiscovery {
-        fn new(snapshots: Vec<MartinResult<Snapshot>>) -> Self {
+        fn new(snapshots: Vec<SourceBuildResult<Snapshot>>) -> Self {
             Self {
                 snapshots: Mutex::new(snapshots.into()),
             }
@@ -232,7 +232,7 @@ mod tests {
     impl Discovery for FakeDiscovery {
         type Args = ();
 
-        fn discover(&self) -> impl Future<Output = MartinResult<Discovered<()>>> + Send {
+        fn discover(&self) -> impl Future<Output = SourceBuildResult<Discovered<()>>> + Send {
             let snap = self
                 .snapshots
                 .lock()
@@ -246,7 +246,7 @@ mod tests {
             &self,
             id: &str,
             _args: &(),
-        ) -> impl Future<Output = MartinResult<BuiltSource>> + Send {
+        ) -> impl Future<Output = SourceBuildResult<BuiltSource>> + Send {
             let source: BoxedSource = Box::new(TestSource::new(id));
             std::future::ready(Ok(source.into()))
         }
@@ -285,7 +285,7 @@ mod tests {
     #[derive(Clone)]
     struct SpySink {
         applied: Arc<Mutex<Vec<AdvisorySnapshot>>>,
-        results: Arc<Mutex<VecDeque<MartinResult<()>>>>,
+        results: Arc<Mutex<VecDeque<SourceBuildResult<()>>>>,
     }
 
     impl SpySink {
@@ -296,7 +296,7 @@ mod tests {
             }
         }
 
-        fn with_results(results: Vec<MartinResult<()>>) -> Self {
+        fn with_results(results: Vec<SourceBuildResult<()>>) -> Self {
             let s = Self::new();
             *s.results.lock().expect("SpySink results mutex poisoned") = results.into();
             s
@@ -311,7 +311,7 @@ mod tests {
         fn apply_changes(
             &self,
             advisory: ReloadAdvisory,
-        ) -> impl Future<Output = MartinResult<()>> + Send {
+        ) -> impl Future<Output = SourceBuildResult<()>> + Send {
             self.applied
                 .lock()
                 .expect("SpySink applied mutex poisoned")
@@ -425,7 +425,7 @@ mod tests {
     async fn failed_seed_then_success_does_not_flood() {
         // Seed fails (baseline stays None); the first good tick establishes it without applying.
         let discovery = FakeDiscovery::new(vec![
-            Err(MartinError::SourceNotFound("seed boom".into())),
+            Err(SourceBuildError::SourceNotFound("seed boom".into())),
             Ok(snapshot(&[
                 ("a", Version::Tracked(1)),
                 ("b", Version::Tracked(1)),
@@ -450,7 +450,7 @@ mod tests {
         // The failed middle tick keeps the baseline, so only `b` diffs on the last tick.
         let discovery = FakeDiscovery::new(vec![
             Ok(snapshot(&[("a", Version::Tracked(1))])),
-            Err(MartinError::SourceNotFound("tick boom".into())),
+            Err(SourceBuildError::SourceNotFound("tick boom".into())),
             Ok(snapshot(&[
                 ("a", Version::Tracked(1)),
                 ("b", Version::Tracked(1)),
@@ -483,7 +483,7 @@ mod tests {
             Ok(snapshot(&[("a", Version::Tracked(1))])),
         ]);
         let sink = SpySink::with_results(vec![
-            Err(MartinError::SourceNotFound("apply boom".into())),
+            Err(SourceBuildError::SourceNotFound("apply boom".into())),
             Ok(()),
         ]);
         let recorded = sink.recorded();

--- a/martin/src/config/file/tiles/driver/sink.rs
+++ b/martin/src/config/file/tiles/driver/sink.rs
@@ -1,4 +1,4 @@
-use crate::MartinResult;
+use crate::config::file::SourceBuildResult;
 use crate::reload::ReloadAdvisory;
 
 /// Where a reload driver applies advisories.
@@ -10,5 +10,5 @@ pub trait Sink: Send + 'static {
     fn apply_changes(
         &self,
         advisory: ReloadAdvisory,
-    ) -> impl Future<Output = MartinResult<()>> + Send;
+    ) -> impl Future<Output = SourceBuildResult<()>> + Send;
 }

--- a/martin/src/config/file/tiles/driver/trigger.rs
+++ b/martin/src/config/file/tiles/driver/trigger.rs
@@ -6,8 +6,6 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, Watcher as _};
 use tokio::sync::mpsc;
 use tokio::time::{Instant, MissedTickBehavior};
 
-use crate::{MartinError, MartinResult};
-
 /// Decides when a [`ReloadDriver`](super::ReloadDriver) reconciles. `None` ends the loop.
 pub trait Trigger: Send + 'static {
     fn next(&mut self) -> impl Future<Output = Option<()>> + Send;
@@ -21,7 +19,7 @@ pub struct NotifyTrigger {
 }
 
 impl NotifyTrigger {
-    pub fn new(directories: &[PathBuf]) -> MartinResult<Self> {
+    pub fn new(directories: &[PathBuf]) -> notify::Result<Self> {
         let (tx, rx) = mpsc::channel::<Event>(256);
 
         let mut watcher = RecommendedWatcher::new(
@@ -33,13 +31,10 @@ impl NotifyTrigger {
                 }
             },
             Config::default(),
-        )
-        .map_err(|e| MartinError::DirectoryWatchError(e.kind))?;
+        )?;
         for dir in directories {
             // FIXME: find a naming scheme for paths that makes sense under recursive and enable it
-            watcher
-                .watch(dir, notify::RecursiveMode::NonRecursive)
-                .map_err(|e| MartinError::DirectoryWatchError(e.kind))?;
+            watcher.watch(dir, notify::RecursiveMode::NonRecursive)?;
         }
 
         Ok(Self {

--- a/martin/src/config/file/tiles/error.rs
+++ b/martin/src/config/file/tiles/error.rs
@@ -1,0 +1,69 @@
+//! Failures from constructing a tile source.
+//!
+//! The error of the *build* seam - [`Discovery`](super::discovery::Discovery) and the
+//! per-backend resolvers. Startup lifts it into [`StartupError`](crate::StartupError) and
+//! renders it; hot reload logs it and retains the previous source set. Runtime tile *fetch*
+//! is a different seam - see [`MartinCoreError`](martin_core::tiles::MartinCoreError).
+
+use std::io;
+use std::path::PathBuf;
+
+#[cfg(feature = "unstable-cog")]
+use martin_core::tiles::cog::CogError;
+#[cfg(feature = "geojson")]
+use martin_core::tiles::geojson::GeoJsonError;
+#[cfg(feature = "mbtiles")]
+use martin_core::tiles::mbtiles::MbtilesError;
+#[cfg(feature = "passthrough")]
+use martin_core::tiles::passthrough::PassthroughError;
+#[cfg(feature = "pmtiles")]
+use martin_core::tiles::pmtiles::PmtilesError;
+#[cfg(feature = "postgres")]
+use martin_core::tiles::postgres::PostgresError;
+
+use crate::config::file::ConfigFileError;
+
+/// A convenience [`Result`] for the tile source build seam.
+pub type SourceBuildResult<T> = Result<T, SourceBuildError>;
+
+/// Why a tile source could not be constructed.
+#[derive(thiserror::Error, Debug)]
+pub enum SourceBuildError {
+    #[cfg(feature = "postgres")]
+    #[error(transparent)]
+    Postgres(#[from] PostgresError),
+
+    #[cfg(feature = "pmtiles")]
+    #[error(transparent)]
+    Pmtiles(#[from] PmtilesError),
+
+    #[cfg(feature = "mbtiles")]
+    #[error(transparent)]
+    Mbtiles(#[from] MbtilesError),
+
+    #[cfg(feature = "passthrough")]
+    #[error(transparent)]
+    Passthrough(#[from] PassthroughError),
+
+    #[cfg(feature = "unstable-cog")]
+    #[error(transparent)]
+    Cog(#[from] CogError),
+
+    #[cfg(feature = "geojson")]
+    #[error(transparent)]
+    GeoJson(#[from] GeoJsonError),
+
+    /// The source's configuration was rejected while building it.
+    #[error(transparent)]
+    Config(#[from] ConfigFileError),
+
+    #[error("IO error while building tile sources: {0}")]
+    Io(#[from] io::Error),
+
+    /// A reload advisory named a source that discovery no longer reports.
+    #[error("Source '{0}' not found in discovered sources")]
+    SourceNotFound(String),
+
+    #[error("Source path is not a file: {0}")]
+    InvalidFilePath(PathBuf),
+}

--- a/martin/src/config/file/tiles/geojson.rs
+++ b/martin/src/config/file/tiles/geojson.rs
@@ -7,10 +7,9 @@ use martin_core::tiles::geojson::source::GeoJsonSource;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::MartinResult;
 use crate::config::file::{
-    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, TileSourceConfiguration,
-    UnrecognizedValues,
+    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, SourceBuildResult,
+    TileSourceConfiguration, UnrecognizedValues,
 };
 
 /// The MVT-spec tile extent `MapLibre` assumes, used when none is configured.
@@ -83,7 +82,7 @@ impl TileSourceConfiguration for GeoJsonConfig {
         id: String,
         path: PathBuf,
         cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         let geojson_source =
             GeoJsonSource::new(id, path, cache.zoom(), self.extent, self.buffer).await?;
         Ok(Box::new(geojson_source))
@@ -98,7 +97,7 @@ impl TileSourceConfiguration for GeoJsonConfig {
         _id: String,
         _url: Url,
         _cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         unreachable!()
     }
 }

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -6,10 +6,9 @@ use martin_core::tiles::mbtiles::MbtSource;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::MartinResult;
 use crate::config::file::{
-    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, TileSourceConfiguration,
-    UnrecognizedValues,
+    CachePolicy, CollectUnrecognizedKeys, ConfigurationLivecycleHooks, SourceBuildResult,
+    TileSourceConfiguration, UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -53,7 +52,7 @@ impl TileSourceConfiguration for MbtConfig {
         id: String,
         path: PathBuf,
         cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         Ok(Box::new(MbtSource::new(id, path, cache.zoom()).await?))
     }
 
@@ -66,7 +65,7 @@ impl TileSourceConfiguration for MbtConfig {
         _id: String,
         _url: Url,
         _cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         unreachable!()
     }
 }

--- a/martin/src/config/file/tiles/mod.rs
+++ b/martin/src/config/file/tiles/mod.rs
@@ -1,3 +1,6 @@
+mod error;
+pub use error::{SourceBuildError, SourceBuildResult};
+
 #[cfg(feature = "unstable-cog")]
 pub mod cog;
 #[cfg(feature = "unstable-duckdb")]

--- a/martin/src/config/file/tiles/passthrough.rs
+++ b/martin/src/config/file/tiles/passthrough.rs
@@ -11,10 +11,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use tilejson::Bounds;
 use tracing::info;
 
-use crate::MartinResult;
 use crate::config::file::{
     CachePolicy, CollectUnrecognizedKeys, ConfigFileError, ConfigurationLivecycleHooks,
-    ResolutionResult, TileSourceWarning, UnrecognizedValues,
+    ResolutionResult, SourceBuildResult, TileSourceWarning, UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -288,7 +287,11 @@ impl Default for PassthroughSourceConfig {
 impl PassthroughSourceConfig {
     /// Build the upstream into a live [`BoxedSource`], fetching the upstream `TileJSON` once for a
     /// document upstream.
-    async fn build(&self, id: String, default_cache: CachePolicy) -> MartinResult<BoxedSource> {
+    async fn build(
+        &self,
+        id: String,
+        default_cache: CachePolicy,
+    ) -> SourceBuildResult<BoxedSource> {
         let format = match self.format.as_deref() {
             Some(value) => Some(Format::parse(value).ok_or_else(|| {
                 ConfigFileError::InvalidPassthroughFormat {

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -23,10 +23,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{trace, warn};
 use url::Url;
 
-use crate::MartinResult;
 use crate::config::file::{
     CachePolicy, CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
-    ConfigurationLivecycleHooks, TileSourceConfiguration, UnrecognizedValues,
+    ConfigurationLivecycleHooks, SourceBuildResult, TileSourceConfiguration, UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -482,7 +481,7 @@ impl TileSourceConfiguration for PmtConfig {
         id: String,
         path: PathBuf,
         cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         // canonicalize to resolve symlinks
         let path = path
             .canonicalize()
@@ -506,7 +505,7 @@ impl TileSourceConfiguration for PmtConfig {
         id: String,
         url: Url,
         cache: CachePolicy,
-    ) -> MartinResult<BoxedSource> {
+    ) -> SourceBuildResult<BoxedSource> {
         let (store, path) = self
             .parse_url_opts(&url)
             .map_err(|e| ConfigFileError::ObjectStoreUrlParsing(e, id.clone()))?;

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -1,13 +1,13 @@
 use martin_core::tiles::BoxedSource;
 use martin_core::tiles::cog::CogSource;
 
+use crate::TileSourceManager;
 use crate::config::file::FileConfigEnum;
 use crate::config::file::cog::CogConfig;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
 use crate::config::primitives::IdResolver;
-use crate::{MartinResult, TileSourceManager};
 
 /// Watches configured directories for `.tif`/`.tiff` changes.
 pub struct CogReloader {
@@ -44,7 +44,7 @@ impl CogReloader {
     }
 
     /// Spawns the reload driver. Does nothing if no directories are configured.
-    pub fn start(self) -> MartinResult<()> {
+    pub fn start(self) -> notify::Result<()> {
         let directories = self.discovery.directories().to_vec();
         if directories.is_empty() {
             return Ok(());

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -1,10 +1,10 @@
+use crate::TileSourceManager;
 use crate::config::file::geojson::GeoJsonConfig;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
 use crate::config::file::{FileConfigEnum, TileSourceConfiguration as _};
 use crate::config::primitives::IdResolver;
-use crate::{MartinResult, TileSourceManager};
 
 /// Watches configured directories for `.json`/`.geojson` changes.
 pub struct GeoJsonReloader {
@@ -43,7 +43,7 @@ impl GeoJsonReloader {
     }
 
     /// Spawns the reload driver. Does nothing if no directories are configured.
-    pub fn start(self) -> MartinResult<()> {
+    pub fn start(self) -> notify::Result<()> {
         let directories = self.discovery.directories().to_vec();
         if directories.is_empty() {
             return Ok(());

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -1,6 +1,7 @@
 use martin_core::tiles::BoxedSource;
 use martin_core::tiles::mbtiles::MbtSource;
 
+use crate::TileSourceManager;
 use crate::config::file::FileConfigEnum;
 use crate::config::file::mbtiles::MbtConfig;
 use crate::config::file::process::ProcessConfig;
@@ -9,7 +10,6 @@ use crate::config::file::resolve_process_config;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
 use crate::config::primitives::IdResolver;
-use crate::{MartinResult, TileSourceManager};
 
 /// Watches configured directories for `.mbtiles` changes.
 pub struct MbtilesReloader {
@@ -63,7 +63,7 @@ impl MbtilesReloader {
     }
 
     /// Spawns the reload driver. Does nothing if no directories are configured.
-    pub fn start(self) -> MartinResult<()> {
+    pub fn start(self) -> notify::Result<()> {
         let directories = self.discovery.directories().to_vec();
         if directories.is_empty() {
             return Ok(());

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -1,3 +1,4 @@
+use crate::TileSourceManager;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
@@ -6,7 +7,6 @@ use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder, Object
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, PollTrigger, ReloadDriver};
 use crate::config::file::{FileConfigEnum, TileSourceConfiguration as _};
 use crate::config::primitives::IdResolver;
-use crate::{MartinResult, TileSourceManager};
 
 const PMTILES_EXT: &str = "pmtiles";
 
@@ -75,7 +75,7 @@ impl PmtilesReloader {
         }
     }
 
-    pub fn start(self) -> MartinResult<()> {
+    pub fn start(self) -> notify::Result<()> {
         let Self {
             tile_source_manager,
             local,

--- a/martin/src/config/test_helpers.rs
+++ b/martin/src/config/test_helpers.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use miette::{GraphicalReportHandler, GraphicalTheme};
 use serde::de::DeserializeOwned;
 
-use crate::MartinError;
+use crate::StartupError;
 use crate::config::file::parse_config;
 use crate::logging::LogFormat;
 
@@ -76,7 +76,7 @@ pub(crate) async fn render_finalize_failure(yaml: &str) -> String {
     err.render_diagnostic()
 }
 
-/// Same as [`render_failure`] but routes through `MartinError::render_diagnostic_with` in
+/// Same as [`render_failure`] but routes through `StartupError::render_diagnostic_with` in
 /// JSON mode, mirroring what the binary emits when `RUST_LOG_FORMAT=json` is set.
 ///
 /// JSON output has no terminal-width dependency, so no fixed-width override is needed.
@@ -85,5 +85,5 @@ pub(crate) fn render_failure_json(yaml: &str) -> String {
     let err = parse_config(yaml, &env, Path::new("config.yaml"))
         .err()
         .unwrap_or_else(|| panic!("expected configuration to fail to parse:\n{yaml}"));
-    MartinError::ConfigFileError(err).render_diagnostic_with(LogFormat::Json)
+    StartupError::Config(err).render_diagnostic_with(LogFormat::Json)
 }

--- a/martin/src/error.rs
+++ b/martin/src/error.rs
@@ -1,115 +1,43 @@
-use std::fmt::Write as _;
+//! The error `main` sees.
+//!
+//! [`StartupError`] is the union of the *phases* that can abort a launch, not of everything
+//! that can go wrong in the crate. Each variant wraps one seam's error, and those seams have
+//! consumers that never need this type - notably [`SourceBuildError`], which hot reload logs
+//! and discards. Runtime tile serving does not appear here at all; it ends at an HTTP
+//! response via [`MartinCoreError`](martin_core::tiles::MartinCoreError).
+
 use std::io;
 
-#[cfg(feature = "unstable-cog")]
-use martin_core::tiles::cog::CogError;
-#[cfg(feature = "geojson")]
-use martin_core::tiles::geojson::GeoJsonError;
-#[cfg(feature = "mbtiles")]
-use martin_core::tiles::mbtiles::MbtilesError;
-#[cfg(feature = "passthrough")]
-use martin_core::tiles::passthrough::PassthroughError;
-#[cfg(feature = "pmtiles")]
-use martin_core::tiles::pmtiles::PmtilesError;
-#[cfg(feature = "postgres")]
-use martin_core::tiles::postgres::PostgresError;
-
+use crate::config::args::ArgsError;
 use crate::config::file::ConfigFileError;
+#[cfg(feature = "_tiles")]
+use crate::config::file::SourceBuildError;
+use crate::srv::ServerStartError;
 
-/// A convenience [`Result`] for Martin crate.
-pub type MartinResult<T> = Result<T, MartinError>;
+/// A convenience [`Result`] for fallible startup steps.
+pub type StartupResult<T> = Result<T, StartupError>;
 
-fn elide_vec(vec: &[String], max_items: usize, max_len: usize) -> String {
-    let mut s = String::new();
-    for (i, v) in vec.iter().enumerate() {
-        if i > max_items {
-            let _ = write!(s, " and {} more", vec.len() - i);
-            break;
-        }
-        if i > 0 {
-            s.push(' ');
-        }
-        if v.len() > max_len {
-            let mut bytes = 0usize;
-            s.extend(v.chars().take_while(|c| {
-                bytes += c.len_utf8();
-                bytes <= max_len
-            }));
-            s.push('…');
-        } else {
-            s.push_str(v);
-        }
-    }
-    s
-}
-
+/// Why martin could not finish starting up.
 #[derive(thiserror::Error, Debug)]
-pub enum MartinError {
-    #[error("The --config and the connection parameters cannot be used together. Please remove unsupported parameters '{}'", elide_vec(.0, 3, 15))]
-    ConfigAndConnectionsError(Vec<String>),
-
-    #[error("Unable to bind to {1}: {0}")]
-    BindingError(#[source] io::Error, String),
-
-    #[error("Base path must be a valid URL path, and must begin with a '/' symbol, but is '{0}'")]
-    BasePathError(String),
-
-    #[error("Unrecognizable connection strings: {0:?}")]
-    UnrecognizableConnections(Vec<String>),
-
-    #[cfg(feature = "postgres")]
+pub enum StartupError {
     #[error(transparent)]
-    PostgresError(#[from] PostgresError),
-
-    #[cfg(feature = "pmtiles")]
-    #[error(transparent)]
-    PmtilesError(#[from] PmtilesError),
-
-    #[cfg(feature = "mbtiles")]
-    #[error(transparent)]
-    MbtilesError(#[from] MbtilesError),
-
-    #[cfg(feature = "passthrough")]
-    #[error(transparent)]
-    PassthroughError(#[from] PassthroughError),
-
-    #[cfg(feature = "unstable-cog")]
-    #[error(transparent)]
-    CogError(#[from] CogError),
-
-    #[cfg(feature = "geojson")]
-    #[error(transparent)]
-    GeoJsonError(#[from] GeoJsonError),
+    Args(#[from] ArgsError),
 
     #[error(transparent)]
-    ConfigFileError(#[from] ConfigFileError),
+    Config(#[from] ConfigFileError),
 
-    #[cfg(feature = "sprites")]
+    #[cfg(feature = "_tiles")]
     #[error(transparent)]
-    SpriteError(#[from] martin_core::sprites::SpriteError),
+    SourceBuild(#[from] SourceBuildError),
 
     #[error(transparent)]
-    IoError(#[from] io::Error),
+    Server(#[from] ServerStartError),
 
-    #[cfg(feature = "lambda")]
     #[error(transparent)]
-    LambdaError(#[from] lambda_web::LambdaError),
-
-    #[cfg(feature = "metrics")]
-    #[error("could not initialize metrics: {0}")]
-    MetricsIntialisationError(#[source] Box<dyn std::error::Error + Send + Sync>),
-
-    #[error("warnings issued during tile source resolution")]
-    TileResolutionWarningsIssued,
-
-    #[error("could not create a watcher for directories configured for tile source discovery")]
-    DirectoryWatchError(notify::ErrorKind),
-
-    #[error("Source '{0}' not found in discovered sources")]
-    SourceNotFound(String),
+    Io(#[from] io::Error),
 }
 
-impl MartinError {
+impl StartupError {
     /// Format the error for end-user display using miette's graphical reporter.
     ///
     /// See [`render_diagnostic_with`](Self::render_diagnostic_with) for an explanation of
@@ -138,8 +66,9 @@ impl MartinError {
     /// render against.
     #[must_use]
     pub fn render_diagnostic_with(&self, format: crate::logging::LogFormat) -> String {
-        if let Self::ConfigFileError(cfg_err) = self
-            && let Some(report) = cfg_err.to_miette_report()
+        if let Some(report) = self
+            .spanned_config_error()
+            .and_then(ConfigFileError::to_miette_report)
         {
             if format.is_json() {
                 let mut buf = String::new();
@@ -159,5 +88,18 @@ impl MartinError {
             return format!(r#"{{"message": {message}}}"#);
         }
         format!("{self}")
+    }
+
+    /// The config error carrying source spans, if this failure bottoms out in one.
+    ///
+    /// A config problem can reach `main` directly or via a source build that rejected the
+    /// config it was handed; both should render the same caret diagnostic.
+    fn spanned_config_error(&self) -> Option<&ConfigFileError> {
+        match self {
+            Self::Config(e) => Some(e),
+            #[cfg(feature = "_tiles")]
+            Self::SourceBuild(SourceBuildError::Config(e)) => Some(e),
+            _ => None,
+        }
     }
 }

--- a/martin/src/lib.rs
+++ b/martin/src/lib.rs
@@ -20,7 +20,7 @@ mod tile_source_manager;
 pub use tile_source_manager::TileSourceManager;
 
 mod error;
-pub use error::{MartinError, MartinResult};
+pub use error::{StartupError, StartupResult};
 
 #[cfg(all(test, feature = "_tiles"))]
 mod test_support;

--- a/martin/src/reload.rs
+++ b/martin/src/reload.rs
@@ -3,9 +3,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use futures::stream::{self, StreamExt as _};
 use martin_core::tiles::BoxedSource;
 
-use crate::MartinResult;
 use crate::config::file::discovery::BuiltSource;
-use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ProcessConfig};
+use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ProcessConfig, SourceBuildResult};
 
 /// A source to be added or updated in the [`TileSourceManager`](super::TileSourceManager).
 #[derive(Debug)]
@@ -13,7 +12,7 @@ pub struct NewSource {
     /// Resolved source ID.
     pub id: String,
     /// The tile source implementation, or an error if initialization failed.
-    pub source: MartinResult<BoxedSource>,
+    pub source: SourceBuildResult<BoxedSource>,
     /// Resolved process config for this source (per-source > source-type > global > default).
     pub process: ProcessConfig,
 }
@@ -21,7 +20,7 @@ pub struct NewSource {
 impl NewSource {
     /// `process` is the kind-level fallback; a per-source override carried by the
     /// [`BuiltSource`] wins over it.
-    fn new(id: String, built: MartinResult<BuiltSource>, process: ProcessConfig) -> Self {
+    fn new(id: String, built: SourceBuildResult<BuiltSource>, process: ProcessConfig) -> Self {
         match built {
             Ok(built) => Self {
                 id,
@@ -68,7 +67,7 @@ impl ReloadAdvisory {
         process: ProcessConfig,
     ) -> Self
     where
-        F: AsyncFn(String) -> MartinResult<BuiltSource>,
+        F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
     {
         let removals = previous_ids
             .difference(next_ids)
@@ -100,7 +99,7 @@ impl ReloadAdvisory {
         process: ProcessConfig,
     ) -> Self
     where
-        F: AsyncFn(String) -> MartinResult<BuiltSource>,
+        F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
     {
         let removals = previous_map
             .keys()
@@ -139,7 +138,7 @@ async fn build_all<F>(
     process: &ProcessConfig,
 ) -> Vec<NewSource>
 where
-    F: AsyncFn(String) -> MartinResult<BuiltSource>,
+    F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
 {
     stream::iter(ids)
         .map(|id| async move {
@@ -194,7 +193,7 @@ mod tests {
         }
     }
 
-    async fn make_source(id: String) -> MartinResult<BuiltSource> {
+    async fn make_source(id: String) -> SourceBuildResult<BuiltSource> {
         let source: BoxedSource = Box::new(TestSource {
             id,
             tj: tilejson! {

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -7,9 +7,9 @@ use actix_web::{HttpResponse, Responder, middleware, route};
 use martin_core::tiles::catalog::TileCatalog;
 use serde::{Deserialize, Serialize};
 
-use crate::MartinResult;
 #[cfg(any(feature = "sprites", feature = "fonts", feature = "styles"))]
 use crate::config::file::ServerState;
+use crate::srv::ServerStartError;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(
@@ -52,7 +52,7 @@ pub struct CatalogSettings {
 impl Catalog {
     pub fn new(
         #[cfg(any(feature = "sprites", feature = "fonts", feature = "styles"))] state: &ServerState,
-    ) -> MartinResult<Self> {
+    ) -> Result<Self, ServerStartError> {
         Ok(Self {
             #[cfg(feature = "_tiles")]
             tiles: HashMap::default(),

--- a/martin/src/srv/error.rs
+++ b/martin/src/srv/error.rs
@@ -1,0 +1,36 @@
+//! Failures from bringing the HTTP server up.
+//!
+//! Reachable only from [`new_server`](super::new_server), whose single caller is
+//! `bin/martin.rs`. Separate from [`StartupError`](crate::StartupError) so config
+//! resolution and source construction can neither produce nor match on a bind failure.
+
+use std::io;
+
+use crate::config::file::ConfigFileError;
+
+/// Why the HTTP server could not be started.
+#[derive(thiserror::Error, Debug)]
+pub enum ServerStartError {
+    #[error("Unable to bind to {1}: {0}")]
+    Binding(#[source] io::Error, String),
+
+    #[cfg(feature = "lambda")]
+    #[error(transparent)]
+    Lambda(#[from] lambda_web::LambdaError),
+
+    #[cfg(feature = "metrics")]
+    #[error("could not initialize metrics: {0}")]
+    MetricsInitialisation(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The sprite catalog could not be built while assembling the server's catalog.
+    #[cfg(feature = "sprites")]
+    #[error(transparent)]
+    SpriteCatalog(#[from] martin_core::sprites::SpriteError),
+
+    /// The CORS block in the config was rejected while configuring the server.
+    #[error(transparent)]
+    Cors(#[from] ConfigFileError),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -1,8 +1,6 @@
-use std::string::ToString as _;
 use std::sync::Arc;
 
 use actix_middleware_etag::Etag;
-use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use actix_web::http::header::LOCATION;
 use actix_web::middleware::Compress;
 use actix_web::web::{Data, Path};
@@ -11,7 +9,7 @@ use martin_core::fonts::{FontCacheKey, FontError, FontSources, OptFontCache, nor
 use serde::Deserialize;
 use tracing::{instrument, warn};
 
-use crate::srv::server::{DebouncedWarning, map_internal_error};
+use crate::srv::server::{DebouncedWarning, map_error};
 
 #[derive(Deserialize, Debug)]
 #[cfg_attr(feature = "unstable-schemas", derive(utoipa::IntoParams))]
@@ -98,13 +96,5 @@ pub async fn redirect_fonts(path: Path<FontRequest>) -> HttpResponse {
 }
 
 pub fn map_font_error(e: &FontError) -> actix_web::Error {
-    match e {
-        FontError::FontNotFound(_) => ErrorNotFound(e.to_string()),
-        FontError::TooManyFontIds { .. }
-        | FontError::InvalidFontRangeStartEnd { .. }
-        | FontError::InvalidFontRangeStart(_)
-        | FontError::InvalidFontRangeEnd(_)
-        | FontError::InvalidFontRange(_, _) => ErrorBadRequest(e.to_string()),
-        _ => map_internal_error(e),
-    }
+    map_error(e)
 }

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -14,6 +14,8 @@ pub use fonts::{__path_get_font, get_font};
 mod server;
 #[cfg(feature = "unstable-schemas")]
 pub use server::{__path_get_health, get_health};
+mod error;
+pub use error::ServerStartError;
 pub use server::{RESERVED_KEYWORDS, new_server, router};
 
 mod admin;

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -16,6 +16,7 @@ use crate::config::args::WebUiMode;
 #[cfg(feature = "_catalog")]
 use crate::config::file::ServerState;
 use crate::config::file::srv::{DEFAULT_KEEP_ALIVE, DEFAULT_LISTEN_ADDRESSES, SrvConfig};
+use crate::srv::ServerStartError;
 #[cfg(any(not(feature = "webui"), docsrs))]
 use crate::srv::admin::get_index_no_ui;
 use crate::srv::admin::{Catalog, get_catalog};
@@ -33,7 +34,6 @@ use crate::srv::styles_rendering;
 use crate::srv::styles_static;
 #[cfg(feature = "_tiles")]
 use crate::srv::tiles;
-use crate::{MartinError, MartinResult};
 
 /// List of keywords that cannot be used as source IDs. Some of these are reserved for future use.
 /// Reserved keywords must never end in a "dot number" (e.g. ".1").
@@ -43,10 +43,30 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     "reload", "sprite", "status",
 ];
 
+/// Maps any classified error onto an HTTP response.
+///
+/// The status comes from the error's own `ErrorKind`, so a failure mode is classified once
+/// where it is defined rather than at each handler that can surface it. Only failures the
+/// caller cannot act on are logged.
 #[cfg(any(feature = "_tiles", feature = "fonts", feature = "sprites"))]
-pub fn map_internal_error<T: std::fmt::Display>(e: T) -> actix_web::Error {
-    tracing::error!("{e}");
-    actix_web::error::ErrorInternalServerError(e.to_string())
+pub fn map_error<E: std::fmt::Display + martin_core::Classify + ?Sized>(e: &E) -> actix_web::Error {
+    use actix_web::error::{
+        ErrorBadRequest, ErrorInternalServerError, ErrorNotFound, ErrorServiceUnavailable,
+    };
+    use martin_core::ErrorKind::{Internal, InvalidInput, NotFound, Unavailable};
+
+    match e.kind() {
+        NotFound => ErrorNotFound(e.to_string()),
+        InvalidInput => ErrorBadRequest(e.to_string()),
+        Unavailable => {
+            tracing::error!("{e}");
+            ErrorServiceUnavailable(e.to_string())
+        }
+        Internal => {
+            tracing::error!("{e}");
+            ErrorInternalServerError(e.to_string())
+        }
+    }
 }
 
 /// Helper struct for debounced warning messages in redirect handlers.
@@ -177,7 +197,7 @@ fn register_services(
     cfg.service(get_index_no_ui);
 }
 
-type Server = Pin<Box<dyn Future<Output = MartinResult<()>>>>;
+type Server = Pin<Box<dyn Future<Output = Result<(), ServerStartError>>>>;
 
 fn cache_control_middleware(value: Option<HeaderValue>) -> middleware::Condition<DefaultHeaders> {
     let enabled = value.is_some();
@@ -190,7 +210,7 @@ fn cache_control_middleware(value: Option<HeaderValue>) -> middleware::Condition
 pub fn new_server(
     config: SrvConfig,
     #[cfg(feature = "_catalog")] state: ServerState,
-) -> MartinResult<(Server, String)> {
+) -> Result<(Server, String), ServerStartError> {
     let cache_control = config.cache_control_header();
     #[cfg(feature = "metrics")]
     let prometheus = {
@@ -214,7 +234,7 @@ pub fn new_server(
                     .add_labels,
             )
             .build()
-            .map_err(MartinError::MetricsIntialisationError)?
+            .map_err(ServerStartError::MetricsInitialisation)?
     };
     let catalog = Catalog::new(
         #[cfg(any(feature = "sprites", feature = "fonts", feature = "styles"))]
@@ -271,13 +291,13 @@ pub fn new_server(
 
     #[cfg(feature = "lambda")]
     if is_running_on_lambda() {
-        let server = run_actix_on_lambda(factory).map_err(MartinError::LambdaError);
+        let server = run_actix_on_lambda(factory).map_err(ServerStartError::Lambda);
         return Ok((Box::pin(server), "(aws lambda)".into()));
     }
 
     let server = HttpServer::new(factory)
         .bind(listen_addresses.clone())
-        .map_err(|e| MartinError::BindingError(e, listen_addresses.clone()))?;
+        .map_err(|e| ServerStartError::Binding(e, listen_addresses.clone()))?;
 
     let listen_addresses = server
         .addrs()

--- a/martin/src/srv/sprites.rs
+++ b/martin/src/srv/sprites.rs
@@ -1,7 +1,6 @@
 use std::string::ToString as _;
 
 use actix_middleware_etag::Etag;
-use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use actix_web::http::header::{ContentType, LOCATION};
 use actix_web::middleware::Compress;
 use actix_web::web::{Bytes, Data, Path};
@@ -12,7 +11,7 @@ use martin_core::sprites::{
 use serde::Deserialize;
 use tracing::{instrument, warn};
 
-use crate::srv::server::{DebouncedWarning, map_internal_error};
+use crate::srv::server::{DebouncedWarning, map_error};
 
 #[derive(thiserror::Error, Debug)]
 enum SpriteComputeError {
@@ -329,14 +328,15 @@ async fn get_index(
     Ok(Bytes::from(json))
 }
 
-fn map_sprite_compute_error(e: &SpriteComputeError) -> actix_web::Error {
-    match e {
-        SpriteComputeError::Sprite(err @ SpriteError::SpriteNotFound(_)) => {
-            ErrorNotFound(err.to_string())
+impl martin_core::Classify for SpriteComputeError {
+    fn kind(&self) -> martin_core::ErrorKind {
+        match self {
+            Self::Sprite(e) => e.kind(),
+            Self::EncodePng(_) | Self::Serialize(_) => martin_core::ErrorKind::Internal,
         }
-        SpriteComputeError::Sprite(err @ SpriteError::TooManySpriteIds { .. }) => {
-            ErrorBadRequest(err.to_string())
-        }
-        other => map_internal_error(other),
     }
+}
+
+fn map_sprite_compute_error(e: &SpriteComputeError) -> actix_web::Error {
+    map_error(e)
 }

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -23,7 +23,7 @@ use crate::config::file::ProcessConfig;
 use crate::config::file::driver::Sink as _;
 use crate::config::file::srv::SrvConfig;
 use crate::reload::{NewSource, ReloadAdvisory};
-use crate::srv::server::{DebouncedWarning, map_internal_error};
+use crate::srv::server::{DebouncedWarning, map_error};
 use crate::srv::tiles::process::apply_pre_cache_processors;
 use crate::tile_source_manager::TileSourceManager;
 
@@ -418,7 +418,7 @@ impl<'a> DynTileSource<'a> {
             Err(ref e) if matches!(e.as_ref(), MartinCoreError::SourceNeedsReload) => {
                 self.reload_source_and_retry_get_tile(s, pc, xyz).await
             }
-            result => result.map_err(|e| map_internal_error(e.as_ref())),
+            result => result.map_err(|e| map_error(e.as_ref())),
         }
     }
 
@@ -444,9 +444,9 @@ impl<'a> DynTileSource<'a> {
                 }
                 self.fetch_tile_content_with_cache(&fresh_src, pc, xyz)
                     .await
-                    .map_err(|e| map_internal_error(e.as_ref()))
+                    .map_err(|e| map_error(e.as_ref()))
             }
-            Err(e) => Err(map_internal_error(&e)),
+            Err(e) => Err(map_error(&e)),
         }
     }
 

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -4,9 +4,8 @@ use dashmap::DashMap;
 use martin_core::tiles::{BoxedSource, OptTileCache};
 use tracing::{info, warn};
 
-use crate::MartinResult;
 use crate::config::file::driver::Sink;
-use crate::config::file::{OnInvalid, ProcessConfig};
+use crate::config::file::{OnInvalid, ProcessConfig, SourceBuildResult};
 use crate::reload::ReloadAdvisory;
 use crate::source::TileSources;
 
@@ -81,7 +80,7 @@ impl Sink for TileSourceManager {
     /// 1. **Updates** - time-critical; invalidate cache then replace the source.
     /// 2. **Additions** - make new sources available.
     /// 3. **Removals** - garbage-collect stale sources and their cached tiles.
-    async fn apply_changes(&self, advisory: ReloadAdvisory) -> MartinResult<()> {
+    async fn apply_changes(&self, advisory: ReloadAdvisory) -> SourceBuildResult<()> {
         if advisory.is_empty() {
             return Ok(());
         }
@@ -311,9 +310,8 @@ mod tests {
 
         use tempfile::TempDir;
 
-        use crate::MartinError;
         use crate::config::file::discovery::BuiltSource;
-        use crate::config::file::{ConfigFileError, ProcessConfig};
+        use crate::config::file::{ConfigFileError, ProcessConfig, SourceBuildError};
 
         const BAD_PREFIX: &str = "bad_";
 
@@ -338,9 +336,9 @@ mod tests {
             clippy::unused_async,
             reason = "must satisfy AsyncFn for ReloadAdvisory::from_maps"
         )]
-        async fn build(id: String, dir: PathBuf) -> MartinResult<BuiltSource> {
+        async fn build(id: String, dir: PathBuf) -> SourceBuildResult<BuiltSource> {
             if id.starts_with(BAD_PREFIX) {
-                return Err(MartinError::from(ConfigFileError::InvalidFilePath(
+                return Err(SourceBuildError::from(ConfigFileError::InvalidFilePath(
                     dir.join(format!("{id}.tiles")),
                 )));
             }

--- a/martin/tests/binary_diagnostics.rs
+++ b/martin/tests/binary_diagnostics.rs
@@ -1,6 +1,6 @@
 //! End-to-end binary smoke tests for config-error diagnostics.
 //!
-//! Unit tests in `src/config/...` exercise `MartinError::render_diagnostic_with` in-process,
+//! Unit tests in `src/config/...` exercise `StartupError::render_diagnostic_with` in-process,
 //! but they don't catch wiring regressions in the binary entry point - for example, if
 //! `main()` stops calling `render_diagnostic_with` or if `RUST_LOG_FORMAT=json` no longer
 //! propagates from env to the renderer. These tests spawn the actual `martin` binary, feed


### PR DESCRIPTION
`MartinError` was a gigantic bob that scaled badly.
This PR splits it into better compartments.