### PR TITLE
refactor(config): resolve the process config once, into ResolvedProcess

### DIFF
--- a/martin/benches/sources.rs
+++ b/martin/benches/sources.rs
@@ -1,7 +1,7 @@
 use criterion::async_executor::FuturesExecutor;
 use criterion::{Criterion, criterion_group, criterion_main};
 use martin::TileSourceManager;
-use martin::config::file::{OnInvalid, ProcessConfig};
+use martin::config::file::{OnInvalid, ResolvedProcess};
 use martin::srv::{DynTileSource, TileRequestHeaders};
 use martin_core::tiles::NO_TILE_CACHE;
 use martin_tile_utils::TileCoord;
@@ -142,7 +142,7 @@ fn bench_null_source(c: &mut Criterion) {
         OnInvalid::Abort,
         vec![vec![(
             Box::new(sources::NullSource::new()),
-            ProcessConfig::default(),
+            ResolvedProcess::default(),
         )]],
     );
     c.bench_function("get_table_source_tile", |b| {
@@ -162,7 +162,7 @@ fn bench_error_source(c: &mut Criterion) {
         OnInvalid::Abort,
         vec![vec![(
             Box::new(sources::ErrorSource::new()),
-            ProcessConfig::default(),
+            ResolvedProcess::default(),
         )]],
     );
     c.bench_function("get_table_source_error", |b| {

--- a/martin/src/bin/martin-cp.rs
+++ b/martin/src/bin/martin-cp.rs
@@ -35,7 +35,7 @@ use martin::config::args::{Args, ArgsError, ExtraArgs, MetaArgs, SrvArgs};
     feature = "postgres"
 ))]
 use martin::config::file::reload::TileReloaders;
-use martin::config::file::{Config, ProcessConfig, ServerState, read_config};
+use martin::config::file::{Config, ResolvedProcess, ServerState, read_config};
 #[cfg(feature = "_tiles")]
 use martin::config::primitives::IdResolver;
 use martin::config::primitives::env::OsEnv;
@@ -653,7 +653,7 @@ fn parse_encoding(encoding: &str) -> MartinCpResult<AcceptEncoding> {
 async fn init_schema(
     mbt: &Mbtiles,
     conn: &mut SqliteConnection,
-    sources: &[(BoxedSource, ProcessConfig)],
+    sources: &[(BoxedSource, ResolvedProcess)],
     tile_info: TileInfo,
     args: &CopyArgs,
 ) -> MartinCpResult<MbtType> {
@@ -730,7 +730,7 @@ mod tests {
     use async_trait::async_trait;
     use insta::assert_yaml_snapshot;
     use martin::TileSourceManager;
-    use martin::config::file::{OnInvalid, ProcessConfig, ServerState};
+    use martin::config::file::{OnInvalid, ResolvedProcess, ServerState};
     use martin_core::CacheZoomRange;
     use martin_core::tiles::{MartinCoreResult, Source, UrlQuery};
     use martin_tile_utils::{Encoding, Format};
@@ -789,7 +789,7 @@ mod tests {
             .into_iter()
             .map(|s| {
                 s.into_iter()
-                    .map(|s| (s, ProcessConfig::default()))
+                    .map(|s| (s, ResolvedProcess::default()))
                     .collect()
             })
             .collect();

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -53,7 +53,16 @@ use crate::config::file::FileConfigSrc;
 #[cfg(any(feature = "_tiles", feature = "sprites", feature = "fonts"))]
 use crate::config::file::cache::{CacheConfig, SubCacheSetting};
 #[cfg(feature = "_tiles")]
+#[cfg(any(
+    feature = "pmtiles",
+    feature = "mbtiles",
+    feature = "passthrough",
+    feature = "unstable-cog",
+    feature = "geojson"
+))]
 use crate::config::file::process::ProcessConfig;
+#[cfg(feature = "_tiles")]
+use crate::config::file::process::ResolvedProcess;
 #[cfg(any(
     feature = "pmtiles",
     feature = "mbtiles",
@@ -121,51 +130,16 @@ impl Config {
         #[cfg(feature = "fonts")]
         self.fonts.finalize().await?;
 
-        #[cfg(all(feature = "hillshade", feature = "_tiles"))]
-        self.validate_hillshade()?;
-
-        #[cfg(all(feature = "contour", feature = "_tiles"))]
-        self.validate_contour()?;
+        // Resolving every source's process settings range-checks them; the map itself is
+        // rebuilt by `resolve()`.
+        #[cfg(feature = "_tiles")]
+        self.resolved_process_map()?;
 
         if self.has_no_sources() {
             Err(ConfigFileError::NoSources.into())
         } else {
             Ok(())
         }
-    }
-
-    /// Range-checks every configured hillshade, naming the source at fault.
-    #[cfg(all(feature = "hillshade", feature = "_tiles"))]
-    fn validate_hillshade(&self) -> StartupResult<()> {
-        for (source_id, pc) in self.build_process_config_map() {
-            if let Some(config) = &pc.convert_to_hillshade
-                && let Err(e) = config.resolve_hillshade()
-            {
-                return Err(ConfigFileError::InvalidHillshade {
-                    source_id,
-                    source: Box::new(e),
-                }
-                .into());
-            }
-        }
-        Ok(())
-    }
-
-    /// Range-checks every configured contour, naming the source at fault.
-    #[cfg(all(feature = "contour", feature = "_tiles"))]
-    fn validate_contour(&self) -> StartupResult<()> {
-        for (source_id, pc) in self.build_process_config_map() {
-            if let Some(config) = &pc.convert_to_contour
-                && let Err(e) = config.resolve_contour()
-            {
-                return Err(ConfigFileError::InvalidContour {
-                    source_id,
-                    source: Box::new(e),
-                }
-                .into());
-            }
-        }
-        Ok(())
     }
 
     /// Returns `true` when no source of any enabled kind has been configured.
@@ -245,18 +219,14 @@ impl Config {
 
         #[cfg(feature = "_tiles")]
         let tile_sources_with_process = {
-            let process_map = self.build_process_config_map();
-            let global_process = ProcessConfig::default();
+            let process_map = self.resolved_process_map()?;
             tile_sources
                 .into_iter()
                 .map(|group| {
                     group
                         .into_iter()
                         .map(|src| {
-                            let pc = process_map
-                                .get(src.get_id())
-                                .cloned()
-                                .unwrap_or_else(|| global_process.clone());
+                            let pc = process_map.get(src.get_id()).cloned().unwrap_or_default();
                             (src, pc)
                         })
                         .collect::<Vec<_>>()
@@ -508,11 +478,11 @@ impl Config {
         }
     }
 
-    /// Build a map from source ID -> resolved [`ProcessConfig`].
+    /// Source ID -> what it is served with, every level folded and range-checked.
     ///
     /// Uses full-override semantics: per-source > source-type > global > default.
     #[cfg(feature = "_tiles")]
-    fn build_process_config_map(&self) -> HashMap<String, ProcessConfig> {
+    fn resolved_process_map(&self) -> StartupResult<HashMap<String, ResolvedProcess>> {
         #[allow(unused_mut)]
         let mut map = HashMap::new();
 
@@ -527,34 +497,38 @@ impl Config {
             let global = self.global_process_config();
 
             #[cfg(all(feature = "pmtiles", feature = "mlt"))]
-            Self::insert_file_source_configs(&mut map, &global, &self.pmtiles, |c| ProcessConfig {
-                convert_to_mlt: c.convert_to_mlt.clone(),
-                convert_to_mvt: c.convert_to_mvt.clone(),
-                cache_control: None,
-                #[cfg(feature = "hillshade")]
-                convert_to_hillshade: None,
-                #[cfg(feature = "contour")]
-                convert_to_contour: None,
-            });
+            Self::insert_file_source_configs(&mut map, &global, &self.pmtiles, |c| {
+                ProcessConfig {
+                    convert_to_mlt: c.convert_to_mlt.clone(),
+                    convert_to_mvt: c.convert_to_mvt.clone(),
+                    cache_control: None,
+                    #[cfg(feature = "hillshade")]
+                    convert_to_hillshade: None,
+                    #[cfg(feature = "contour")]
+                    convert_to_contour: None,
+                }
+            })?;
             #[cfg(all(feature = "pmtiles", not(feature = "mlt")))]
             Self::insert_file_source_configs(&mut map, &global, &self.pmtiles, |_| {
                 ProcessConfig::default()
-            });
+            })?;
 
             #[cfg(all(feature = "mbtiles", feature = "mlt"))]
-            Self::insert_file_source_configs(&mut map, &global, &self.mbtiles, |c| ProcessConfig {
-                convert_to_mlt: c.convert_to_mlt.clone(),
-                convert_to_mvt: c.convert_to_mvt.clone(),
-                cache_control: None,
-                #[cfg(feature = "hillshade")]
-                convert_to_hillshade: None,
-                #[cfg(feature = "contour")]
-                convert_to_contour: None,
-            });
+            Self::insert_file_source_configs(&mut map, &global, &self.mbtiles, |c| {
+                ProcessConfig {
+                    convert_to_mlt: c.convert_to_mlt.clone(),
+                    convert_to_mvt: c.convert_to_mvt.clone(),
+                    cache_control: None,
+                    #[cfg(feature = "hillshade")]
+                    convert_to_hillshade: None,
+                    #[cfg(feature = "contour")]
+                    convert_to_contour: None,
+                }
+            })?;
             #[cfg(all(feature = "mbtiles", not(feature = "mlt")))]
             Self::insert_file_source_configs(&mut map, &global, &self.mbtiles, |_| {
                 ProcessConfig::default()
-            });
+            })?;
 
             // COG and GeoJSON have no kind-level conversion settings.
             // COG cannot be hillshaded either: shading reads Mapzen *normal* tiles, whose surface
@@ -563,12 +537,12 @@ impl Config {
             #[cfg(feature = "unstable-cog")]
             Self::insert_file_source_configs(&mut map, &global, &self.cog, |_| {
                 ProcessConfig::default()
-            });
+            })?;
 
             #[cfg(feature = "geojson")]
             Self::insert_file_source_configs(&mut map, &global, &self.geojson, |_| {
                 ProcessConfig::default()
-            });
+            })?;
 
             #[cfg(feature = "passthrough")]
             if let Some(sources) = &self.passthrough.sources {
@@ -600,14 +574,14 @@ impl Config {
                         },
                         PassthroughSrc::Shorthand(_) => ProcessConfig::default(),
                     }
-                });
+                })?;
             }
         }
 
