### PR TITLE
feat(cache-control): per-source Cache-Control overrides

### DIFF
--- a/docs/content/run-with-reverse-proxy/index.md
+++ b/docs/content/run-with-reverse-proxy/index.md
@@ -20,7 +20,7 @@ Doing so has a few downsides:
     - [Varnish](https://varnish-cache.org/)
     - [Apache](https://httpd.apache.org/)
 
-  For client- and CDN-side caching, Martin can set a default `Cache-Control` response header itself via the `cache_control` option in the [configuration file](../config-file/index.md).
+  For client- and CDN-side caching, Martin can set the `Cache-Control` response header itself via the `cache_control` option in the [configuration file](../config-file/index.md), both as a server-wide default and per tile source.
 - You may need to host more than just tiles/resources on the domain name.
 - Martin has a fixed public API, but your site may require a different structure.
   For example, you may want to serve tiles from `/{sourceID}/tiles?z={z}&x={x}&y={y}` instead of `/{sourceID}/{z}/{x}/{y}`.

--- a/docs/content/sources-tiles/index.md
+++ b/docs/content/sources-tiles/index.md
@@ -38,3 +38,6 @@ The choice depends on your specific usecase and requirements.
 
 Most vector tile sources support optional [postprocessing](../postprocessing/index.md) (format conversion) via the `convert_to_mlt` and `convert_to_mvt` configuration keys.
 DuckDB / GeoParquet sources do not currently support postprocessing.
+
+Tile sources also accept a per-source `cache_control` configuration key that sets the `Cache-Control` response header for that source's tiles, overriding the top-level `cache_control` default.
+A composite tile request uses the per-source value only when every requested source is configured with the same one; otherwise the response falls back to the top-level default.

--- a/e2e-tests/tests/cache_control.rs
+++ b/e2e-tests/tests/cache_control.rs
@@ -1,6 +1,6 @@
-//! The `cache_control` server setting.
+//! The `cache_control` server setting and its per-source overrides.
 
-use martin_e2e_tests::{Martin, StartError};
+use martin_e2e_tests::{Martin, StartError, mbtiles_fixture};
 
 const CONFIG: &str = "
 cache_control: public, max-age=3600
@@ -84,6 +84,98 @@ pmtiles:
     martin.stop().await;
     martin.assert_startup_warnings();
     martin.assert_log_clean();
+}
+
+async fn martin_with_per_source_overrides() -> (tempfile::TempDir, Martin) {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let cities = mbtiles_fixture(dir.path(), "world_cities").await;
+    let cities = cities.to_str().expect("fixture path is valid utf-8");
+    let config = format!(
+        "
+cache_control: public, max-age=3600
+mbtiles:
+  sources:
+    plain: {cities}
+    pinned:
+      path: {cities}
+      cache_control: no-store
+    pinned_alike:
+      path: {cities}
+      cache_control: no-store
+    pinned_differently:
+      path: {cities}
+      cache_control: public, max-age=60
+"
+    );
+    let martin = Martin::builder()
+        .config(&config)
+        .start()
+        .await
+        .expect("failed to start martin");
+    (dir, martin)
+}
+
+#[tokio::test]
+async fn a_per_source_cache_control_overrides_the_server_default() {
+    let (_dir, mut martin) = martin_with_per_source_overrides().await;
+
+    let response = martin.get("/pinned/0/0/0").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.header("cache-control"), Some("no-store"));
+
+    let response = martin.get("/plain/0/0/0").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.header("cache-control"),
+        Some("public, max-age=3600")
+    );
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn a_composite_request_uses_the_override_only_when_all_sources_agree() {
+    let (_dir, mut martin) = martin_with_per_source_overrides().await;
+
+    let response = martin.get("/pinned,pinned_alike/0/0/0").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.header("cache-control"), Some("no-store"));
+
+    let response = martin.get("/pinned,pinned_differently/0/0/0").await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.header("cache-control"),
+        Some("public, max-age=3600")
+    );
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_invalid_per_source_cache_control_value_fails_startup() {
+    let error = Martin::builder()
+        .config(
+            "
+pmtiles:
+  sources:
+    pmt:
+      path: tests/fixtures/pmtiles/png.pmtiles
+      cache_control: max-age=invalid
+",
+        )
+        .start()
+        .await
+        .expect_err("martin must reject an invalid per-source Cache-Control value");
+    let StartError::EarlyExit { status, log } = error else {
+        panic!("expected an early exit, got: {error}");
+    };
+    assert!(!status.success(), "exit status must be a failure: {status}");
+    assert!(
+        log.contains("invalid Cache-Control header value 'max-age=invalid'"),
+        "log must name the invalid value; log:\n{log}"
+    );
 }
 
 #[tokio::test]

--- a/e2e-tests/tests/save_config.rs
+++ b/e2e-tests/tests/save_config.rs
@@ -25,6 +25,7 @@ pmtiles:
       cache:
         minzoom: 0
         maxzoom: 3
