### PR TITLE
fix(fonts): redirect glyph URLs with a file extension

### DIFF
--- a/e2e-tests/tests/fonts.rs
+++ b/e2e-tests/tests/fonts.rs
@@ -267,6 +267,33 @@ async fn the_plural_fonts_path_redirects() {
     martin.assert_log_clean();
 }
 
+#[rstest]
+#[case::singular("font")]
+#[case::plural("fonts")]
+#[tokio::test]
+async fn a_glyph_url_with_a_file_extension_redirects(#[case] segment: &str) {
+    let mut martin = martin_with_font_dir().await;
+
+    let path = format!("/{segment}/{REGULAR}/0-255.pbf");
+    for response in [martin.get(&path).await, martin.head(&path).await] {
+        assert_eq!(response.status(), 301);
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(response.headers_snapshot(), @"
+            content-length: 0
+            location: /font/Overpass Mono Regular/0-255
+            vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+            ");
+        }
+    }
+    assert_eq!(
+        martin.get(&format!("/font/{REGULAR}/0-255")).await.status(),
+        200
+    );
+
+    martin.stop().await;
+    martin.assert_log_clean();
+}
+
 #[tokio::test]
 async fn a_font_configured_from_two_paths_is_registered_once() {
     let mut martin = Martin::builder()

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -4,7 +4,7 @@ use actix_middleware_etag::Etag;
 use actix_web::http::header::LOCATION;
 use actix_web::middleware::Compress;
 use actix_web::web::{Data, Path};
-use actix_web::{HttpResponse, Result as ActixResult, route};
+use actix_web::{HttpResponse, Result as ActixResult, route, routes};
 use martin_core::fonts::{FontCacheKey, FontError, FontSources, OptFontCache, normalize_font_ids};
 use serde::Deserialize;
 use tracing::{instrument, warn};
@@ -92,6 +92,43 @@ pub async fn redirect_fonts(path: Path<FontRequest>) -> HttpResponse {
             LOCATION,
             format!("/font/{}/{}-{}", path.fontstack, path.start, path.end),
         ))
+        .finish()
+}
+
+#[derive(Deserialize, Debug)]
+struct FontExtRequest {
+    fontstack: String,
+    start: u32,
+    end: u32,
+    ext: String,
+}
+
+/// Redirect `/font/{fontstack}/{start}-{end}.{extension}` to `/font/{fontstack}/{start}-{end}` (HTTP 301)
+/// Registered before the main font route to match the more specific pattern first
+#[routes]
+#[get("/font/{fontstack}/{start}-{end}.{ext}")]
+#[head("/font/{fontstack}/{start}-{end}.{ext}")]
+#[get("/fonts/{fontstack}/{start}-{end}.{ext}")]
+#[head("/fonts/{fontstack}/{start}-{end}.{ext}")]
+pub async fn redirect_font_ext(path: Path<FontExtRequest>) -> HttpResponse {
+    static WARNING: DebouncedWarning = DebouncedWarning::new();
+    let FontExtRequest {
+        fontstack,
+        start,
+        end,
+        ext,
+    } = path.as_ref();
+
+    WARNING
+        .once_per_hour(|| {
+            warn!(
+                "Request to /font/{fontstack}/{start}-{end}.{ext} caused unnecessary redirect. Use /font/{fontstack}/{start}-{end} to avoid extra round-trip latency."
+            );
+        })
+        .await;
+
+    HttpResponse::MovedPermanently()
+        .insert_header((LOCATION, format!("/font/{fontstack}/{start}-{end}")))
         .finish()
 }
 

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -104,7 +104,6 @@ struct FontExtRequest {
 }
 
 /// Redirect `/font/{fontstack}/{start}-{end}.{extension}` to `/font/{fontstack}/{start}-{end}` (HTTP 301)
-/// Registered before the main font route to match the more specific pattern first
 #[routes]
 #[get("/font/{fontstack}/{start}-{end}.{ext}")]
 #[head("/font/{fontstack}/{start}-{end}.{ext}")]

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -165,7 +165,10 @@ fn register_services(
         .service(sprites::redirect_sprites_png);
 
     #[cfg(feature = "fonts")]
-    cfg.service(fonts::get_font).service(fonts::redirect_fonts);
+    // Register the glyph file-extension redirect BEFORE the main font route
+    cfg.service(fonts::redirect_font_ext)
+        .service(fonts::get_font)
+        .service(fonts::redirect_fonts);
 
     #[cfg(feature = "styles")]
     cfg.service(styles::get_style_json)


### PR DESCRIPTION
Closes #1443

`/font/{fontstack}/{start}-{end}.pbf` answered 404, and so did the plural form. OpenMapTiles styles write their glyph URL as `{fontstack}/{range}.pbf`, so pointing one at Martin failed until the suffix was removed by hand. Both forms now redirect to the canonical URL with the same once-an-hour warning the tile extension redirect logs.