-        map
+        Ok(map)
     }
 
-    /// Resolve and insert the effective [`ProcessConfig`] for each source in a map, layering
+    /// Resolve and insert the effective [`ResolvedProcess`] for each source in a map, layering
     /// per-source settings over the source-type and global defaults.
     #[cfg(any(
         feature = "pmtiles",
@@ -617,20 +591,19 @@ impl Config {
         feature = "geojson"
     ))]
     fn insert_source_configs<'a, S: 'a>(
-        map: &mut HashMap<String, ProcessConfig>,
+        map: &mut HashMap<String, ResolvedProcess>,
         global: &ProcessConfig,
         source_type: &ProcessConfig,
         sources: impl IntoIterator<Item = (&'a String, &'a S)>,
         get_per_source_pc: impl Fn(&S) -> ProcessConfig,
-    ) {
-        use crate::config::file::process::resolve_process_config;
-
+    ) -> StartupResult<()> {
         for (id, src) in sources {
-            map.insert(
-                id.clone(),
-                resolve_process_config(global, source_type, &get_per_source_pc(src)),
-            );
+            let resolved = ProcessConfig::layered(global, source_type, &get_per_source_pc(src))
+                .resolve()
+                .map_err(|e| e.for_source(id.clone()))?;
+            map.insert(id.clone(), resolved);
         }
+        Ok(())
     }
 
     /// Helper to resolve process configs for file-based source types.
@@ -641,11 +614,11 @@ impl Config {
         feature = "geojson"
     ))]
     fn insert_file_source_configs<T: ConfigurationLivecycleHooks>(
-        map: &mut HashMap<String, ProcessConfig>,
+        map: &mut HashMap<String, ResolvedProcess>,
         global: &ProcessConfig,
         file_cfg: &FileConfigEnum<T>,
         get_source_type_pc: impl Fn(&T) -> ProcessConfig,
-    ) {
+    ) -> StartupResult<()> {
         if let FileConfigEnum::Config(cfg) = file_cfg {
             let source_type = get_source_type_pc(&cfg.custom);
             if let Some(sources) = &cfg.sources {
@@ -662,9 +635,10 @@ impl Config {
                         convert_to_contour: obj.convert_to_contour.clone(),
                     },
                     FileConfigSrc::Path(_) => ProcessConfig::default(),
-                });
+                })?;
             }
         }
+        Ok(())
     }
 
     /// A copy of this config whose sections carry the sources currently in the catalog:

--- a/martin/src/config/file/mod.rs
+++ b/martin/src/config/file/mod.rs
@@ -31,11 +31,13 @@ pub use hillshade::{
 };
 
 pub mod process;
-pub use process::ProcessConfig;
 #[cfg(any(feature = "postgres", feature = "_file_kinds"))]
-pub(crate) use process::resolve_process_config;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
-pub use process::{MltEncoderConfig, MltProcessConfig, MvtEncoderConfig, MvtProcessConfig};
+pub use process::{
+    MltConversion, MltEncoderConfig, MltProcessConfig, MvtConversion, MvtEncoderConfig,
+    MvtProcessConfig,
+};
+pub use process::{ProcessConfig, ProcessResolveError, ResolvedProcess};
 
 #[cfg(any(feature = "fonts", feature = "sprites", feature = "styles"))]
 mod resources;

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -11,17 +11,23 @@ use tilejson::TileJSON;
 #[cfg(all(feature = "contour", feature = "_tiles"))]
 use tilejson::VectorLayer;
 
-use crate::config::file::CacheControlHeader;
 #[cfg(all(feature = "contour", feature = "_tiles"))]
-use crate::config::file::contour::{ContourProcessConfig, ResolvedContour};
+use crate::config::file::contour::{ContourProcessConfig, ContourRangeError, ResolvedContour};
 #[cfg(all(feature = "hillshade", feature = "_tiles"))]
-use crate::config::file::hillshade::HillshadeProcessConfig;
+use crate::config::file::hillshade::{
+    HillshadeProcessConfig, HillshadeRangeError, ResolvedHillshade,
+};
+use crate::config::file::{CacheControlHeader, ConfigFileError};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{CollectUnrecognizedKeys, UnrecognizedKeys, UnrecognizedValues};
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::primitives::AutoOption;
 
-/// Internal carrier for resolved per-source serving settings.
+/// One level of serving settings as written in the config, global, source-type or per-source.
+///
+/// Every field is `None` until that level sets it.
+/// Levels fold together with [`layered`](Self::layered) and become a [`ResolvedProcess`] through [`resolve`](Self::resolve).
+/// Nothing past `Config::finalize` reads this type.
 ///
 /// Not serialized directly - config files use `convert_to_mlt` / `convert_to_mvt` /
 /// `cache_control`.