+      cache_control: no-store
 geojson: {}
 sprites:
   paths: tests/fixtures/sprites/src1

--- a/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
+++ b/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
@@ -24,6 +24,7 @@ pmtiles:
       cache:
         minzoom: 0
         maxzoom: 3
+      cache_control: no-store
 geojson: {}
 sprites:
   paths: tests/fixtures/sprites/src1

--- a/martin/src/bin/martin.rs
+++ b/martin/src/bin/martin.rs
@@ -89,6 +89,7 @@ async fn start(args: Args) -> StartupResult<()> {
         let pc = ProcessConfig {
             convert_to_mlt: config.convert_to_mlt.clone(),
             convert_to_mvt: config.convert_to_mvt.clone(),
+            ..Default::default()
         };
         #[cfg(not(feature = "mlt"))]
         let pc = ProcessConfig::default();

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -24,7 +24,8 @@ use tracing::{info, warn};
 use url::Url;
 
 use crate::config::file::{
-    CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, UnrecognizedValues,
+    CacheControlHeader, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
+    UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -381,6 +382,11 @@ pub struct FileConfigSource {
     #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
     #[cfg_attr(feature = "unstable-schemas", schemars(with = "CachePolicyShape"))]
     pub cache: CachePolicy,
+    /// `Cache-Control` response header for this source.
+    /// Overrides the top-level `cache_control` default.
+    #[serde(default)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<String>"))]
+    pub cache_control: Option<CacheControlHeader>,
 }
 
 #[cfg(feature = "_tiles")]

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -36,15 +36,24 @@ use crate::StartupResult;
 use crate::config::file::ConfigurationLivecycleHooks;
 #[cfg(any(
     feature = "pmtiles",
+    feature = "mbtiles",
+    feature = "unstable-cog",
+    feature = "geojson",
     feature = "sprites",
     feature = "fonts",
-    all(feature = "mlt", feature = "mbtiles"),
 ))]
 use crate::config::file::FileConfigEnum;
-#[cfg(all(feature = "mlt", any(feature = "pmtiles", feature = "mbtiles")))]
+#[cfg(any(
+    feature = "pmtiles",
+    feature = "mbtiles",
+    feature = "unstable-cog",
+    feature = "geojson"
+))]
 use crate::config::file::FileConfigSrc;
 #[cfg(any(feature = "_tiles", feature = "sprites", feature = "fonts"))]
 use crate::config::file::cache::{CacheConfig, SubCacheSetting};
+#[cfg(feature = "postgres")]
+use crate::config::file::postgres::PostgresConfig;
 #[cfg(feature = "_tiles")]
 use crate::config::file::process::ProcessConfig;
 #[cfg(any(
