### PR TITLE
docs(nginx): document request authentication with auth_request

### DIFF
--- a/docs/content/run-with-nginx.md
+++ b/docs/content/run-with-nginx.md
@@ -32,6 +32,38 @@ location ~ /tiles/(?<fwd_path>.*) {
 }
 ```
 
+### Authenticating requests
+
+Martin does not authenticate requests, so put the check in NGINX.
+The [`auth_request`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) directive sends a subrequest to a service of your choice before each tile request is proxied.
+A `2xx` reply lets the request through and a `401` or `403` reply is returned to the client as is.
+The subrequest carries the headers of the original request, so the service can validate a JWT in the `Authorization` header, check a cookie, or look up an API key from the query string.
+The check runs before the cache lookup, so cached tiles are protected too.
+
+```nginx
+location = /auth {
+    internal;
+    proxy_pass              http://auth:8080/check;
+    proxy_pass_request_body off;
+    proxy_set_header        Content-Length "";
+    proxy_set_header        X-Original-URI $request_uri;
+}
+
+location ~ /tiles/(?<fwd_path>.*) {
+    auth_request      /auth;
+
+    proxy_set_header  X-Rewrite-URL $uri;
+    proxy_set_header  X-Forwarded-Host $host:$server_port;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_redirect    off;
+
+    proxy_pass        http://martin:3000/$fwd_path$is_args$args;
+}
+```
+
+The service behind `/auth` can be a few lines in any language or a ready-made one such as [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/).
+On the client side, MapLibre GL JS can attach the credential to every tile request through the [`transformRequest`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/RequestTransformFunction/) option.
+
 ### Caching tiles
 
 You can also use NGINX to cache tiles.

--- a/docs/content/run-with-reverse-proxy/index.md
+++ b/docs/content/run-with-reverse-proxy/index.md
@@ -9,6 +9,8 @@ Martin **can run without** a reverse proxy.
 Doing so has a few downsides:
 
 - Martin does not support HTTPS connections (TLS termination).
+- Martin does not authenticate requests.
+  If some sources are private, the reverse proxy has to check the request before Martin sees it, for example with [`auth_request` in NGINX](../run-with-nginx.md#authenticating-requests).
 - We do not check `HOST`-headers - we just serve on a port.
   This means anybody can point their dns record to your server and serve to all requests going to the port Martin is running on.
   Using a reverse proxy makes this abuse obvious.


### PR DESCRIPTION
Closes #78

Martin leaves authentication to the reverse proxy, and the closing note on #190 points at the nginx and apache pages for how. At the moment, neither page says a word about it. This adds an "Authenticating requests" section to the nginx page built on auth_request, the recipe gbip left on #78 in 2021, and one line on the reverse proxy index saying Martin does not authenticate requests.