### PR TITLE
ci: compile the bundled DuckDB once in just test-duckdb

### DIFF
--- a/justfile
+++ b/justfile
@@ -608,12 +608,11 @@ test-cog: fetch
     cargo build --package martin --no-default-features --features unstable-cog
     cargo test --package martin-e2e-tests --features test-cog --test cog
 
+# Same packages and a test target on every cargo call below, so the bundled DuckDB compiles once
 # Run DuckDB/GeoParquet tests only, including the end-to-end ones
 test-duckdb: fetch
-    cargo test -p martin --features test-duckdb --no-default-features --lib
-    cargo test -p martin-core --features unstable-duckdb --no-default-features --lib
-    cargo test -p martin-core --features unstable-duckdb --no-default-features --test duckdb_test
-    cargo build --package martin --no-default-features --features unstable-duckdb
+    cargo test -p martin -p martin-core --no-default-features --features martin/test-duckdb,martin-core/unstable-duckdb --lib --test duckdb_test
+    cargo build -p martin -p martin-core --no-default-features --features martin/test-duckdb,martin-core/unstable-duckdb --bin martin --test duckdb_test
     cargo test --package martin-e2e-tests --features test-duckdb --test duckdb
 
 # Run the style rendering tests end-to-end, replaying tests/fixtures/render_cassette

--- a/justfile
+++ b/justfile
@@ -608,7 +608,6 @@ test-cog: fetch
     cargo build --package martin --no-default-features --features unstable-cog
     cargo test --package martin-e2e-tests --features test-cog --test cog
 
-# Same packages and a test target on every cargo call below, so the bundled DuckDB compiles once
 # Run DuckDB/GeoParquet tests only, including the end-to-end ones
 test-duckdb: fetch
     cargo test -p martin -p martin-core --no-default-features --features martin/test-duckdb,martin-core/unstable-duckdb --lib --test duckdb_test


### PR DESCRIPTION
`just test-duckdb` compiled the bundled DuckDB three times. Each cargo call resolved a different set of shared build-script dependencies, which changed the `libduckdb-sys` fingerprint. Every call now uses the same package set with a test target in the resolution.

Cold local run, fresh target dir, same targets and the same 265 tests:

| | before | after |
|---|---:|---:|
| `libduckdb-sys` compiles | 3 | 1 |
| wall | 282 s | 164 s |
| CPU | 2084 s | 990 s |
| target dir | 9.1 GB | 5.6 GB |

Per step, cold:

| step | before | after |
|---|---:|---:|
| unit tests | 1m45s + 1m08s + 2s | 1m55s |
| `martin` binary | 1m10s | 10s |
| e2e | 24s | 26s |

Warm run: no recompiles, 8.75 s. The e2e binary is built under the test resolution, so some dependencies carry extra features (`tokio` process and test-util, `time` serde).