@@ -449,59 +458,60 @@ impl Config {
         #[allow(unused_mut)]
         let mut map = HashMap::new();
 
-        #[cfg(all(
-            feature = "mlt",
-            any(
-                feature = "postgres",
-                feature = "pmtiles",
-                feature = "mbtiles",
-                feature = "passthrough"
-            )
+        #[cfg(any(
+            feature = "postgres",
+            feature = "pmtiles",
+            feature = "mbtiles",
+            feature = "passthrough",
+            feature = "unstable-cog",
+            feature = "geojson"
         ))]
         {
+            // The server-level `cache_control` is applied by middleware, not carried here.
             let global = ProcessConfig {
+                #[cfg(feature = "mlt")]
                 convert_to_mlt: self.convert_to_mlt.clone(),
+                #[cfg(feature = "mlt")]
                 convert_to_mvt: self.convert_to_mvt.clone(),
+                cache_control: None,
             };
 
             #[cfg(feature = "postgres")]
             for pg in self.postgres.iter() {
-                let source_type = ProcessConfig {
-                    convert_to_mlt: pg.convert_to_mlt.clone(),
-                    convert_to_mvt: pg.convert_to_mvt.clone(),
-                };
-                if let Some(tables) = &pg.tables {
-                    Self::insert_source_configs(&mut map, &global, &source_type, tables, |info| {
-                        ProcessConfig {
-                            convert_to_mlt: info.convert_to_mlt.clone(),
-                            convert_to_mvt: info.convert_to_mvt.clone(),
-                        }
-                    });
-                }
-                if let Some(functions) = &pg.functions {
-                    Self::insert_source_configs(
-                        &mut map,
-                        &global,
-                        &source_type,
-                        functions,
-                        |info| ProcessConfig {
-                            convert_to_mlt: info.convert_to_mlt.clone(),
-                            convert_to_mvt: info.convert_to_mvt.clone(),
-                        },
-                    );
-                }
+                Self::insert_postgres_configs(&mut map, &global, pg);
             }
 
-            #[cfg(feature = "pmtiles")]
+            #[cfg(all(feature = "pmtiles", feature = "mlt"))]
             Self::insert_file_source_configs(&mut map, &global, &self.pmtiles, |c| ProcessConfig {
                 convert_to_mlt: c.convert_to_mlt.clone(),
                 convert_to_mvt: c.convert_to_mvt.clone(),
+                cache_control: None,
+            });
+            #[cfg(all(feature = "pmtiles", not(feature = "mlt")))]
+            Self::insert_file_source_configs(&mut map, &global, &self.pmtiles, |_| {
+                ProcessConfig::default()
             });
 
-            #[cfg(feature = "mbtiles")]
+            #[cfg(all(feature = "mbtiles", feature = "mlt"))]
             Self::insert_file_source_configs(&mut map, &global, &self.mbtiles, |c| ProcessConfig {
                 convert_to_mlt: c.convert_to_mlt.clone(),
                 convert_to_mvt: c.convert_to_mvt.clone(),
+                cache_control: None,
+            });
+            #[cfg(all(feature = "mbtiles", not(feature = "mlt")))]
+            Self::insert_file_source_configs(&mut map, &global, &self.mbtiles, |_| {
+                ProcessConfig::default()
+            });
+
+            // COG and GeoJSON have no kind-level conversion settings.
+            #[cfg(feature = "unstable-cog")]
+            Self::insert_file_source_configs(&mut map, &global, &self.cog, |_| {
+                ProcessConfig::default()
+            });
+
+            #[cfg(feature = "geojson")]
+            Self::insert_file_source_configs(&mut map, &global, &self.geojson, |_| {
+                ProcessConfig::default()
             });
 
             #[cfg(feature = "passthrough")]
@@ -509,14 +519,20 @@ impl Config {
                 use crate::config::file::passthrough::PassthroughSrc;
 
                 let source_type = ProcessConfig {
+                    #[cfg(feature = "mlt")]
                     convert_to_mlt: self.passthrough.convert_to_mlt.clone(),
+                    #[cfg(feature = "mlt")]
                     convert_to_mvt: self.passthrough.convert_to_mvt.clone(),
+                    cache_control: None,
                 };
                 Self::insert_source_configs(&mut map, &global, &source_type, sources, |src| {
                     match src {
                         PassthroughSrc::Detailed(obj) => ProcessConfig {
+                            #[cfg(feature = "mlt")]
                             convert_to_mlt: obj.convert_to_mlt.clone(),
+                            #[cfg(feature = "mlt")]
                             convert_to_mvt: obj.convert_to_mvt.clone(),
+                            cache_control: obj.cache_control.clone(),
                         },
                         PassthroughSrc::Shorthand(_) => ProcessConfig::default(),
                     }
@@ -524,23 +540,53 @@ impl Config {
             }
         }
 
-        // COG sources produce raster tiles (TIFF), not vector tiles (MVT),
-        // so process config (MLT conversion, compression) does not apply.
-        // They fall through to the global default, which is a no-op for raster formats.
-
         map
+    }
+
+    #[cfg(feature = "postgres")]
+    fn insert_postgres_configs(
+        map: &mut HashMap<String, ProcessConfig>,
+        global: &ProcessConfig,
+        pg: &PostgresConfig,
+    ) {
+        let source_type = ProcessConfig {
+            #[cfg(feature = "mlt")]
+            convert_to_mlt: pg.convert_to_mlt.clone(),
+            #[cfg(feature = "mlt")]
+            convert_to_mvt: pg.convert_to_mvt.clone(),
+            cache_control: None,
+        };
+        if let Some(tables) = &pg.tables {
+            Self::insert_source_configs(map, global, &source_type, tables, |info| ProcessConfig {
+                #[cfg(feature = "mlt")]
+                convert_to_mlt: info.convert_to_mlt.clone(),
+                #[cfg(feature = "mlt")]
+                convert_to_mvt: info.convert_to_mvt.clone(),
+                cache_control: info.cache_control.clone(),
+            });
+        }
+        if let Some(functions) = &pg.functions {
+            Self::insert_source_configs(map, global, &source_type, functions, |info| {
+                ProcessConfig {
+                    #[cfg(feature = "mlt")]
+                    convert_to_mlt: info.convert_to_mlt.clone(),
+                    #[cfg(feature = "mlt")]
+                    convert_to_mvt: info.convert_to_mvt.clone(),
+                    cache_control: info.cache_control.clone(),
+                }
+            });
+        }
     }
 
     /// Resolve and insert the effective [`ProcessConfig`] for each source in a map, layering
     /// per-source settings over the source-type and global defaults.
-    #[cfg(all(
-        feature = "mlt",
-        any(
-            feature = "postgres",
-            feature = "pmtiles",
-            feature = "mbtiles",
-            feature = "passthrough"
-        )
+    #[cfg(any(
+        feature = "postgres",
+        feature = "pmtiles",
+        feature = "mbtiles",
+        feature = "passthrough",
+        feature = "unstable-cog",
+        feature = "geojson"
     ))]
     fn insert_source_configs<'a, S: 'a>(
         map: &mut HashMap<String, ProcessConfig>,
@@ -559,8 +605,13 @@ impl Config {
         }
     }
 