@@ -41,22 +47,173 @@ pub struct ProcessConfig {
 }
 
 impl ProcessConfig {
-    #[cfg(all(feature = "contour", feature = "_tiles"))]
-    fn is_contoured(&self) -> bool {
-        self.convert_to_contour
-            .as_ref()
-            .is_some_and(ContourProcessConfig::is_enabled)
+    /// Folds the three levels into one, per-source over source-type over global.
+    ///
+    /// The `convert_to_mlt`/`convert_to_mvt` pair overrides as a unit, `cache_control` resolves on
+    /// its own, and `convert_to_hillshade`/`convert_to_contour` are per-source only.
+    #[must_use]
+    pub fn layered(global: &Self, source_type: &Self, per_source: &Self) -> Self {
+        let cache_control = per_source
+            .cache_control
+            .clone()
+            .or_else(|| source_type.cache_control.clone())
+            .or_else(|| global.cache_control.clone());
+        #[cfg(all(feature = "mlt", feature = "_tiles"))]
+        let conversions = [per_source, source_type, global]
+            .into_iter()
+            .find(|pc| pc.convert_to_mlt.is_some() || pc.convert_to_mvt.is_some())
+            .unwrap_or(global);
+        Self {
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            convert_to_mlt: conversions.convert_to_mlt.clone(),
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            convert_to_mvt: conversions.convert_to_mvt.clone(),
+            cache_control,
+            #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+            convert_to_hillshade: per_source.convert_to_hillshade.clone(),
+            #[cfg(all(feature = "contour", feature = "_tiles"))]
+            convert_to_contour: per_source.convert_to_contour.clone(),
+        }
     }
 
-    /// The contour settings this source traces with, if any.
-    #[cfg(all(feature = "contour", feature = "_tiles"))]
-    fn resolved_contour(&self) -> Option<ResolvedContour> {
-        self.convert_to_contour
-            .as_ref()?
-            .resolve_contour()
-            .expect("contour settings are range-checked by Config::finalize")
+    /// Applies the defaults and range-checks the settings, once.
+    ///
+    /// # Errors
+    ///
+    /// A hillshade or contour parameter outside its range.
+    pub fn resolve(&self) -> Result<ResolvedProcess, ProcessResolveError> {
+        Ok(ResolvedProcess {
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            mlt: match &self.convert_to_mlt {
+                None | Some(MltProcessConfig::Auto) => {
+                    MltConversion::Encode(EncoderConfig::default())
+                }
+                Some(MltProcessConfig::Explicit(cfg)) => {
+                    MltConversion::Encode(EncoderConfig::from(cfg.clone()))
+                }
+                Some(MltProcessConfig::Disabled) => MltConversion::Disabled,
+            },
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            mvt: match &self.convert_to_mvt {
+                Some(MvtProcessConfig::Disabled) => MvtConversion::Disabled,
+                None | Some(MvtProcessConfig::Auto | MvtProcessConfig::Explicit(_)) => {
+                    MvtConversion::Encode
+                }
+            },
+            cache_control: self.cache_control.clone(),
+            #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+            hillshade: match &self.convert_to_hillshade {
+                None => None,
+                Some(config) => config.resolve_hillshade()?,
+            },
+            #[cfg(all(feature = "contour", feature = "_tiles"))]
+            contour: match &self.convert_to_contour {
+                None => None,
+                Some(config) => config.resolve_contour()?,
+            },
+        })
     }
+}
 
+/// A setting that did not survive [`ProcessConfig::resolve`].
+#[derive(Debug, thiserror::Error)]
+pub enum ProcessResolveError {
+    #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+    #[error(transparent)]
+    Hillshade(#[from] HillshadeRangeError),
+    #[cfg(all(feature = "contour", feature = "_tiles"))]
+    #[error(transparent)]
+    Contour(#[from] ContourRangeError),
+}
+
+impl ProcessResolveError {
+    /// The startup error naming the source at fault.
+    #[must_use]
+    #[cfg_attr(
+        not(any(
+            all(feature = "hillshade", feature = "_tiles"),
+            all(feature = "contour", feature = "_tiles")
+        )),
+        expect(
+            unused_variables,
+            reason = "nothing can fail to resolve without those features"
+        )
+    )]
+    pub fn for_source(self, source_id: String) -> ConfigFileError {
+        match self {
+            #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+            Self::Hillshade(source) => ConfigFileError::InvalidHillshade {
+                source_id,
+                source: Box::new(source),
+            },
+            #[cfg(all(feature = "contour", feature = "_tiles"))]
+            Self::Contour(source) => ConfigFileError::InvalidContour {
+                source_id,
+                source: Box::new(source),
+            },
+        }
+    }
+}
+
+/// Whether, and how, MVT tiles are re-encoded as MLT for clients that accept it.
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MltConversion {
+    /// Convert with these encoder settings.
+    Encode(EncoderConfig),
+    /// Serve the MVT bytes as they are.
+    Disabled,
+}
+
+/// Whether MLT tiles are decoded to MVT for clients that accept only that.
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MvtConversion {
+    /// Convert.
+    #[default]
+    Encode,
+    /// Serve the MLT bytes as they are.
+    Disabled,
+}
+
+/// What a source is served with, every config level folded together and range-checked.
+///
+/// The catalog and the tile pipeline only ever see this type.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedProcess {
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    pub mlt: MltConversion,
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    pub mvt: MvtConversion,
+    /// `Cache-Control` response header for this source.
+    /// `None` leaves the server-level default to the middleware.
+    pub cache_control: Option<CacheControlHeader>,
+    /// Kernel parameters when the source is hillshaded.
+    #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+    pub hillshade: Option<ResolvedHillshade>,
+    /// Tracer parameters when the source is contoured.
+    #[cfg(all(feature = "contour", feature = "_tiles"))]
+    pub contour: Option<ResolvedContour>,
+}
+
+impl Default for ResolvedProcess {
+    /// What a source gets when no level configures anything.
+    fn default() -> Self {
+        Self {
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            mlt: MltConversion::Encode(EncoderConfig::default()),
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            mvt: MvtConversion::Encode,
+            cache_control: None,
+            #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+            hillshade: None,
+            #[cfg(all(feature = "contour", feature = "_tiles"))]
+            contour: None,
+        }
+    }
+}
+
+impl ResolvedProcess {
     /// The [`TileInfo`] this source answers with once post-processing has run.
     ///
     /// Contouring replaces an elevation raster with a vector tile, so the format
@@ -65,7 +222,7 @@ impl ProcessConfig {
     #[must_use]
     pub fn advertised_tile_info(&self, source: TileInfo) -> TileInfo {
         #[cfg(all(feature = "contour", feature = "_tiles"))]
-        if self.is_contoured() {
+        if self.contour.is_some() {
             return TileInfo::new(Format::Mvt, Encoding::Uncompressed);
         }
         source
@@ -75,7 +232,7 @@ impl ProcessConfig {
     #[must_use]
     pub fn advertised_tilejson(&self, tilejson: TileJSON) -> TileJSON {
         #[cfg(all(feature = "contour", feature = "_tiles"))]
-        if let Some(settings) = self.resolved_contour() {
+        if let Some(settings) = &self.contour {
             let mut fields = std::collections::BTreeMap::new();
             fields.insert("ele".to_owned(), "Number".to_owned());
             fields.insert("major".to_owned(), "Boolean".to_owned());
@@ -202,39 +359,6 @@ impl From<MltEncoderConfig> for EncoderConfig {
             cfg = cfg.with_shared_dict(v);
         }
         cfg
-    }
-}
-
-/// Resolve the effective per-source config: per-source > source-type > global > default.
-///
-/// The `convert_to_mlt`/`convert_to_mvt` pair overrides as a unit, `cache_control` resolves on
-/// its own, and `convert_to_hillshade` is per-source only.
-#[must_use]
-pub fn resolve_process_config(
-    global: &ProcessConfig,
-    source_type: &ProcessConfig,
-    per_source: &ProcessConfig,
-) -> ProcessConfig {
-    let cache_control = per_source
-        .cache_control
-        .clone()
-        .or_else(|| source_type.cache_control.clone())
-        .or_else(|| global.cache_control.clone());
-    #[cfg(all(feature = "mlt", feature = "_tiles"))]
-    let conversions = [per_source, source_type, global]
-        .into_iter()
-        .find(|pc| pc.convert_to_mlt.is_some() || pc.convert_to_mvt.is_some())
-        .unwrap_or(global);
-    ProcessConfig {
-        #[cfg(all(feature = "mlt", feature = "_tiles"))]
-        convert_to_mlt: conversions.convert_to_mlt.clone(),
-        #[cfg(all(feature = "mlt", feature = "_tiles"))]
-        convert_to_mvt: conversions.convert_to_mvt.clone(),
-        cache_control,
-        #[cfg(all(feature = "hillshade", feature = "_tiles"))]
-        convert_to_hillshade: per_source.convert_to_hillshade.clone(),
-        #[cfg(all(feature = "contour", feature = "_tiles"))]
-        convert_to_contour: per_source.convert_to_contour.clone(),
     }
 }
 
@@ -406,7 +530,7 @@ mod tests {
             #[cfg(all(feature = "contour", feature = "_tiles"))]
             convert_to_contour: None,
         };
-        let resolved = resolve_process_config(&global, &ProcessConfig::default(), &per_source);
+        let resolved = ProcessConfig::layered(&global, &ProcessConfig::default(), &per_source);
         assert_eq!(resolved.convert_to_mlt, Some(MltProcessConfig::Disabled));
     }
 
@@ -441,7 +565,7 @@ mod tests {
             convert_to_contour: None,
         };
 
-        let resolved = resolve_process_config(&global, &source_type, &per_source);
+        let resolved = ProcessConfig::layered(&global, &source_type, &per_source);
         assert_eq!(resolved, per_source);
     }
 
@@ -465,7 +589,7 @@ mod tests {
             convert_to_contour: None,
         };
 
-        let resolved = resolve_process_config(&global, &source_type, &ProcessConfig::default());
+        let resolved = ProcessConfig::layered(&global, &source_type, &ProcessConfig::default());
         assert_eq!(resolved, source_type);
     }
 
@@ -481,7 +605,7 @@ mod tests {
             convert_to_contour: None,
         };
 
-        let resolved = resolve_process_config(
+        let resolved = ProcessConfig::layered(
             &global,
             &ProcessConfig::default(),
             &ProcessConfig::default(),
@@ -511,7 +635,7 @@ mod tests {
     fn resolve_per_source_cache_control_wins() {
         let source_type = only_cache_control("public, max-age=60");
         let per_source = only_cache_control("no-store");
-        let resolved = resolve_process_config(&ProcessConfig::default(), &source_type, &per_source);
+        let resolved = ProcessConfig::layered(&ProcessConfig::default(), &source_type, &per_source);
         assert_eq!(resolved.cache_control, Some(cache_control("no-store")));
     }
 
@@ -527,14 +651,14 @@ mod tests {
             convert_to_mlt: Some(MltProcessConfig::Auto),
             ..Default::default()
         };
-        let resolved = resolve_process_config(&ProcessConfig::default(), &source_type, &per_source);
+        let resolved = ProcessConfig::layered(&ProcessConfig::default(), &source_type, &per_source);
         assert_eq!(resolved.convert_to_mlt, Some(MltProcessConfig::Auto));
         assert_eq!(
             resolved.cache_control,
             Some(cache_control("public, max-age=60"))
         );
 
-        let resolved = resolve_process_config(
+        let resolved = ProcessConfig::layered(
             &ProcessConfig::default(),
             &source_type,
             &only_cache_control("no-store"),
@@ -545,7 +669,7 @@ mod tests {
 
     #[test]
     fn resolve_default_when_all_none() {
-        let resolved = resolve_process_config(
+        let resolved = ProcessConfig::layered(
             &ProcessConfig::default(),
             &ProcessConfig::default(),
             &ProcessConfig::default(),
@@ -691,5 +815,32 @@ mod tests {
             saw_encoder_ref,
             "expected $ref to MltEncoderConfig: {schema}"
         );
+    }
+
+    #[test]
+    fn resolve_of_nothing_configured_is_the_default() {
+        assert_eq!(
+            ProcessConfig::default().resolve().unwrap(),
+            ResolvedProcess::default()
+        );
+    }
+
+    #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+    #[test]
+    fn resolve_range_checks_the_hillshade() {
+        use crate::config::file::hillshade::{HillshadeProcessConfig, HillshadeSettings};
+
+        let out_of_range = ProcessConfig {
+            convert_to_hillshade: Some(HillshadeProcessConfig::Explicit(HillshadeSettings {
+                azimuth: Some(400.0),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let err = out_of_range
+            .resolve()
+            .unwrap_err()
+            .for_source("dem".to_owned());
+        insta::assert_snapshot!(err, @"Source dem has an invalid hillshade configuration: Hillshade parameter azimuth must be between `0` and `360`, but was `400`");
     }
 }

--- a/martin/src/config/file/tiles/discovery/discovery_trait.rs
+++ b/martin/src/config/file/tiles/discovery/discovery_trait.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use martin_core::tiles::BoxedSource;
 
-use crate::config::file::{ProcessConfig, SourceBuildResult, TileSourceWarning};
+use crate::config::file::{ResolvedProcess, SourceBuildResult, TileSourceWarning};
 use crate::reload::SourceProvenance;
 
 /// Per-Source change-detection value. `Opaque` sources only diff on presence, never update.
@@ -40,7 +40,7 @@ pub struct BuiltSource {
     /// What `--save-config` needs to write the source back to a config file.
     pub provenance: Option<SourceProvenance>,
     /// Per-source override of the kind's [`Discovery::process`], if the source configures one.
-    pub process: Option<ProcessConfig>,
+    pub process: Option<ResolvedProcess>,
 }
 
 impl From<BoxedSource> for BuiltSource {
@@ -68,8 +68,8 @@ pub trait Discovery: Send + Sync + 'static {
         args: &Self::Args,
     ) -> impl Future<Output = SourceBuildResult<BuiltSource>> + Send;
 
-    /// `ProcessConfig` stamped onto every source this kind emits.
-    fn process(&self) -> ProcessConfig;
+    /// `ResolvedProcess` stamped onto every source this kind emits.
+    fn process(&self) -> ResolvedProcess;
 
     /// Findings from constructing this discovery, reported once through `init()`.
     fn construction_warnings(&self) -> Vec<TileSourceWarning> {

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -12,8 +12,8 @@ use tokio::fs::{self, DirEntry};
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{
-    CachePolicy, FileConfigEnum, FileConfigSrc, ProcessConfig, SourceBuildError, SourceBuildResult,
-    TileSourceWarning,
+    CachePolicy, FileConfigEnum, FileConfigSrc, ProcessConfig, ResolvedProcess, SourceBuildError,
+    SourceBuildResult, TileSourceWarning,
 };
 use crate::config::primitives::{IdResolver, OptOneMany};
 use crate::reload::{FileKind, SourceProvenance};
@@ -37,7 +37,8 @@ pub type FsSourceBuilder = Box<dyn Fn(String, PathBuf, CachePolicy) -> BuildFutu
 /// same canonical path keeps its policy and per-source process settings.
 struct ConfiguredSource {
     policy: CachePolicy,
-    /// Per-source `convert_to_*` / `cache_control` override, already resolved against the kind level.
+    /// Per-source `convert_to_*` / `cache_control` override layered over the kind level.
+    /// Resolved when the source is built so a bad parameter fails that source alone.
     process: Option<ProcessConfig>,
     /// The entry as configured, preserved verbatim for `--save-config`.
     src: FileConfigSrc,
@@ -52,7 +53,8 @@ pub struct FsDiscovery {
     /// Canonical path -> configured entry for explicitly-configured sources.
     configured: BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: IdResolver,
-    process: ProcessConfig,
+    /// The kind level, resolved once for every source without its own override.
+    process: ResolvedProcess,
     build: FsSourceBuilder,
     /// Configured directories that could not be read at construction.
     warnings: Vec<TileSourceWarning>,
@@ -66,7 +68,7 @@ impl FsDiscovery {
         config: &FileConfigEnum<C>,
         extensions: &'static [&'static str],
         id_resolver: IdResolver,
-        process: ProcessConfig,
+        process: &ProcessConfig,
         build: FsSourceBuilder,
     ) -> Self {
         let mut directories: Vec<PathBuf> = vec![];
@@ -89,7 +91,7 @@ impl FsDiscovery {
                     canonical,
                     ConfiguredSource {
                         policy: src.cache_zoom(),
-                        process: per_source_process(&process, src),
+                        process: per_source_process(process, src),
                         src: src.clone(),
                     },
                 );
@@ -137,7 +139,9 @@ impl FsDiscovery {
             extensions,
             configured,
             id_resolver,
-            process,
+            process: process
+                .resolve()
+                .expect("the kind level carries no range-checked settings"),
             build,
             warnings,
         }
@@ -172,10 +176,8 @@ impl FsDiscovery {
     }
 }
 
-/// Per-source `convert_to_*` and `cache_control` settings override the kind-level [`ProcessConfig`].
+/// Per-source `convert_to_*` and `cache_control` settings layered over the kind-level [`ProcessConfig`].
 fn per_source_process(kind_level: &ProcessConfig, src: &FileConfigSrc) -> Option<ProcessConfig> {
-    use crate::config::file::resolve_process_config;
-
     let FileConfigSrc::Obj(obj) = src else {
         return None;
     };
@@ -193,7 +195,7 @@ fn per_source_process(kind_level: &ProcessConfig, src: &FileConfigSrc) -> Option
     if per_source == ProcessConfig::default() {
         return None;
     }
-    Some(resolve_process_config(
+    Some(ProcessConfig::layered(
         kind_level,
         &ProcessConfig::default(),
         &per_source,
@@ -227,7 +229,9 @@ impl Discovery for FsDiscovery {
         let process = self
             .configured
             .get(&args.0)
-            .and_then(|cfg| cfg.process.clone());
+            .and_then(|cfg| cfg.process.as_ref())
+            .map(|pc| pc.resolve().map_err(|e| e.for_source(id.to_owned())))
+            .transpose()?;
         Ok(BuiltSource {
             source,
             process,
@@ -238,7 +242,7 @@ impl Discovery for FsDiscovery {
         })
     }
 
-    fn process(&self) -> ProcessConfig {
+    fn process(&self) -> ResolvedProcess {
         self.process.clone()
     }
 
@@ -428,7 +432,7 @@ mod tests {
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             unreachable_builder(),
         );
 
@@ -457,7 +461,7 @@ mod tests {
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             fake_builder(),
         );
         let catalog = TileSourceManager::new(None, OnInvalid::Warn);
@@ -483,7 +487,7 @@ mod tests {
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             fake_builder(),
         );
         let catalog = TileSourceManager::new(None, OnInvalid::Abort);
@@ -545,7 +549,7 @@ mod tests {
             &config,
             &["mbtiles"],
             IdResolver::new(&[]),
-            kind_level,
+            &kind_level,
             unreachable_builder(),
         );
 
@@ -600,7 +604,7 @@ mod tests {
             &config,
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             unreachable_builder(),
         );
 
@@ -634,7 +638,7 @@ mod tests {
             ]),
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             fake_builder(),
         );
         std::fs::set_permissions(unreadable.path(), std::fs::Permissions::from_mode(0o755))
@@ -671,7 +675,7 @@ mod tests {
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
             &["mbtiles"],
             IdResolver::new(&[]),
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             unreachable_builder(),
         );
 

--- a/martin/src/config/file/tiles/discovery/object_store.rs
+++ b/martin/src/config/file/tiles/discovery/object_store.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::config::file::file_config::is_remote_url;
 use crate::config::file::pmtiles::PmtConfig;
-use crate::config::file::process::ProcessConfig;
+use crate::config::file::process::{ProcessConfig, ResolvedProcess};
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{
     CachePolicy, ConfigFileError, FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _,
@@ -24,7 +24,8 @@ pub struct ObjectStoreDiscovery {
     remote_prefixes: Vec<Url>,
     id_resolver: IdResolver,
     config: PmtConfig,
-    process: ProcessConfig,
+    /// The kind level, which every remote prefix serves with.
+    process: ResolvedProcess,
 }
 
 impl ObjectStoreDiscovery {
@@ -33,7 +34,7 @@ impl ObjectStoreDiscovery {
     pub fn from_config(
         config: &FileConfigEnum<PmtConfig>,
         id_resolver: IdResolver,
-        process: ProcessConfig,
+        process: &ProcessConfig,
     ) -> Self {
         let mut remote_prefixes: Vec<Url> = vec![];
         let mut collect = |path: &PathBuf| {
@@ -75,7 +76,9 @@ impl ObjectStoreDiscovery {
             remote_prefixes,
             id_resolver,
             config: pmt_config,
-            process,
+            process: process
+                .resolve()
+                .expect("the kind level carries no range-checked settings"),
         }
     }
 
@@ -122,7 +125,7 @@ impl Discovery for ObjectStoreDiscovery {
             .map(Into::into)
     }
 
-    fn process(&self) -> ProcessConfig {
+    fn process(&self) -> ResolvedProcess {
         self.process.clone()
     }
 }

--- a/martin/src/config/file/tiles/discovery/postgres.rs
+++ b/martin/src/config/file/tiles/discovery/postgres.rs
@@ -6,7 +6,10 @@ use tokio::sync::OnceCell;
 
 use crate::config::file::postgres::{PostgresAutoDiscoveryBuilder, PostgresConfig, SourceSpec};
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
-use crate::config::file::{CachePolicy, ProcessConfig, SourceBuildError, SourceBuildResult};
+use crate::config::file::{
+    CachePolicy, ProcessConfig, ProcessResolveError, ResolvedProcess, SourceBuildError,
+    SourceBuildResult,
+};
 use crate::config::primitives::IdResolver;
 use crate::reload::SourceProvenance;
 
@@ -19,7 +22,10 @@ pub struct PostgresDiscovery {
     config: PostgresConfig,
     id_resolver: IdResolver,
     default_cache: CachePolicy,
+    /// The connection level, which per-source settings layer over.
     process: ProcessConfig,
+    /// The connection level resolved, for every source without its own settings.
+    resolved: ResolvedProcess,
     builder: OnceCell<PostgresAutoDiscoveryBuilder>,
 }
 
@@ -36,6 +42,9 @@ impl PostgresDiscovery {
             config,
             id_resolver,
             default_cache,
+            resolved: process
+                .resolve()
+                .expect("the connection level carries no range-checked settings"),
             process,
             builder: OnceCell::new(),
         }
@@ -95,7 +104,10 @@ impl Discovery for PostgresDiscovery {
         log_published(id, &spec);
         Ok(BuiltSource {
             source,
-            process: Some(per_source_process(&self.process, &spec)),
+            process: Some(
+                per_source_process(&self.process, &spec)
+                    .map_err(|e| e.for_source(id.to_owned()))?,
+            ),
             provenance: Some(SourceProvenance::Postgres {
                 connection_string: self
                     .config
@@ -107,15 +119,16 @@ impl Discovery for PostgresDiscovery {
         })
     }
 
-    fn process(&self) -> ProcessConfig {
-        self.process.clone()
+    fn process(&self) -> ResolvedProcess {
+        self.resolved.clone()
     }
 }
 
-/// Per-source `convert_to_*` and `cache_control` settings override the connection-level [`ProcessConfig`].
-fn per_source_process(connection: &ProcessConfig, spec: &SourceSpec) -> ProcessConfig {
-    use crate::config::file::resolve_process_config;
-
+/// Per-source `convert_to_*` and `cache_control` settings layered over the connection level.
+fn per_source_process(
+    connection: &ProcessConfig,
+    spec: &SourceSpec,
+) -> Result<ResolvedProcess, ProcessResolveError> {
     let per_source = match spec {
         SourceSpec::Table(info) => ProcessConfig {
             #[cfg(all(feature = "mlt", feature = "_tiles"))]
@@ -140,7 +153,7 @@ fn per_source_process(connection: &ProcessConfig, spec: &SourceSpec) -> ProcessC
             convert_to_contour: None,
         },
     };
-    resolve_process_config(connection, &ProcessConfig::default(), &per_source)
+    ProcessConfig::layered(connection, &ProcessConfig::default(), &per_source).resolve()
 }
 
 fn log_published(id: &str, spec: &SourceSpec) {
@@ -325,10 +338,12 @@ mod tests {
     #[test]
     fn per_source_convert_overrides_the_connection_level() {
         use crate::config::file::postgres::TableInfo;
+        use crate::config::file::process::MltConversion;
         use crate::config::primitives::AutoOption;
         let connection = ProcessConfig {
             convert_to_mlt: Some(AutoOption::Auto),
             convert_to_mvt: None,
+            cache_control: None,
             #[cfg(feature = "hillshade")]
             convert_to_hillshade: None,
             #[cfg(feature = "contour")]
@@ -340,15 +355,15 @@ mod tests {
             ..TableInfo::default()
         });
         assert_eq!(
-            per_source_process(&connection, &with_override).convert_to_mlt,
-            Some(AutoOption::Disabled),
+            per_source_process(&connection, &with_override).unwrap().mlt,
+            MltConversion::Disabled,
             "a per-table convert_to_mlt must win over the connection-level setting"
         );
 
         let without_override = SourceSpec::Table(TableInfo::default());
         assert_eq!(
-            per_source_process(&connection, &without_override),
-            connection,
+            per_source_process(&connection, &without_override).unwrap(),
+            connection.resolve().unwrap(),
             "a table without overrides must inherit the connection-level setting"
         );
     }

--- a/martin/src/config/file/tiles/driver/reconcile.rs
+++ b/martin/src/config/file/tiles/driver/reconcile.rs
@@ -165,7 +165,7 @@ mod tests {
     use tilejson::{TileJSON, tilejson};
 
     use super::*;
-    use crate::config::file::ProcessConfig;
+    use crate::config::file::ResolvedProcess;
     use crate::config::file::tiles::discovery::Discovered;
 
     /// A minimal in-memory [`Source`] returning a fixed tile; used to populate advisories.
@@ -281,8 +281,8 @@ mod tests {
             std::future::ready(Ok(source.into()))
         }
 
-        fn process(&self) -> ProcessConfig {
-            ProcessConfig::default()
+        fn process(&self) -> ResolvedProcess {
+            ResolvedProcess::default()
         }
     }
 

--- a/martin/src/config/file/tiles/passthrough.rs
+++ b/martin/src/config/file/tiles/passthrough.rs
@@ -102,7 +102,7 @@ impl PassthroughConfig {
     /// [`TileSourceWarning`]s so one bad upstream does not abort the others.
     ///
     /// The `sources` map is rewritten so its keys become the [`IdResolver`]-assigned source ids,
-    /// matching what [`build_process_config_map`](crate::config::file::Config) later keys on.
+    /// matching what [`resolved_process_map`](crate::config::file::Config) later keys on.
     pub async fn resolve(
         &mut self,
         idr: &IdResolver,

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -35,7 +35,7 @@ impl CogReloader {
             config,
             &["tif", "tiff"],
             id_resolver,
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             build,
         );
         Self {

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -38,7 +38,7 @@ impl GeoJsonReloader {
             config,
             &["json", "geojson"],
             id_resolver,
-            ProcessConfig::default(),
+            &ProcessConfig::default(),
             build,
         );
         Self {

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -4,8 +4,6 @@ use martin_core::tiles::mbtiles::MbtSource;
 use crate::TileSourceManager;
 use crate::config::file::mbtiles::MbtConfig;
 use crate::config::file::process::ProcessConfig;
-#[cfg(feature = "_process")]
-use crate::config::file::resolve_process_config;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
 use crate::config::file::{FileConfigEnum, SourceBuildResult, TileSourceWarning};
@@ -44,7 +42,7 @@ impl MbtilesReloader {
                     ProcessConfig::default()
                 }
             };
-            resolve_process_config(global_process, &source_type, &ProcessConfig::default())
+            ProcessConfig::layered(global_process, &source_type, &ProcessConfig::default())
         };
         #[cfg(not(feature = "_process"))]
         let process = {
@@ -68,7 +66,7 @@ impl MbtilesReloader {
             config,
             &["mbtiles"],
             id_resolver,
-            process,
+            &process,
             build,
         );
 

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -1,8 +1,6 @@
 use crate::TileSourceManager;
 use crate::config::file::pmtiles::PmtConfig;
 use crate::config::file::process::ProcessConfig;
-#[cfg(feature = "_process")]
-use crate::config::file::resolve_process_config;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder, ObjectStoreDiscovery};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, PollTrigger, ReloadDriver};
 use crate::config::file::{
@@ -45,7 +43,7 @@ impl PmtilesReloader {
                     ProcessConfig::default()
                 }
             };
-            resolve_process_config(global_process, &source_type, &ProcessConfig::default())
+            ProcessConfig::layered(global_process, &source_type, &ProcessConfig::default())
         };
         #[cfg(not(feature = "_process"))]
         let process = {
@@ -73,10 +71,10 @@ impl PmtilesReloader {
             config,
             &[PMTILES_EXT],
             id_resolver.clone(),
-            process.clone(),
+            &process,
             build,
         );
-        let remote = ObjectStoreDiscovery::from_config(config, id_resolver, process);
+        let remote = ObjectStoreDiscovery::from_config(config, id_resolver, &process);
 
         Self {
             local: ReloadDriver::new(local, tsm.clone()),

--- a/martin/src/config/file/tiles/reload/postgres.rs
+++ b/martin/src/config/file/tiles/reload/postgres.rs
@@ -13,8 +13,6 @@ use crate::TileSourceManager;
 use crate::config::args::{BoundsCalcType, DEFAULT_BOUNDS_TIMEOUT};
 use crate::config::file::postgres::PostgresConfig;
 use crate::config::file::process::ProcessConfig;
-#[cfg(all(feature = "mlt", feature = "_tiles"))]
-use crate::config::file::resolve_process_config;
 use crate::config::file::tiles::discovery::PostgresDiscovery;
 use crate::config::file::tiles::driver::{Baseline, PollTrigger, ReloadDriver};
 use crate::config::file::{CachePolicy, SourceBuildResult, TileSourceWarning};
@@ -48,7 +46,7 @@ impl PostgresReloader {
                 convert_to_mvt: config.convert_to_mvt.clone(),
                 ..Default::default()
             };
-            resolve_process_config(global_process, &source_type, &ProcessConfig::default())
+            ProcessConfig::layered(global_process, &source_type, &ProcessConfig::default())
         };
         #[cfg(not(all(feature = "mlt", feature = "_tiles")))]
         let process = {

--- a/martin/src/reload.rs
+++ b/martin/src/reload.rs
@@ -8,7 +8,7 @@ use crate::config::file::FileConfigSrc;
 use crate::config::file::discovery::BuiltSource;
 #[cfg(feature = "postgres")]
 use crate::config::file::postgres::SourceSpec;
-use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ProcessConfig, SourceBuildResult};
+use crate::config::file::{MAX_CONCURRENT_SOURCE_INITS, ResolvedProcess, SourceBuildResult};
 
 /// Which config section a directory-discovered file serializes under.
 #[cfg(feature = "_file_kinds")]
@@ -50,7 +50,7 @@ pub struct NewSource {
     /// The tile source implementation, or an error if initialization failed.
     pub source: SourceBuildResult<BoxedSource>,
     /// Resolved process config for this source (per-source > source-type > global > default).
-    pub process: ProcessConfig,
+    pub process: ResolvedProcess,
     /// Retained by the catalog so `--save-config` can serialize what is actually served.
     pub provenance: Option<SourceProvenance>,
 }
@@ -58,7 +58,7 @@ pub struct NewSource {
 impl NewSource {
     /// `process` is the kind-level fallback; a per-source override carried by the
     /// [`BuiltSource`] wins over it.
-    fn new(id: String, built: SourceBuildResult<BuiltSource>, process: ProcessConfig) -> Self {
+    fn new(id: String, built: SourceBuildResult<BuiltSource>, process: ResolvedProcess) -> Self {
         match built {
             Ok(built) => Self {
                 id,
@@ -104,7 +104,7 @@ impl ReloadAdvisory {
         previous_ids: &BTreeSet<String>,
         next_ids: &BTreeSet<String>,
         initializer: F,
-        process: ProcessConfig,
+        process: ResolvedProcess,
     ) -> Self
     where
         F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
@@ -136,7 +136,7 @@ impl ReloadAdvisory {
         previous_map: &BTreeMap<String, V>,
         next_map: &BTreeMap<String, V>,
         initializer: F,
-        process: ProcessConfig,
+        process: ResolvedProcess,
     ) -> Self
     where
         F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
@@ -175,7 +175,7 @@ impl ReloadAdvisory {
 async fn build_all<F>(
     ids: impl IntoIterator<Item = String>,
     initializer: &F,
-    process: &ProcessConfig,
+    process: &ResolvedProcess,
 ) -> Vec<NewSource>
 where
     F: AsyncFn(String) -> SourceBuildResult<BuiltSource>,
@@ -269,7 +269,7 @@ mod tests {
         let prev = BTreeSet::new();
         let next = BTreeSet::new();
         let advisory =
-            ReloadAdvisory::from_sets(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_sets(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions: []
         updates: []
@@ -282,7 +282,7 @@ mod tests {
         let prev = BTreeSet::new();
         let next: BTreeSet<String> = ["a", "b"].into_iter().map(String::from).collect();
         let advisory =
-            ReloadAdvisory::from_sets(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_sets(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions:
           - a
@@ -297,7 +297,7 @@ mod tests {
         let prev: BTreeSet<String> = ["a", "b"].into_iter().map(String::from).collect();
         let next = BTreeSet::new();
         let advisory =
-            ReloadAdvisory::from_sets(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_sets(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions: []
         updates: []
@@ -312,7 +312,7 @@ mod tests {
         let prev: BTreeSet<String> = ["a", "b", "c"].into_iter().map(String::from).collect();
         let next: BTreeSet<String> = ["b", "c", "d"].into_iter().map(String::from).collect();
         let advisory =
-            ReloadAdvisory::from_sets(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_sets(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions:
           - d
@@ -327,7 +327,7 @@ mod tests {
         let prev: BTreeMap<String, u64> = [("a".into(), 1), ("b".into(), 2)].into_iter().collect();
         let next: BTreeMap<String, u64> = [("b".into(), 2), ("c".into(), 3)].into_iter().collect();
         let advisory =
-            ReloadAdvisory::from_maps(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_maps(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions:
           - c
@@ -342,7 +342,7 @@ mod tests {
         let prev: BTreeMap<String, u64> = [("a".into(), 1), ("b".into(), 2)].into_iter().collect();
         let next: BTreeMap<String, u64> = [("a".into(), 1), ("b".into(), 5)].into_iter().collect();
         let advisory =
-            ReloadAdvisory::from_maps(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_maps(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions: []
         updates:
@@ -360,7 +360,7 @@ mod tests {
             .into_iter()
             .collect();
         let advisory =
-            ReloadAdvisory::from_maps(&prev, &next, make_source, ProcessConfig::default()).await;
+            ReloadAdvisory::from_maps(&prev, &next, make_source, ResolvedProcess::default()).await;
         assert_yaml_snapshot!(AdvisorySnapshot::from(&advisory), @"
         additions:
           - d

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -7,7 +7,7 @@ use martin_core::tiles::{BoxedSource, Source};
 use martin_tile_utils::TileInfo;
 use tracing::debug;
 
-use crate::config::file::ProcessConfig;
+use crate::config::file::ResolvedProcess;
 
 /// Maximum number of comma-separated source ids accepted in a single
 /// composite tile request (`/{source_ids}/{z}/{x}/{y}`).
@@ -15,7 +15,7 @@ const MAX_SOURCE_IDS_PER_REQUEST: usize = 128;
 
 /// Result of resolving multiple sources for a composite tile request.
 pub struct ResolvedSources {
-    pub sources: Vec<(BoxedSource, ProcessConfig)>,
+    pub sources: Vec<(BoxedSource, ResolvedProcess)>,
     pub use_url_query: bool,
     pub info: TileInfo,
 }
@@ -23,14 +23,14 @@ pub struct ResolvedSources {
 /// Thread-safe registry of tile sources indexed by ID.
 ///
 /// Uses a [`DashMap`] for concurrent access without explicit locking.
-/// Each source is paired with its resolved [`ProcessConfig`].
+/// Each source is paired with its resolved [`ResolvedProcess`].
 #[derive(Default, Clone)]
-pub struct TileSources(Arc<DashMap<String, (BoxedSource, ProcessConfig)>>);
+pub struct TileSources(Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>);
 
 impl TileSources {
     /// Creates a new registry from flattened source collections.
     ///
-    /// All sources receive the default [`ProcessConfig`].
+    /// All sources receive the default [`ResolvedProcess`].
     #[must_use]
     pub fn new(sources: Vec<Vec<BoxedSource>>) -> Self {
         Self::new_with_process(
@@ -39,7 +39,7 @@ impl TileSources {
                 .map(|group| {
                     group
                         .into_iter()
-                        .map(|src| (src, ProcessConfig::default()))
+                        .map(|src| (src, ResolvedProcess::default()))
                         .collect()
                 })
                 .collect(),
@@ -48,7 +48,7 @@ impl TileSources {
 
     /// Creates a new registry from sources paired with their resolved process configs.
     #[must_use]
-    pub fn new_with_process(sources: Vec<Vec<(BoxedSource, ProcessConfig)>>) -> Self {
+    pub fn new_with_process(sources: Vec<Vec<(BoxedSource, ResolvedProcess)>>) -> Self {
         Self(Arc::new(
             sources
                 .into_iter()
@@ -60,7 +60,7 @@ impl TileSources {
 
     /// Creates a registry backed by an existing shared `DashMap`.
     #[must_use]
-    pub(crate) fn from_dashmap(map: Arc<DashMap<String, (BoxedSource, ProcessConfig)>>) -> Self {
+    pub(crate) fn from_dashmap(map: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>) -> Self {
         Self(map)
     }
 
@@ -89,7 +89,7 @@ impl TileSources {
     }
 
     /// Gets a source and its process config by ID, returning 404 error if not found.
-    pub fn get_source(&self, id: &str) -> actix_web::Result<(BoxedSource, ProcessConfig)> {
+    pub fn get_source(&self, id: &str) -> actix_web::Result<(BoxedSource, ResolvedProcess)> {
         Ok(self
             .0
             .get(id)

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -19,11 +19,11 @@ use serde::Deserialize;
 use tracing::{instrument, warn};
 
 use crate::config::args::PreferredEncoding;
-use crate::config::file::ProcessConfig;
 #[cfg(all(feature = "contour", feature = "_tiles"))]
 use crate::config::file::ResolvedContour;
 #[cfg(all(feature = "hillshade", feature = "_tiles"))]
 use crate::config::file::ResolvedHillshade;
+use crate::config::file::ResolvedProcess;
 use crate::config::file::driver::Sink as _;
 use crate::config::file::srv::SrvConfig;
 use crate::reload::{NewSource, ReloadAdvisory};
@@ -266,7 +266,7 @@ fn redirect_tile_with_query(
 }
 
 pub struct DynTileSource<'a> {
-    pub sources: Vec<(BoxedSource, ProcessConfig)>,
+    pub sources: Vec<(BoxedSource, ResolvedProcess)>,
     pub info: TileInfo,
     /// The request's query string and its parsed form, when the request carried one.
     pub query: Option<(&'a str, UrlQuery)>,
@@ -441,7 +441,7 @@ impl<'a> DynTileSource<'a> {
     async fn get_tile_content_from_one_source(
         &self,
         s: &BoxedSource,
-        pc: &ProcessConfig,
+        pc: &ResolvedProcess,
         xyz: TileCoord,
     ) -> ActixResult<Tile> {
         #[cfg(all(feature = "hillshade", feature = "_tiles"))]
@@ -477,7 +477,11 @@ impl<'a> DynTileSource<'a> {
     /// Reloads `s`, publishes the fresh instance, and hands it back.
     ///
     /// Publishing also invalidates the source's cached tiles, so a retry reads fresh data.
-    async fn reload_source(&self, s: &BoxedSource, pc: &ProcessConfig) -> ActixResult<BoxedSource> {
+    async fn reload_source(
+        &self,
+        s: &BoxedSource,
+        pc: &ResolvedProcess,
+    ) -> ActixResult<BoxedSource> {
         let fresh_src = s.try_reload().await.map_err(|e| map_error(&e))?;
         warn!(source.id = s.get_id(), "Source modified; reloading");
         let advisory = ReloadAdvisory {
@@ -498,7 +502,7 @@ impl<'a> DynTileSource<'a> {
     async fn reload_source_and_retry_get_tile(
         &self,
         s: &BoxedSource,
-        pc: &ProcessConfig,
+        pc: &ResolvedProcess,
         xyz: TileCoord,
     ) -> ActixResult<Tile> {
         let fresh_src = self.reload_source(s, pc).await?;
@@ -514,7 +518,7 @@ impl<'a> DynTileSource<'a> {
     async fn fetch_tile_content_with_cache(
         &self,
         s: &BoxedSource,
-        pc: &ProcessConfig,
+        pc: &ResolvedProcess,
         xyz: TileCoord,
     ) -> Result<Tile, Arc<MartinCoreError>> {
         let cache_zoom = s.cache_zoom().contains(xyz.z);
@@ -558,14 +562,8 @@ impl<'a> DynTileSource<'a> {
     /// Resolves this source's contour settings for the current request.
     /// Returns `None` when the source is not contoured.
     #[cfg(all(feature = "contour", feature = "_tiles"))]
-    fn resolve_contour(&self, pc: &ProcessConfig) -> ActixResult<Option<ResolvedContour>> {
-        let Some(config) = pc.convert_to_contour.as_ref() else {
-            return Ok(None);
-        };
-        let Some(settings) = config
-            .resolve_contour()
-            .map_err(|e| actix_web::Error::from(ProcessError::from(e)))?
-        else {
+    fn resolve_contour(&self, pc: &ResolvedProcess) -> ActixResult<Option<ResolvedContour>> {
+        let Some(settings) = pc.contour.clone() else {
             return Ok(None);
         };
 
@@ -585,14 +583,8 @@ impl<'a> DynTileSource<'a> {
     /// Resolves this source's hillshade settings for the current request.
     /// Returns `None` when the source is not hillshaded.
     #[cfg(all(feature = "hillshade", feature = "_tiles"))]
-    fn resolve_hillshade(&self, pc: &ProcessConfig) -> ActixResult<Option<ResolvedHillshade>> {
-        let Some(config) = pc.convert_to_hillshade.as_ref() else {
-            return Ok(None);
-        };
-        let Some(settings) = config
-            .resolve_hillshade()
-            .map_err(|e| actix_web::Error::from(ProcessError::from(e)))?
-        else {
+    fn resolve_hillshade(&self, pc: &ResolvedProcess) -> ActixResult<Option<ResolvedHillshade>> {
+        let Some(settings) = pc.hillshade else {
             return Ok(None);
         };
 
@@ -870,7 +862,7 @@ mod tests {
             .into_iter()
             .map(|s| {
                 s.into_iter()
-                    .map(|s| (s, ProcessConfig::default()))
+                    .map(|s| (s, ResolvedProcess::default()))
                     .collect()
             })
             .collect();
@@ -1206,17 +1198,11 @@ mod tests {
     #[cfg(all(feature = "mlt", feature = "hillshade", feature = "_tiles"))]
     #[actix_rt::test]
     async fn a_hillshaded_source_needing_reload_is_reloaded_and_the_bake_retried() {
-        use crate::config::file::HillshadeProcessConfig;
-
         let normal_tile =
             include_bytes!("../../../../tests/fixtures/terrain/normal/10_163_396.png").to_vec();
-        let pc = ProcessConfig {
-            convert_to_hillshade: Some(HillshadeProcessConfig::Auto),
-            convert_to_mlt: None,
-            convert_to_mvt: None,
-            cache_control: None,
-            #[cfg(all(feature = "contour", feature = "_tiles"))]
-            convert_to_contour: None,
+        let pc = ResolvedProcess {
+            hillshade: Some(ResolvedHillshade::default()),
+            ..Default::default()
         };
         let src = SourceNeedsReloadTestSource::new("terrain", normal_tile, Format::Png);
         let mgr = TileSourceManager::from_sources(

--- a/martin/src/srv/tiles/metadata.rs
+++ b/martin/src/srv/tiles/metadata.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use tilejson::{TileJSON, tilejson};
 use url::form_urlencoded;
 
-use crate::config::file::ProcessConfig;
+use crate::config::file::ResolvedProcess;
 use crate::config::file::srv::SrvConfig;
 use crate::tile_source_manager::TileSourceManager;
 
@@ -114,7 +114,7 @@ pub async fn get_source_info(
 
 /// Merges what each source advertises after post-processing into one [`TileJSON`].
 #[must_use]
-pub fn merge_tilejson(sources: &[(BoxedSource, ProcessConfig)], tiles_url: String) -> TileJSON {
+pub fn merge_tilejson(sources: &[(BoxedSource, ResolvedProcess)], tiles_url: String) -> TileJSON {
     let mut advertised: Vec<TileJSON> = sources
         .iter()
         .map(|(src, pc)| pc.advertised_tilejson(src.get_tilejson().clone()))
@@ -243,7 +243,7 @@ pub mod tests {
         let tj = merge_tilejson(
             &[(
                 Box::new(src1.clone()) as BoxedSource,
-                ProcessConfig::default(),
+                ResolvedProcess::default(),
             )],
             url.clone(),
         );
@@ -278,9 +278,9 @@ pub mod tests {
             &[
                 (
                     Box::new(src1.clone()) as BoxedSource,
-                    ProcessConfig::default(),
+                    ResolvedProcess::default(),
                 ),
-                (Box::new(src2) as BoxedSource, ProcessConfig::default()),
+                (Box::new(src2) as BoxedSource, ResolvedProcess::default()),
             ],
             url.clone(),
         );

--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -150,7 +150,6 @@ pub fn apply_pre_cache_processors(
     let tile = if accepted == Some(Format::Mlt) && tile.info.format == Format::Mvt {
         match config.mlt {
             MltConversion::Encode(cfg) => convert_mvt_to_mlt(tile, cfg)?,
-            // Explicitly opted out - serve the original MVT bytes.
             MltConversion::Disabled => tile,
         }
     } else if accepted == Some(Format::Mvt)

--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -20,8 +20,6 @@ use martin_core::tiles::hillshade::HillshadeError;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use martin_tile_utils::Format;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
-use mlt_core::encoder::EncoderConfig;
-#[cfg(all(feature = "mlt", feature = "_tiles"))]
 use to_mlt::convert_mvt_to_mlt;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use to_mvt::convert_mlt_to_mvt;
@@ -31,7 +29,7 @@ use crate::config::file::ContourRangeError;
 #[cfg(all(feature = "hillshade", feature = "_tiles"))]
 use crate::config::file::HillshadeRangeError;
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
-use crate::config::file::{MltProcessConfig, MvtProcessConfig, ProcessConfig};
+use crate::config::file::{MltConversion, MvtConversion, ResolvedProcess};
 
 /// Errors that can occur during tile post-processing.
 #[derive(thiserror::Error, Debug)]
@@ -130,9 +128,8 @@ impl From<ProcessError> for actix_web::Error {
 ///
 /// Currently supports:
 /// - MVT -> MLT conversion when the client requests `application/vnd.maplibre-tile`
-///   (requires `mlt` feature). Encoder settings come from `config.convert_to_mlt`; an
-///   absent block is treated as `convert_to_mlt: auto` and uses `mlt-core`'s defaults.
-///   `convert_to_mlt: disabled` (or any of `off`/`no`/`false`) skips conversion entirely
+///   (requires `mlt` feature). Encoder settings come from `config.mlt`, resolved from
+///   `convert_to_mlt` at startup, and `disabled` skips conversion entirely
 ///   even if the client asked for MLT - the original MVT bytes are returned.
 /// - MLT -> MVT conversion when the client requests `application/vnd.mapbox-vector-tile`
 ///   from an MLT source (requires `mlt` feature). `convert_to_mvt: disabled` skips it.
@@ -142,7 +139,7 @@ impl From<ProcessError> for actix_web::Error {
 /// coexist naturally.
 pub fn apply_pre_cache_processors(
     tile: Tile,
-    #[cfg(all(feature = "mlt", feature = "_tiles"))] config: &ProcessConfig,
+    #[cfg(all(feature = "mlt", feature = "_tiles"))] config: &ResolvedProcess,
     #[cfg(all(feature = "mlt", feature = "_tiles"))] accepted: Option<Format>,
 ) -> Result<Tile, ProcessError> {
     if tile.data.is_empty() {
@@ -151,23 +148,14 @@ pub fn apply_pre_cache_processors(
 
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     let tile = if accepted == Some(Format::Mlt) && tile.info.format == Format::Mvt {
-        match config.convert_to_mlt.as_ref() {
-            // No level configured anything -> use defaults.
-            None | Some(MltProcessConfig::Auto) => {
-                convert_mvt_to_mlt(tile, EncoderConfig::default())?
-            }
-            Some(MltProcessConfig::Explicit(cfg)) => {
-                convert_mvt_to_mlt(tile, EncoderConfig::from(cfg.clone()))?
-            }
+        match config.mlt {
+            MltConversion::Encode(cfg) => convert_mvt_to_mlt(tile, cfg)?,
             // Explicitly opted out - serve the original MVT bytes.
-            Some(MltProcessConfig::Disabled) => tile,
+            MltConversion::Disabled => tile,
         }
     } else if accepted == Some(Format::Mvt)
         && tile.info.format == Format::Mlt
-        && !config
-            .convert_to_mvt
-            .as_ref()
-            .is_some_and(MvtProcessConfig::is_disabled)
+        && config.mvt == MvtConversion::Encode
     {
         convert_mlt_to_mvt(tile)?
     } else {
@@ -207,7 +195,7 @@ mod tests {
     ) {
         let tile = make_tile(Vec::new(), format, encoding);
         let result =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(target)).unwrap();
+            apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(target)).unwrap();
         assert!(result.data.is_empty());
     }
 
@@ -215,10 +203,7 @@ mod tests {
     #[test]
     fn mvt_request_is_noop() {
         let tile = make_tile(vec![1, 2, 3], Format::Mvt, Encoding::Uncompressed);
-        let config = ProcessConfig {
-            convert_to_mlt: Some(MltProcessConfig::Auto),
-            ..Default::default()
-        };
+        let config = ResolvedProcess::default();
         let result = apply_pre_cache_processors(tile, &config, Some(Format::Mvt)).unwrap();
         assert_eq!(result.data, vec![1, 2, 3]);
         assert_eq!(result.info.format, Format::Mvt);
@@ -228,7 +213,7 @@ mod tests {
     #[test]
     fn no_accept_header_is_noop() {
         let tile = make_tile(vec![1, 2, 3], Format::Mvt, Encoding::Uncompressed);
-        let result = apply_pre_cache_processors(tile, &ProcessConfig::default(), None).unwrap();
+        let result = apply_pre_cache_processors(tile, &ResolvedProcess::default(), None).unwrap();
         assert_eq!(result.data, vec![1, 2, 3]);
         assert_eq!(result.info.format, Format::Mvt);
     }
@@ -238,7 +223,8 @@ mod tests {
     fn non_mvt_source_with_mlt_accept_is_noop() {
         let tile = make_tile(vec![1, 2, 3], Format::Png, Encoding::Internal);
         let result =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
+            apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(Format::Mlt))
+                .unwrap();
         assert_eq!(result.info.format, Format::Png);
     }
 
@@ -247,7 +233,8 @@ mod tests {
     fn mlt_accept_converts_mvt_with_default_encoder() {
         let tile = make_tile(empty_layer_mvt_bytes(), Format::Mvt, Encoding::Uncompressed);
         let result =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
+            apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(Format::Mlt))
+                .unwrap();
         assert_eq!(result.info.format, Format::Mlt);
         assert_eq!(result.info.encoding, Encoding::Internal);
     }
@@ -256,10 +243,7 @@ mod tests {
     #[test]
     fn mlt_accept_uses_explicit_encoder_overrides() {
         let tile = make_tile(empty_layer_mvt_bytes(), Format::Mvt, Encoding::Uncompressed);
-        let config = ProcessConfig {
-            convert_to_mlt: Some(MltProcessConfig::Auto),
-            ..Default::default()
-        };
+        let config = ResolvedProcess::default();
         let result = apply_pre_cache_processors(tile, &config, Some(Format::Mlt)).unwrap();
         assert_eq!(result.info.format, Format::Mlt);
     }
@@ -268,8 +252,8 @@ mod tests {
     #[test]
     fn mlt_accept_with_disabled_serves_mvt_unchanged() {
         let tile = make_tile(empty_layer_mvt_bytes(), Format::Mvt, Encoding::Uncompressed);
-        let config = ProcessConfig {
-            convert_to_mlt: Some(MltProcessConfig::Disabled),
+        let config = ResolvedProcess {
+            mlt: MltConversion::Disabled,
             ..Default::default()
         };
         let result = apply_pre_cache_processors(tile, &config, Some(Format::Mlt)).unwrap();
@@ -285,7 +269,8 @@ mod tests {
         let gzipped = encode_gzip(&empty_layer_mvt_bytes()).unwrap();
         let tile = make_tile(gzipped, Format::Mvt, Encoding::Gzip);
         let result =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
+            apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(Format::Mlt))
+                .unwrap();
         assert_eq!(result.info.format, Format::Mlt);
         assert_eq!(result.info.encoding, Encoding::Internal);
     }
@@ -304,14 +289,14 @@ mod tests {
         // First convert MVT->MLT
         let original = make_tile(mvt_with_feature(), Format::Mvt, Encoding::Uncompressed);
         let encoded =
-            apply_pre_cache_processors(original, &ProcessConfig::default(), Some(Format::Mlt))
+            apply_pre_cache_processors(original, &ResolvedProcess::default(), Some(Format::Mlt))
                 .unwrap();
         assert_eq!(encoded.info.format, Format::Mlt);
         assert!(!encoded.data.is_empty(), "MLT tile should have data");
 
         // Now convert MLT->MVT via the pipeline
         let decoded =
-            apply_pre_cache_processors(encoded, &ProcessConfig::default(), Some(Format::Mvt))
+            apply_pre_cache_processors(encoded, &ResolvedProcess::default(), Some(Format::Mvt))
                 .unwrap();
         assert_eq!(decoded.info.format, Format::Mvt);
         assert_eq!(decoded.info.encoding, Encoding::Uncompressed);
@@ -329,13 +314,13 @@ mod tests {
             TileInfo::new(Format::Mvt, Encoding::Uncompressed),
             "upstream-etag".to_owned(),
         );
-        let mlt =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mlt)).unwrap();
+        let mlt = apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(Format::Mlt))
+            .unwrap();
         assert_eq!(mlt.info.format, Format::Mlt);
         assert_eq!(mlt.etag, "upstream-etag+mlt");
 
-        let mvt =
-            apply_pre_cache_processors(mlt, &ProcessConfig::default(), Some(Format::Mvt)).unwrap();
+        let mvt = apply_pre_cache_processors(mlt, &ResolvedProcess::default(), Some(Format::Mvt))
+            .unwrap();
         assert_eq!(mvt.info.format, Format::Mvt);
         assert_eq!(mvt.etag, "upstream-etag+mlt+mvt");
     }
@@ -347,14 +332,15 @@ mod tests {
         // First produce an MLT tile from MVT
         let original = make_tile(mvt_with_feature(), Format::Mvt, Encoding::Uncompressed);
         let encoded =
-            apply_pre_cache_processors(original, &ProcessConfig::default(), Some(Format::Mlt))
+            apply_pre_cache_processors(original, &ResolvedProcess::default(), Some(Format::Mlt))
                 .unwrap();
         assert!(!encoded.data.is_empty());
 
         // Simulate an MLT source receiving Accept: MVT
         let tile = make_tile(encoded.data, Format::Mlt, Encoding::Uncompressed);
         let result =
-            apply_pre_cache_processors(tile, &ProcessConfig::default(), Some(Format::Mvt)).unwrap();
+            apply_pre_cache_processors(tile, &ResolvedProcess::default(), Some(Format::Mvt))
+                .unwrap();
         assert_eq!(result.info.format, Format::Mvt);
     }
 }

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -5,7 +5,7 @@ use martin_core::tiles::{BoxedSource, OptTileCache};
 use tracing::{info, warn};
 
 use crate::config::file::driver::Sink;
-use crate::config::file::{OnInvalid, ProcessConfig, SourceBuildResult};
+use crate::config::file::{OnInvalid, ResolvedProcess, SourceBuildResult};
 use crate::reload::{NewSource, ReloadAdvisory, SourceProvenance};
 use crate::source::TileSources;
 
@@ -18,7 +18,7 @@ use crate::source::TileSources;
 /// `TileSourceManager` is cheap to clone.
 #[derive(Clone)]
 pub struct TileSourceManager {
-    tile_sources: Arc<DashMap<String, (BoxedSource, ProcessConfig)>>,
+    tile_sources: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>,
     /// Kept beside the serving map so `--save-config` can serialize what is actually served.
     provenance: Arc<DashMap<String, SourceProvenance>>,
     tile_cache: OptTileCache,
@@ -39,14 +39,14 @@ impl TileSourceManager {
 
     /// Creates a manager pre-populated with the given sources.
     ///
-    /// All sources receive the default [`ProcessConfig`].
+    /// All sources receive the default [`ResolvedProcess`].
     #[must_use]
     pub fn from_sources(
         tile_cache: OptTileCache,
         on_invalid: OnInvalid,
-        sources: Vec<Vec<(BoxedSource, ProcessConfig)>>,
+        sources: Vec<Vec<(BoxedSource, ResolvedProcess)>>,
     ) -> Self {
-        let map: DashMap<String, (BoxedSource, ProcessConfig)> = sources
+        let map: DashMap<String, (BoxedSource, ResolvedProcess)> = sources
             .into_iter()
             .flatten()
             .map(|(src, pc)| (src.get_id().to_owned(), (src, pc)))
@@ -93,7 +93,7 @@ impl TileSourceManager {
         &self,
         id: String,
         src: BoxedSource,
-        process: ProcessConfig,
+        process: ResolvedProcess,
         provenance: Option<SourceProvenance>,
     ) {
         if let Some(p) = provenance {
@@ -242,7 +242,7 @@ mod tests {
                 id: name.to_owned(),
                 tj: tilejson! { tiles: vec![] },
             })),
-            process: ProcessConfig::default(),
+            process: ResolvedProcess::default(),
             provenance: None,
         }
     }
@@ -325,7 +325,7 @@ mod tests {
         let mgr = TileSourceManager::from_sources(
             None,
             OnInvalid::Abort,
-            vec![vec![(src, ProcessConfig::default())]],
+            vec![vec![(src, ResolvedProcess::default())]],
         );
         assert_yaml_snapshot!(sorted_source_names(&mgr), @"- x");
         assert!(mgr.tile_cache().is_none());
@@ -358,7 +358,7 @@ mod tests {
         use tempfile::TempDir;
 
         use crate::config::file::discovery::BuiltSource;
-        use crate::config::file::{ConfigFileError, ProcessConfig, SourceBuildError};
+        use crate::config::file::{ConfigFileError, ResolvedProcess, SourceBuildError};
 
         const BAD_PREFIX: &str = "bad_";
 
@@ -408,7 +408,7 @@ mod tests {
                 state,
                 &next,
                 async |id| build(id, dir_path.clone()).await,
-                ProcessConfig::default(),
+                ResolvedProcess::default(),
             )
             .await;
             mgr.apply_changes(advisory)


### PR DESCRIPTION
Closes #3192

`ProcessConfig` was both the settings users write and the value the tile pipeline runs on, all `Option` in both roles. Every consumer re-learned which `None` meant unset and which meant off, and hillshade/contour re-resolved their parameters on every request.

Now `ProcessConfig` is only the per-level layer. `Config::finalize` folds global > source-type > per-source once into `ResolvedProcess`, and that is the only type the catalog, the reloaders and `content.rs` see.

- `mlt` / `mvt` are two-state enums with the encoder already built
- `hillshade` / `contour` carry their `Resolved*` types, so the two `validate_*` passes fold into the same walk
- `cache_control` stays `Option`, no header is a real state
- discovery keeps the kind-level layer to fold per-source overrides over and resolves on the way out

No behaviour change intended.

Side fix: the `mlt`-gated PG discovery test was missing `cache_control` and did not compile under `--features test-pg --all-targets`.
