### PR TITLE
build: drop debuginfo from the bundled DuckDB build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ sqlx-macros.opt-level = 3
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs
 insta.opt-level = 3
 similar.opt-level = 3
-# The bundled DuckDB C++ build takes its debuginfo setting from here; with `-g` libduckdb.a is 1.7GB
+# very large debug bundles
 libduckdb-sys.debug = false
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,8 @@ sqlx-macros.opt-level = 3
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs
 insta.opt-level = 3
 similar.opt-level = 3
+# The bundled DuckDB C++ build takes its debuginfo setting from here; with `-g` libduckdb.a is 1.7GB
+libduckdb-sys.debug = false
 
 [profile.release]
 # Make release binaries a bit smaller


### PR DESCRIPTION
Ref #3156

The DuckDB job's cache entry is 4.9GB (run [32820471902](https://github.com/maplibre/martin/actions/runs/32820471902) saves `4894610292` bytes), half the repo's 10GB quota, so it is the first entry evicted on any Cargo.lock bump and takes the others with it. `libduckdb-sys` builds DuckDB's C++ through `cc`, which reads the profile's debuginfo setting, so the dev profile compiles all of DuckDB with `-g`. Adding `libduckdb-sys.debug = false` to the existing `[profile.dev.package]` overrides takes `libduckdb.a` from 1.75GB to 268MB per copy and the saved cache entry from 4.9GB to 1.85GB (`4894591590` → `1851514928` bytes, measured on my fork: [before](https://github.com/johncarmack1984/martin/actions/runs/32854032587), [after](https://github.com/johncarmack1984/martin/actions/runs/32854035267)). Martin's own code keeps full debuginfo; DuckDB frames lose line info in backtraces and get `NDEBUG`, which is how DuckDB ships its own builds.