-    /// Helper to resolve process configs for file-based source types (pmtiles, mbtiles).
-    #[cfg(all(feature = "mlt", any(feature = "pmtiles", feature = "mbtiles")))]
+    /// Helper to resolve process configs for file-based source types.
+    #[cfg(any(
+        feature = "pmtiles",
+        feature = "mbtiles",
+        feature = "unstable-cog",
+        feature = "geojson"
+    ))]
     fn insert_file_source_configs<T: ConfigurationLivecycleHooks>(
         map: &mut HashMap<String, ProcessConfig>,
         global: &ProcessConfig,
@@ -572,8 +623,11 @@ impl Config {
             if let Some(sources) = &cfg.sources {
                 Self::insert_source_configs(map, global, &source_type, sources, |src| match src {
                     FileConfigSrc::Obj(obj) => ProcessConfig {
+                        #[cfg(feature = "mlt")]
                         convert_to_mlt: obj.convert_to_mlt.clone(),
+                        #[cfg(feature = "mlt")]
                         convert_to_mvt: obj.convert_to_mvt.clone(),
+                        cache_control: obj.cache_control.clone(),
                     },
                     FileConfigSrc::Path(_) => ProcessConfig::default(),
                 });

--- a/martin/src/config/file/mod.rs
+++ b/martin/src/config/file/mod.rs
@@ -9,13 +9,20 @@ pub use main::*;
 pub mod cache;
 pub mod cors;
 pub mod srv;
+pub use srv::CacheControlHeader;
 
 mod error;
 pub use error::{ConfigFileError, ConfigFileResult};
 
 pub mod process;
 pub use process::ProcessConfig;
-#[cfg(all(feature = "mlt", feature = "_tiles"))]
+#[cfg(any(
+    feature = "postgres",
+    feature = "mbtiles",
+    feature = "unstable-cog",
+    feature = "geojson",
+    feature = "pmtiles"
+))]
 pub(crate) use process::resolve_process_config;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 pub use process::{MltEncoderConfig, MltProcessConfig, MvtEncoderConfig, MvtProcessConfig};

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -3,20 +3,25 @@ use mlt_core::encoder::EncoderConfig;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use serde::{Deserialize, Serialize};
 
+use crate::config::file::CacheControlHeader;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{CollectUnrecognizedKeys, UnrecognizedKeys, UnrecognizedValues};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::primitives::AutoOption;
 
-/// Internal carrier for resolved per-source processing settings.
+/// Internal carrier for resolved per-source serving settings.
 ///
-/// Not serialized directly - config files use `convert_to_mlt` / `convert_to_mvt`.
+/// Not serialized directly - config files use `convert_to_mlt` / `convert_to_mvt` /
+/// `cache_control`.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ProcessConfig {
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     pub convert_to_mlt: Option<MltProcessConfig>,
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     pub convert_to_mvt: Option<MvtProcessConfig>,
+    /// `Cache-Control` response header for this source,
+    /// overriding the server-level `cache_control` default.
+    pub cache_control: Option<CacheControlHeader>,
 }
 
 /// Configuration for MVT-to-MLT format conversion.
@@ -125,21 +130,31 @@ impl From<MltEncoderConfig> for EncoderConfig {
     }
 }
 
-/// Resolve effective process config using full-override semantics:
-/// per-source > source-type > global > default.
+/// Resolve the effective per-source config: per-source > source-type > global > default.
+///
+/// The `convert_to_*` pair overrides as a unit; `cache_control` resolves on its own.
 #[must_use]
 pub fn resolve_process_config(
     global: &ProcessConfig,
     source_type: &ProcessConfig,
     per_source: &ProcessConfig,
 ) -> ProcessConfig {
-    let default = ProcessConfig::default();
-    if *per_source != default {
-        per_source.clone()
-    } else if *source_type != default {
-        source_type.clone()
-    } else {
-        global.clone()
+    let cache_control = per_source
+        .cache_control
+        .clone()
+        .or_else(|| source_type.cache_control.clone())
+        .or_else(|| global.cache_control.clone());
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    let conversions = [per_source, source_type, global]
+        .into_iter()
+        .find(|pc| pc.convert_to_mlt.is_some() || pc.convert_to_mvt.is_some())
+        .unwrap_or(global);
+    ProcessConfig {
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        convert_to_mlt: conversions.convert_to_mlt.clone(),
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        convert_to_mvt: conversions.convert_to_mvt.clone(),
+        cache_control,
     }
 }
 
@@ -301,10 +316,12 @@ mod tests {
         let global = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Auto),
             convert_to_mvt: None,
+            cache_control: None,
         };
         let per_source = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Disabled),
             convert_to_mvt: None,
+            cache_control: None,
         };
         let resolved = resolve_process_config(&global, &ProcessConfig::default(), &per_source);
         assert_eq!(resolved.convert_to_mlt, Some(MltProcessConfig::Disabled));
@@ -316,10 +333,12 @@ mod tests {
         let global = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Auto),
             convert_to_mvt: None,
+            cache_control: None,
         };
         let source_type = ProcessConfig {
             convert_to_mlt: None,
             convert_to_mvt: Some(MvtProcessConfig::Auto),
+            cache_control: None,
         };
         let per_source = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Explicit(MltEncoderConfig {
@@ -327,6 +346,7 @@ mod tests {
                 ..Default::default()
             })),
             convert_to_mvt: None,
+            cache_control: None,
         };
 
         let resolved = resolve_process_config(&global, &source_type, &per_source);
@@ -339,10 +359,12 @@ mod tests {
         let global = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Auto),
             convert_to_mvt: None,
+            cache_control: None,
         };
         let source_type = ProcessConfig {
             convert_to_mlt: None,
             convert_to_mvt: Some(MvtProcessConfig::Auto),
+            cache_control: None,
         };
 
         let resolved = resolve_process_config(&global, &source_type, &ProcessConfig::default());
@@ -355,6 +377,7 @@ mod tests {
         let global = ProcessConfig {
             convert_to_mlt: Some(MltProcessConfig::Auto),
             convert_to_mvt: None,
+            cache_control: None,
         };
 
         let resolved = resolve_process_config(
@@ -363,6 +386,57 @@ mod tests {
             &ProcessConfig::default(),
         );
         assert_eq!(resolved, global);
+    }
+
+    fn cache_control(value: &str) -> CacheControlHeader {
+        serde_saphyr::from_str(value).expect("valid Cache-Control header")
+    }
+
+    #[cfg_attr(
+        not(all(feature = "mlt", feature = "_tiles")),
+        allow(clippy::needless_update)
+    )]
+    fn only_cache_control(value: &str) -> ProcessConfig {
+        ProcessConfig {
+            cache_control: Some(cache_control(value)),
+            ..ProcessConfig::default()
+        }
+    }
+
+    #[test]
+    fn resolve_per_source_cache_control_wins() {
+        let source_type = only_cache_control("public, max-age=60");
+        let per_source = only_cache_control("no-store");
+        let resolved = resolve_process_config(&ProcessConfig::default(), &source_type, &per_source);
+        assert_eq!(resolved.cache_control, Some(cache_control("no-store")));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[test]
+    fn resolve_cache_control_independently_of_conversions() {
+        let source_type = ProcessConfig {
+            convert_to_mlt: Some(MltProcessConfig::Disabled),
+            cache_control: Some(cache_control("public, max-age=60")),
+            ..Default::default()
+        };
+        let per_source = ProcessConfig {
+            convert_to_mlt: Some(MltProcessConfig::Auto),
+            ..Default::default()
+        };
+        let resolved = resolve_process_config(&ProcessConfig::default(), &source_type, &per_source);
+        assert_eq!(resolved.convert_to_mlt, Some(MltProcessConfig::Auto));
+        assert_eq!(
+            resolved.cache_control,
+            Some(cache_control("public, max-age=60"))
+        );
+
+        let resolved = resolve_process_config(
+            &ProcessConfig::default(),
+            &source_type,
+            &only_cache_control("no-store"),
+        );
+        assert_eq!(resolved.convert_to_mlt, Some(MltProcessConfig::Disabled));
+        assert_eq!(resolved.cache_control, Some(cache_control("no-store")));
     }
 
     #[test]

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -9,7 +9,6 @@ use futures::future::BoxFuture;
 use martin_core::tiles::BoxedSource;
 use tokio::fs::{self, DirEntry};
 
-#[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::FileConfigSrc;
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
@@ -37,8 +36,7 @@ pub type FsSourceBuilder = Box<dyn Fn(String, PathBuf, CachePolicy) -> BuildFutu
 /// same canonical path keeps its policy and per-source process settings.
 struct ConfiguredSource {
     policy: CachePolicy,
-    /// Per-source `convert_to_*` override, already resolved against the kind level.
-    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    /// Per-source `convert_to_*` / `cache_control` override, already resolved against the kind level.
     process: Option<ProcessConfig>,
 }
 
@@ -81,7 +79,6 @@ impl FsDiscovery {
                     canonical,
                     ConfiguredSource {
                         policy: src.cache_zoom(),
-                        #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         process: per_source_process(&process, src),
                     },
                 );
@@ -131,21 +128,23 @@ impl FsDiscovery {
     }
 }
 
-/// Per-source `convert_to_*` settings override the kind-level [`ProcessConfig`].
-#[cfg(all(feature = "mlt", feature = "_tiles"))]
+/// Per-source `convert_to_*` and `cache_control` settings override the kind-level [`ProcessConfig`].
 fn per_source_process(kind_level: &ProcessConfig, src: &FileConfigSrc) -> Option<ProcessConfig> {
     use crate::config::file::resolve_process_config;
 
     let FileConfigSrc::Obj(obj) = src else {
         return None;
     };
-    if obj.convert_to_mlt.is_none() && obj.convert_to_mvt.is_none() {
+    let per_source = ProcessConfig {
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        convert_to_mlt: obj.convert_to_mlt.clone(),
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        convert_to_mvt: obj.convert_to_mvt.clone(),
+        cache_control: obj.cache_control.clone(),
+    };
+    if per_source == ProcessConfig::default() {
         return None;
     }
-    let per_source = ProcessConfig {
-        convert_to_mlt: obj.convert_to_mlt.clone(),
-        convert_to_mvt: obj.convert_to_mvt.clone(),
-    };
     Some(resolve_process_config(
         kind_level,
         &ProcessConfig::default(),
@@ -177,13 +176,10 @@ impl Discovery for FsDiscovery {
 
     async fn build(&self, id: &str, args: &Self::Args) -> SourceBuildResult<BuiltSource> {
         let source = (self.build)(id.to_owned(), args.0.clone(), args.1).await?;
-        #[cfg(all(feature = "mlt", feature = "_tiles"))]
         let process = self
             .configured
             .get(&args.0)
             .and_then(|cfg| cfg.process.clone());
-        #[cfg(not(all(feature = "mlt", feature = "_tiles")))]
-        let process = None;
         Ok(BuiltSource { source, process })
     }
 
@@ -340,6 +336,7 @@ mod tests {
                         path: overridden.clone(),
                         convert_to_mlt: Some(AutoOption::Disabled),
                         convert_to_mvt: None,
+                        cache_control: None,
                         cache: CachePolicy::default(),
                     }),
                 ),
@@ -350,6 +347,7 @@ mod tests {
         let kind_level = ProcessConfig {
             convert_to_mlt: Some(AutoOption::Auto),
             convert_to_mvt: None,
+            cache_control: None,
         };
         let discovery = FsDiscovery::from_config(
             &config,
@@ -374,5 +372,49 @@ mod tests {
             Some(AutoOption::Disabled)
         );
         assert_eq!(configured(&plain).process, None);
+    }
+
+    #[test]
+    fn configured_sources_keep_their_cache_control_override() {
+        use crate::config::file::{FileConfig, FileConfigSource};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pinned = dir.path().join("pinned.mbtiles");
+        File::create(&pinned).expect("create pinned");
+
+        let config = FileConfigEnum::Config(FileConfig {
+            sources: Some(BTreeMap::from([(
+                "pinned".to_owned(),
+                FileConfigSrc::Obj(FileConfigSource {
+                    path: pinned.clone(),
+                    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                    convert_to_mlt: None,
+                    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                    convert_to_mvt: None,
+                    cache_control: Some(
+                        serde_saphyr::from_str("public, max-age=60").expect("valid header"),
+                    ),
+                    cache: CachePolicy::default(),
+                }),
+            )])),
+            ..FileConfig::<()>::default()
+        });
+        let discovery = FsDiscovery::from_config(
+            &config,
+            &["mbtiles"],
+            IdResolver::new(&[]),
+            ProcessConfig::default(),
+            unreachable_builder(),
+        );
+
+        let canonical = pinned.canonicalize().expect("canonicalize");
+        let process = discovery
+            .configured
+            .get(&canonical)
+            .expect("configured path")
+            .process
+            .as_ref()
+            .expect("a cache_control-only override is still an override");
+        assert!(process.cache_control.is_some());
     }
 }

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -91,27 +91,27 @@ impl Discovery for PostgresDiscovery {
     }
 }
 
-/// Per-source `convert_to_*` settings override the connection-level [`ProcessConfig`].
-#[cfg(feature = "mlt")]
+/// Per-source `convert_to_*` and `cache_control` settings override the connection-level [`ProcessConfig`].
 fn per_source_process(connection: &ProcessConfig, spec: &SourceSpec) -> ProcessConfig {
     use crate::config::file::resolve_process_config;
 
     let per_source = match spec {
         SourceSpec::Table(info) => ProcessConfig {
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mlt: info.convert_to_mlt.clone(),
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mvt: info.convert_to_mvt.clone(),
+            cache_control: info.cache_control.clone(),
         },
         SourceSpec::Function(info, _) => ProcessConfig {
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mlt: info.convert_to_mlt.clone(),
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mvt: info.convert_to_mvt.clone(),
+            cache_control: info.cache_control.clone(),
         },
     };
     resolve_process_config(connection, &ProcessConfig::default(), &per_source)
-}
-
-#[cfg(not(feature = "mlt"))]
-fn per_source_process(connection: &ProcessConfig, _spec: &SourceSpec) -> ProcessConfig {
-    connection.clone()
 }
 
 #[cfg(all(test, feature = "test-pg"))]

--- a/martin/src/config/file/tiles/geojson.rs
+++ b/martin/src/config/file/tiles/geojson.rs
@@ -165,6 +165,7 @@ mod tests {
                         #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         convert_to_mvt: None,
                         cache: CachePolicy::default(),
+                        cache_control: None,
                     })
                 ),
                 (
@@ -180,6 +181,7 @@ mod tests {
                         #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         convert_to_mvt: None,
                         cache: CachePolicy::default(),
+                        cache_control: None,
                     })
                 ),
             ]))

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -139,6 +139,7 @@ mod tests {
                         #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         convert_to_mvt: None,
                         cache: CachePolicy::default(),
+                        cache_control: None,
                     })
                 ),
                 (
@@ -154,6 +155,7 @@ mod tests {
                         #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         convert_to_mvt: None,
                         cache: CachePolicy::default(),
+                        cache_control: None,
                     })
                 ),
                 (
@@ -165,6 +167,7 @@ mod tests {
                         #[cfg(all(feature = "mlt", feature = "_tiles"))]
                         convert_to_mvt: None,
                         cache: CachePolicy::new(CacheZoomRange::new(Some(0), Some(6))),
+                        cache_control: None,
                     })
                 ),
             ]))

--- a/martin/src/config/file/tiles/passthrough.rs
+++ b/martin/src/config/file/tiles/passthrough.rs
@@ -12,8 +12,9 @@ use tilejson::Bounds;
 use tracing::info;
 
 use crate::config::file::{
-    CachePolicy, CollectUnrecognizedKeys, ConfigFileError, ConfigurationLivecycleHooks,
-    ResolutionResult, SourceBuildResult, TileSourceWarning, UnrecognizedValues,
+    CacheControlHeader, CachePolicy, CollectUnrecognizedKeys, ConfigFileError,
+    ConfigurationLivecycleHooks, ResolutionResult, SourceBuildResult, TileSourceWarning,
+    UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -247,6 +248,12 @@ pub struct PassthroughSourceConfig {
     )]
     pub cache: CachePolicy,
 
+    /// `Cache-Control` response header for this source.
+    /// Overrides the top-level `cache_control` default.
+    #[serde(default)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<String>"))]
+    pub cache_control: Option<CacheControlHeader>,
+
     /// MVT->MLT encoder settings for this source.
     /// Overrides source-type and global `convert_to_mlt`.
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
@@ -275,6 +282,7 @@ impl Default for PassthroughSourceConfig {
             bounds: None,
             attribution: None,
             cache: CachePolicy::default(),
+            cache_control: None,
             #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mlt: None,
             #[cfg(all(feature = "mlt", feature = "_tiles"))]

--- a/martin/src/config/file/tiles/postgres/config_function.rs
+++ b/martin/src/config/file/tiles/postgres/config_function.rs
@@ -9,7 +9,9 @@ use super::config::PostgresInfo;
 #[cfg(feature = "unstable-schemas")]
 use crate::config::file::postgres::config_table::bounds_world_example;
 use crate::config::file::postgres::utils::patch_json;
-use crate::config::file::{CachePolicy, CollectUnrecognizedKeys, UnrecognizedValues};
+use crate::config::file::{
+    CacheControlHeader, CachePolicy, CollectUnrecognizedKeys, UnrecognizedValues,
+};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
 
@@ -49,6 +51,12 @@ pub struct FunctionInfo {
         schemars(with = "Option<crate::config::file::CachePolicyShape>")
     )]
     pub cache: Option<CachePolicy>,
+
+    /// `Cache-Control` response header for this source.
+    /// Overrides the top-level `cache_control` default.
+    #[serde(default)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<String>"))]
+    pub cache_control: Option<CacheControlHeader>,
 
     /// `TileJSON` provided by the SQL function comment. Not serialized.
     #[serde(skip)]

--- a/martin/src/config/file/tiles/postgres/config_table.rs
+++ b/martin/src/config/file/tiles/postgres/config_table.rs
@@ -8,7 +8,9 @@ use tracing::{info, warn};
 
 use super::PostgresInfo;
 use crate::config::file::postgres::utils::{normalize_key, patch_json};
-use crate::config::file::{CachePolicy, CollectUnrecognizedKeys, UnrecognizedValues};
+use crate::config::file::{
+    CacheControlHeader, CachePolicy, CollectUnrecognizedKeys, UnrecognizedValues,
+};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
 
@@ -103,6 +105,12 @@ pub struct TableInfo {
         schemars(with = "Option<crate::config::file::CachePolicyShape>")
     )]
     pub cache: Option<CachePolicy>,
+
+    /// `Cache-Control` response header for this source.
+    /// Overrides the top-level `cache_control` default.
+    #[serde(default)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(with = "Option<String>"))]
+    pub cache_control: Option<CacheControlHeader>,
 
     /// List of columns, that should be encoded as tile properties (required)
     ///

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -32,6 +32,7 @@ impl MbtilesReloader {
                 FileConfigEnum::Config(cfg) => ProcessConfig {
                     convert_to_mlt: cfg.custom.convert_to_mlt.clone(),
                     convert_to_mvt: cfg.custom.convert_to_mvt.clone(),
+                    ..Default::default()
                 },
                 _ => ProcessConfig::default(),
             };

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -35,6 +35,7 @@ impl PmtilesReloader {
                 FileConfigEnum::Config(cfg) => ProcessConfig {
                     convert_to_mlt: cfg.custom.convert_to_mlt.clone(),
                     convert_to_mvt: cfg.custom.convert_to_mvt.clone(),
+                    ..Default::default()
                 },
                 _ => ProcessConfig::default(),
             };
@@ -215,6 +216,7 @@ mod tests {
                 convert_to_mlt: None,
                 #[cfg(all(feature = "mlt", feature = "_tiles"))]
                 convert_to_mvt: None,
+                cache_control: None,
             }),
         );
         let cfg = FileConfigEnum::Config(FileConfig {

--- a/martin/src/config/file/tiles/reload/postgres.rs
+++ b/martin/src/config/file/tiles/reload/postgres.rs
@@ -38,6 +38,7 @@ impl PostgresReloader {
             let source_type = ProcessConfig {
                 convert_to_mlt: config.convert_to_mlt.clone(),
                 convert_to_mvt: config.convert_to_mvt.clone(),
+                ..Default::default()
             };
             resolve_process_config(global_process, &source_type, &ProcessConfig::default())
         };

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -4,8 +4,8 @@ use actix_http::ContentEncoding;
 use actix_http::header::Quality;
 use actix_web::error::{ErrorBadRequest, ErrorNotAcceptable, ErrorNotFound};
 use actix_web::http::header::{
-    Accept, AcceptEncoding, CONTENT_ENCODING, ETAG, Encoding as HeaderEnc, EntityTag, IfNoneMatch,
-    LOCATION, Preference,
+    Accept, AcceptEncoding, CACHE_CONTROL, CONTENT_ENCODING, ETAG, Encoding as HeaderEnc,
+    EntityTag, HeaderValue, IfNoneMatch, LOCATION, Preference,
 };
 use actix_web::web::{Data, Path, Query};
 use actix_web::{HttpMessage as _, HttpRequest, HttpResponse, Result as ActixResult, route};
@@ -383,7 +383,19 @@ impl<'a> DynTileSource<'a> {
         if let Some(val) = tile.info.encoding.compression() {
             response.insert_header((CONTENT_ENCODING, val));
         }
+        if let Some(cache_control) = self.cache_control_header() {
+            response.insert_header((CACHE_CONTROL, cache_control));
+        }
         Ok(response.body(tile.data))
+    }
+
+    /// The per-source `Cache-Control` value, when every source of this request agrees on one.
+    fn cache_control_header(&self) -> Option<HeaderValue> {
+        let mut configured = self.sources.iter().map(|(_, pc)| &pc.cache_control);
+        let first = configured.next()?.as_ref()?;
+        configured
+            .all(|c| c.as_ref() == Some(first))
+            .then(|| first.header_value())
     }
 
     #[hotpath::measure]

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -405,6 +405,10 @@
           "$ref": "#/$defs/CachePolicyShape",
           "description": "Zoom-level bounds for tile caching."
         },
+        "cache_control": {
+          "description": "`Cache-Control` response header for this source.\nOverrides the top-level `cache_control` default.",
+          "type": ["string", "null"]
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -468,6 +472,10 @@
             }
           ],
           "description": "Zoom-level bounds for tile caching."
+        },
+        "cache_control": {
+          "description": "`Cache-Control` response header for this source.\nOverrides the top-level `cache_control` default.",
+          "type": ["string", "null"]
         },
         "convert_to_mlt": {
           "anyOf": [
@@ -828,6 +836,10 @@
           "$ref": "#/$defs/CachePolicyShape",
           "description": "Zoom-level bounds for tile caching."
         },
+        "cache_control": {
+          "description": "`Cache-Control` response header for this source.\nOverrides the top-level `cache_control` default.",
+          "type": ["string", "null"]
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -1116,6 +1128,10 @@
             }
           ],
           "description": "Zoom-level bounds for tile caching (overrides top-level cache).\ndefault: null (inherit from top-level default)\nUse `cache: disable` to disable caching for this source."
+        },
+        "cache_control": {
+          "description": "`Cache-Control` response header for this source.\nOverrides the top-level `cache_control` default.",
+          "type": ["string", "null"]
         },
         "clip_geom": {
           "description": "Boolean to control if geometries should be clipped or encoded as is",


### PR DESCRIPTION
Closes #749

#3042 added the server-level `cache_control` default and #3148 covered it.
This is the per-source half, in the shape #2673 set for per-source `cache`: a global default plus a `cache_control` key on each source.