### PR TITLE
feat(cache): add an opt-in DELETE /cache/{source_id} purge route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5487,6 +5487,7 @@ dependencies = [
  "geojson",
  "image",
  "image-compare",
+ "indoc",
  "insta",
  "jxl-oxide",
  "libc",

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -502,8 +502,7 @@ postgres:
 preferred_encoding: brotli
 # Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
 #
-# The route has no authentication of its own.
-# Put it behind the same proxy rules as the rest of the server.
+# The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
 purge_endpoint: false
 # Set the URL path prefix for all API routes.
 # When set, Martin will serve all endpoints under this path prefix.

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -113,6 +113,12 @@ cors:
   # '*' will use the requests `ORIGIN` header
   origin:
     - https://example.org
+# Optional endpoints, each off unless enabled here.
+endpoints:
+  # Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
+  #
+  # The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
+  purge_cache: false
 # Font configuration
 fonts:
   # Cache configuration for fonts.
@@ -500,12 +506,6 @@ postgres:
 # `gzip` is faster, but `brotli` is smaller, and may be faster with caching.
 # Default could be different depending on Martin version.
 preferred_encoding: brotli
-# Optional endpoints, each off unless enabled here.
-endpoints:
-  # Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
-  #
-  # The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
-  purge_cache: false
 # Set the URL path prefix for all API routes.
 # When set, Martin will serve all endpoints under this path prefix.
 # This allows Martin to be served under a subpath when behind a reverse proxy (e.g., Traefik).

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -500,6 +500,11 @@ postgres:
 # `gzip` is faster, but `brotli` is smaller, and may be faster with caching.
 # Default could be different depending on Martin version.
 preferred_encoding: brotli
+# Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
+#
+# The route has no authentication of its own.
+# Put it behind the same proxy rules as the rest of the server.
+purge_endpoint: false
 # Set the URL path prefix for all API routes.
 # When set, Martin will serve all endpoints under this path prefix.
 # This allows Martin to be served under a subpath when behind a reverse proxy (e.g., Traefik).

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -500,10 +500,12 @@ postgres:
 # `gzip` is faster, but `brotli` is smaller, and may be faster with caching.
 # Default could be different depending on Martin version.
 preferred_encoding: brotli
-# Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
-#
-# The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
-purge_endpoint: false
+# Optional endpoints, each off unless enabled here.
+endpoints:
+  # Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. [default: false]
+  #
+  # The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
+  purge_cache: false
 # Set the URL path prefix for all API routes.
 # When set, Martin will serve all endpoints under this path prefix.
 # This allows Martin to be served under a subpath when behind a reverse proxy (e.g., Traefik).

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -38,6 +38,7 @@ wiremock.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
+indoc.workspace = true
 flate2.workspace = true
 insta = { workspace = true, features = ["filters", "json", "redactions"] }
 mlt-core.workspace = true

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -38,8 +38,8 @@ wiremock.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
-indoc.workspace = true
 flate2.workspace = true
+indoc.workspace = true
 insta = { workspace = true, features = ["filters", "json", "redactions"] }
 mlt-core.workspace = true
 pbf_font_tools.workspace = true

--- a/e2e-tests/src/martin.rs
+++ b/e2e-tests/src/martin.rs
@@ -288,6 +288,11 @@ impl Martin {
         self.request(Method::HEAD, path, headers).await
     }
 
+    /// Perform a DELETE request.
+    pub async fn delete(&self, path: &str) -> TestResponse {
+        self.request(Method::DELETE, path, &[]).await
+    }
+
     /// Perform a POST request carrying a JSON `body`.
     pub async fn post_json(&self, path: &str, body: &[u8]) -> TestResponse {
         self.send(

--- a/e2e-tests/tests/cache_purge.rs
+++ b/e2e-tests/tests/cache_purge.rs
@@ -1,0 +1,52 @@
+//! The opt-in `DELETE /cache/{source_id}` route.
+
+use martin_e2e_tests::Martin;
+
+const ENABLED: &str = "
+purge_endpoint: true
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+";
+
+const DISABLED: &str = "
+pmtiles:
+  sources:
+    pmt: tests/fixtures/pmtiles/png.pmtiles
+";
+
+#[tokio::test]
+async fn purging_a_source_drops_its_cached_tiles() {
+    let mut martin = Martin::builder()
+        .config(ENABLED)
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    assert_eq!(martin.get("/pmt/0/0/0").await.status(), 200);
+    let purged = martin.delete("/cache/pmt").await;
+    assert_eq!(purged.status(), 204);
+    assert!(purged.body().is_empty());
+    assert_eq!(martin.get("/pmt/0/0/0").await.status(), 200);
+
+    assert_eq!(martin.delete("/cache/nope").await.status(), 404);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_contains("Invalidated tile cache for source: pmt");
+}
+
+#[tokio::test]
+async fn the_route_is_absent_unless_enabled() {
+    let mut martin = Martin::builder()
+        .config(DISABLED)
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    assert_eq!(martin.delete("/cache/pmt").await.status(), 404);
+
+    martin.stop().await;
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}

--- a/e2e-tests/tests/cache_purge.rs
+++ b/e2e-tests/tests/cache_purge.rs
@@ -1,45 +1,111 @@
 //! The opt-in `DELETE /cache/{source_id}` route.
 
-use martin_e2e_tests::Martin;
+use indoc::formatdoc;
+use martin_e2e_tests::{Martin, StaticFiles};
 
-const ENABLED: &str = "
-purge_endpoint: true
-pmtiles:
-  sources:
-    pmt: tests/fixtures/pmtiles/png.pmtiles
-";
+/// A minimal but valid MVT tile: one layer with one point feature.
+fn mvt_tile() -> Vec<u8> {
+    use mlt_core::TileLayer;
+    use mlt_core::geo_types::{Geometry, Point};
+    use mlt_core::mvt::tile_layers_to_mvt;
 
-const DISABLED: &str = "
-pmtiles:
-  sources:
-    pmt: tests/fixtures/pmtiles/png.pmtiles
-";
+    let mut builder = TileLayer::builder("test", 4096).expect("layer builder");
+    {
+        let mut feature = builder.feature(Geometry::Point(Point::new(100, 200)));
+        feature.id(Some(1));
+        feature.finish().expect("finish feature");
+    }
+    tile_layers_to_mvt(vec![builder.finish()]).expect("encode MVT")
+}
+
+async fn upstream_with_one_tile() -> StaticFiles {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let tile = dir.path().join("tile.pbf");
+    std::fs::write(&tile, mvt_tile()).expect("failed to write the tile");
+    StaticFiles::serving(&[("0/0/0.pbf", tile)]).await
+}
 
 #[tokio::test]
-async fn purging_a_source_drops_its_cached_tiles() {
+async fn purging_a_source_makes_the_next_request_hit_the_upstream_again() {
+    let upstream = upstream_with_one_tile().await;
+    let config = formatdoc! {"
+        purge_endpoint: true
+        passthrough:
+          sources:
+            proxy: {url}/{{z}}/{{x}}/{{y}}.pbf
+    ", url = upstream.base_url()};
     let mut martin = Martin::builder()
-        .config(ENABLED)
+        .config(&config)
         .start()
         .await
         .expect("failed to start martin");
 
-    assert_eq!(martin.get("/pmt/0/0/0").await.status(), 200);
-    let purged = martin.delete("/cache/pmt").await;
-    assert_eq!(purged.status(), 204);
-    assert!(purged.body().is_empty());
-    assert_eq!(martin.get("/pmt/0/0/0").await.status(), 200);
+    assert_eq!(martin.get("/proxy/0/0/0").await.status(), 200);
+    assert_eq!(martin.get("/proxy/0/0/0").await.status(), 200);
+    assert_eq!(
+        upstream.request_log().await.lines().count(),
+        1,
+        "the second request must come from the tile cache"
+    );
+
+    let purged = martin.delete("/cache/proxy").await;
+    assert_eq!(purged.status(), 200);
+    assert_eq!(purged.text(), "Purged the cached tiles of source proxy");
+
+    assert_eq!(martin.get("/proxy/0/0/0").await.status(), 200);
+    assert_eq!(
+        upstream.request_log().await.lines().count(),
+        2,
+        "after the purge the tile must be fetched from the upstream again"
+    );
 
     assert_eq!(martin.delete("/cache/nope").await.status(), 404);
 
     martin.stop().await;
+    martin.assert_log_contains("Invalidated tile cache for source: proxy");
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn without_a_tile_cache_the_body_says_so() {
+    let mut martin = Martin::builder()
+        .config(
+            formatdoc! {"
+            purge_endpoint: true
+            cache: disable
+            pmtiles:
+              sources:
+                pmt: tests/fixtures/pmtiles/png.pmtiles
+        "}
+            .as_str(),
+        )
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let purged = martin.delete("/cache/pmt").await;
+    assert_eq!(purged.status(), 200);
+    assert_eq!(
+        purged.text(),
+        "Source pmt has no cached tiles, tile caching is disabled"
+    );
+
+    martin.stop().await;
     martin.assert_startup_warnings();
-    martin.assert_log_contains("Invalidated tile cache for source: pmt");
+    martin.assert_log_clean();
 }
 
 #[tokio::test]
 async fn the_route_is_absent_unless_enabled() {
     let mut martin = Martin::builder()
-        .config(DISABLED)
+        .config(
+            formatdoc! {"
+            pmtiles:
+              sources:
+                pmt: tests/fixtures/pmtiles/png.pmtiles
+        "}
+            .as_str(),
+        )
         .start()
         .await
         .expect("failed to start martin");

--- a/e2e-tests/tests/cache_purge.rs
+++ b/e2e-tests/tests/cache_purge.rs
@@ -29,7 +29,8 @@ async fn upstream_with_one_tile() -> StaticFiles {
 async fn purging_a_source_makes_the_next_request_hit_the_upstream_again() {
     let upstream = upstream_with_one_tile().await;
     let config = formatdoc! {"
-        purge_endpoint: true
+        endpoints:
+          purge_cache: true
         passthrough:
           sources:
             proxy: {url}/{{z}}/{{x}}/{{y}}.pbf
@@ -71,7 +72,8 @@ async fn without_a_tile_cache_the_body_says_so() {
     let mut martin = Martin::builder()
         .config(
             formatdoc! {"
-            purge_endpoint: true
+            endpoints:
+              purge_cache: true
             cache: disable
             pmtiles:
               sources:

--- a/martin/martin-ui/src/lib/types.gen.ts
+++ b/martin/martin-ui/src/lib/types.gen.ts
@@ -14,10 +14,6 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /**
-         * Drops every cached tile of one source.
-         * @description Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.
-         */
         delete: operations["purge_source"];
         options?: never;
         head?: never;
@@ -462,12 +458,14 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description The source's cached tiles are gone */
-            204: {
+            /** @description The source's cached tiles are gone, or tile cacheing is disabled. */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "text/plain": string;
+                };
             };
             /** @description No such source */
             404: {

--- a/martin/martin-ui/src/lib/types.gen.ts
+++ b/martin/martin-ui/src/lib/types.gen.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+    "/cache/{source_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Drops every cached tile of one source.
+         * @description Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.
+         */
+        delete: operations["purge_source"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/catalog": {
         parameters: {
             query?: never;
@@ -430,6 +450,34 @@ export type StaticStyleOverlay = components['schemas']['StaticStyleOverlay'];
 export type StyleKind = components['schemas']['StyleKind'];
 export type $defs = Record<string, never>;
 export interface operations {
+    purge_source: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Source ID */
+                source_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The source's cached tiles are gone */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such source */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     get_catalog: {
         parameters: {
             query?: never;

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -118,12 +118,9 @@ pub struct SrvConfig {
     #[cfg(all(feature = "webui", not(docsrs)))]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &"disable"))]
     pub web_ui: Option<WebUiMode>,
-    /// Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \[default: false\]
-    ///
-    /// The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
+    /// Optional endpoints, each off unless enabled here.
     #[cfg(feature = "_tiles")]
-    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
-    pub purge_endpoint: Option<bool>,
+    pub endpoints: Option<EndpointsConfig>,
     /// CORS Configuration
     ///
     /// Defaults to `cors: true`, which allows all origins.
@@ -215,6 +212,31 @@ pub struct MetricsConfig {
     /// Example: `{ env: prod, server: martin }`
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub add_labels: HashMap<String, String>,
+
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
+    pub unrecognized: UnrecognizedValues,
+}
+
+/// Optional endpoints, each off unless enabled here.
+#[cfg(feature = "_tiles")]
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Default,
+    CollectUnrecognizedKeys,
+    ConfigurationLivecycleHooks,
+)]
+#[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
+pub struct EndpointsConfig {
+    /// Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \[default: false\]
+    ///
+    /// The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub purge_cache: Option<bool>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -118,6 +118,13 @@ pub struct SrvConfig {
     #[cfg(all(feature = "webui", not(docsrs)))]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &"disable"))]
     pub web_ui: Option<WebUiMode>,
+    /// Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \[default: false\]
+    ///
+    /// The route has no authentication of its own.
+    /// Put it behind the same proxy rules as the rest of the server.
+    #[cfg(feature = "_tiles")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub purge_endpoint: Option<bool>,
     /// CORS Configuration
     ///
     /// Defaults to `cors: true`, which allows all origins.

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -120,8 +120,7 @@ pub struct SrvConfig {
     pub web_ui: Option<WebUiMode>,
     /// Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \[default: false\]
     ///
-    /// The route has no authentication of its own.
-    /// Put it behind the same proxy rules as the rest of the server.
+    /// The route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.
     #[cfg(feature = "_tiles")]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
     pub purge_endpoint: Option<bool>,

--- a/martin/src/config/file/srv.rs
+++ b/martin/src/config/file/srv.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser};
 use crate::config::args::PreferredEncoding;
 #[cfg(all(feature = "webui", not(docsrs)))]
 use crate::config::args::WebUiMode;
-#[cfg(feature = "metrics")]
+#[cfg(any(feature = "metrics", feature = "_tiles"))]
 use crate::config::file::UnrecognizedValues;
 use crate::config::file::cors::CorsConfig;
 use crate::config::file::{CollectUnrecognizedKeys, ConfigurationLivecycleHooks, UnrecognizedKeys};

--- a/martin/src/schemas.rs
+++ b/martin/src/schemas.rs
@@ -35,6 +35,7 @@ pub fn config_json_schema() -> serde_json::Value {
         crate::srv::get_catalog,
         crate::srv::get_source_info,
         crate::srv::get_tile,
+        crate::srv::purge_source,
         crate::srv::get_sprite_png,
         crate::srv::get_sprite_sdf_png,
         crate::srv::get_sprite_json,

--- a/martin/src/srv/cache.rs
+++ b/martin/src/srv/cache.rs
@@ -5,7 +5,7 @@ use crate::tile_source_manager::TileSourceManager;
 
 /// Drops every cached tile of one source.
 ///
-/// Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.
+/// The body says whether tiles were dropped or no tile cache is configured, and an unknown source answers `404`.
 #[cfg_attr(
     feature = "unstable-schemas",
     utoipa::path(
@@ -13,7 +13,7 @@ use crate::tile_source_manager::TileSourceManager;
         path = "/cache/{source_id}",
         params(("source_id" = String, Path, description = "Source ID")),
         responses(
-            (status = 204, description = "The source's cached tiles are gone"),
+            (status = 200, description = "The source's cached tiles are gone, or there was no tile cache to drop them from. The body says which.", body = String),
             (status = 404, description = "No such source"),
         ),
     )
@@ -24,9 +24,12 @@ pub async fn purge_source(
     tile_manager: Data<TileSourceManager>,
 ) -> actix_web::Result<impl Responder> {
     tile_manager.tile_sources().get_source(&source_id)?;
-    if let Some(cache) = tile_manager.tile_cache() {
-        cache.invalidate_source(&source_id);
-        cache.run_pending_tasks().await;
-    }
-    Ok(HttpResponse::NoContent())
+    let Some(cache) = tile_manager.tile_cache() else {
+        return Ok(HttpResponse::Ok().body(format!(
+            "Source {source_id} has no cached tiles, tile caching is disabled"
+        )));
+    };
+    cache.invalidate_source(&source_id);
+    cache.run_pending_tasks().await;
+    Ok(HttpResponse::Ok().body(format!("Purged the cached tiles of source {source_id}")))
 }

--- a/martin/src/srv/cache.rs
+++ b/martin/src/srv/cache.rs
@@ -3,9 +3,6 @@ use actix_web::{HttpResponse, Responder, route};
 
 use crate::tile_source_manager::TileSourceManager;
 
-/// Drops every cached tile of one source.
-///
-/// The body says whether tiles were dropped or no tile cache is configured, and an unknown source answers `404`.
 #[cfg_attr(
     feature = "unstable-schemas",
     utoipa::path(
@@ -13,7 +10,7 @@ use crate::tile_source_manager::TileSourceManager;
         path = "/cache/{source_id}",
         params(("source_id" = String, Path, description = "Source ID")),
         responses(
-            (status = 200, description = "The source's cached tiles are gone, or there was no tile cache to drop them from. The body says which.", body = String),
+            (status = 200, description = "The source's cached tiles are gone, or tile cacheing is disabled.", body = String),
             (status = 404, description = "No such source"),
         ),
     )

--- a/martin/src/srv/cache.rs
+++ b/martin/src/srv/cache.rs
@@ -1,0 +1,32 @@
+use actix_web::web::{Data, Path};
+use actix_web::{HttpResponse, Responder, route};
+
+use crate::tile_source_manager::TileSourceManager;
+
+/// Drops every cached tile of one source.
+///
+/// Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.
+#[cfg_attr(
+    feature = "unstable-schemas",
+    utoipa::path(
+        delete,
+        path = "/cache/{source_id}",
+        params(("source_id" = String, Path, description = "Source ID")),
+        responses(
+            (status = 204, description = "The source's cached tiles are gone"),
+            (status = 404, description = "No such source"),
+        ),
+    )
+)]
+#[route("/cache/{source_id}", method = "DELETE")]
+pub async fn purge_source(
+    source_id: Path<String>,
+    tile_manager: Data<TileSourceManager>,
+) -> actix_web::Result<impl Responder> {
+    tile_manager.tile_sources().get_source(&source_id)?;
+    if let Some(cache) = tile_manager.tile_cache() {
+        cache.invalidate_source(&source_id);
+        cache.run_pending_tasks().await;
+    }
+    Ok(HttpResponse::NoContent())
+}

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -20,8 +20,13 @@ pub use server::{RESERVED_KEYWORDS, new_server, router};
 
 mod admin;
 pub use admin::Catalog;
+
+#[cfg(feature = "_tiles")]
+mod cache;
 #[cfg(feature = "unstable-schemas")]
 pub use admin::{__path_get_catalog, get_catalog};
+#[cfg(all(feature = "_tiles", feature = "unstable-schemas"))]
+pub use cache::{__path_purge_source, purge_source};
 
 #[cfg(feature = "_tiles")]
 pub(crate) mod tiles;

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -153,7 +153,11 @@ fn register_services(
         // Register /tiles/ prefix redirect after main tile route
         cfg.service(tiles::content::redirect_tiles);
 
-        if usr_cfg.purge_endpoint.unwrap_or(false) {
+        if usr_cfg
+            .endpoints
+            .as_ref()
+            .is_some_and(|endpoints| endpoints.purge_cache.unwrap_or(false))
+        {
             cfg.service(super::cache::purge_source);
         }
     }

--- a/martin/src/srv/server.rs
+++ b/martin/src/srv/server.rs
@@ -121,7 +121,7 @@ pub fn router(cfg: &mut web::ServiceConfig, usr_cfg: &SrvConfig) {
         cfg.service(web::scope(prefix).configure(|cfg| {
             register_services(
                 cfg,
-                #[cfg(all(feature = "webui", not(docsrs)))]
+                #[cfg(any(all(feature = "webui", not(docsrs)), feature = "_tiles"))]
                 usr_cfg,
             );
         }));
@@ -129,7 +129,7 @@ pub fn router(cfg: &mut web::ServiceConfig, usr_cfg: &SrvConfig) {
     } else {
         register_services(
             cfg,
-            #[cfg(all(feature = "webui", not(docsrs)))]
+            #[cfg(any(all(feature = "webui", not(docsrs)), feature = "_tiles"))]
             usr_cfg,
         );
     }
@@ -138,7 +138,7 @@ pub fn router(cfg: &mut web::ServiceConfig, usr_cfg: &SrvConfig) {
 /// Helper function to register all services
 fn register_services(
     cfg: &mut web::ServiceConfig,
-    #[cfg(all(feature = "webui", not(docsrs)))] usr_cfg: &SrvConfig,
+    #[cfg(any(all(feature = "webui", not(docsrs)), feature = "_tiles"))] usr_cfg: &SrvConfig,
 ) {
     cfg.service(get_health).service(get_catalog);
 
@@ -152,6 +152,10 @@ fn register_services(
 
         // Register /tiles/ prefix redirect after main tile route
         cfg.service(tiles::content::redirect_tiles);
+
+        if usr_cfg.purge_endpoint.unwrap_or(false) {
+            cfg.service(super::cache::purge_source);
+        }
     }
 
     #[cfg(feature = "sprites")]

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -1755,7 +1755,7 @@
       "description": "Which compression should be used if the\n- client accepts multiple compression formats, and\n- tile source is not pre-compressed.\n\n`gzip` is faster, but `brotli` is smaller, and may be faster with caching.\nDefault could be different depending on Martin version."
     },
     "purge_endpoint": {
-      "description": "Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \\[default: false\\]\n\nThe route has no authentication of its own.\nPut it behind the same proxy rules as the rest of the server.",
+      "description": "Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \\[default: false\\]\n\nThe route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.",
       "examples": [false],
       "type": ["boolean", "null"]
     },

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -320,6 +320,17 @@
       "enum": ["disable"],
       "type": "string"
     },
+    "EndpointsConfig": {
+      "description": "Optional endpoints, each off unless enabled here.",
+      "properties": {
+        "purge_cache": {
+          "description": "Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \\[default: false\\]\n\nThe route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.",
+          "examples": [false],
+          "type": ["boolean", "null"]
+        }
+      },
+      "type": "object"
+    },
     "FileConfig": {
       "properties": {
         "convert_to_mlt": {
@@ -1684,6 +1695,17 @@
       ],
       "description": "CORS Configuration\n\nDefaults to `cors: true`, which allows all origins.\nSending/Acting on CORS headers can be completely disabled via `cors: false`"
     },
+    "endpoints": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EndpointsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional endpoints, each off unless enabled here."
+    },
     "fonts": {
       "$ref": "#/$defs/FileConfigEnum6",
       "description": "Font configuration"
@@ -1753,11 +1775,6 @@
         }
       ],
       "description": "Which compression should be used if the\n- client accepts multiple compression formats, and\n- tile source is not pre-compressed.\n\n`gzip` is faster, but `brotli` is smaller, and may be faster with caching.\nDefault could be different depending on Martin version."
-    },
-    "purge_endpoint": {
-      "description": "Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \\[default: false\\]\n\nThe route has no authentication of its own, so to prevent DOS please put it behind a reverse proxy.",
-      "examples": [false],
-      "type": ["boolean", "null"]
     },
     "route_prefix": {
       "description": "Set the URL path prefix for all API routes.\nWhen set, Martin will serve all endpoints under this path prefix.\nThis allows Martin to be served under a subpath when behind a reverse proxy (e.g., Traefik).\nMust begin with a `/`.\nExamples: `/tiles`, `/api/v1/tiles`",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -1754,6 +1754,11 @@
       ],
       "description": "Which compression should be used if the\n- client accepts multiple compression formats, and\n- tile source is not pre-compressed.\n\n`gzip` is faster, but `brotli` is smaller, and may be faster with caching.\nDefault could be different depending on Martin version."
     },
+    "purge_endpoint": {
+      "description": "Serve `DELETE /cache/{source_id}`, which drops that source's cached tiles. \\[default: false\\]\n\nThe route has no authentication of its own.\nPut it behind the same proxy rules as the rest of the server.",
+      "examples": [false],
+      "type": ["boolean", "null"]
+    },
     "route_prefix": {
       "description": "Set the URL path prefix for all API routes.\nWhen set, Martin will serve all endpoints under this path prefix.\nThis allows Martin to be served under a subpath when behind a reverse proxy (e.g., Traefik).\nMust begin with a `/`.\nExamples: `/tiles`, `/api/v1/tiles`",
       "type": ["string", "null"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -434,6 +434,33 @@
         "tags": ["crate::srv"]
       }
     },
+    "/cache/{source_id}": {
+      "delete": {
+        "description": "Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.",
+        "operationId": "purge_source",
+        "parameters": [
+          {
+            "description": "Source ID",
+            "in": "path",
+            "name": "source_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The source's cached tiles are gone"
+          },
+          "404": {
+            "description": "No such source"
+          }
+        },
+        "summary": "Drops every cached tile of one source.",
+        "tags": ["crate::srv"]
+      }
+    },
     "/catalog": {
       "get": {
         "operationId": "get_catalog",

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -436,7 +436,6 @@
     },
     "/cache/{source_id}": {
       "delete": {
-        "description": "Answers `404` for an unknown source and `204` otherwise, also when no tile cache is configured.",
         "operationId": "purge_source",
         "parameters": [
           {
@@ -450,14 +449,20 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "The source's cached tiles are gone"
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The source's cached tiles are gone, or tile cacheing is disabled."
           },
           "404": {
             "description": "No such source"
           }
         },
-        "summary": "Drops every cached tile of one source.",
         "tags": ["crate::srv"]
       }
     },


### PR DESCRIPTION
Closes #1707

Martin can drop a source's cached tiles when a file source changes, but nothing outside the process can ask for it. A PostgreSQL user whose rows change has only the TTL knob or a full restart.

This adds `DELETE /cache/{source_id}`, behind `purge_endpoint: true` in the config (off by default). It calls the same `invalidate_source` the reloaders use and answers `200` with a body saying whether tiles were dropped or no tile cache is configured, or `404` for an unknown source. Like the rest of the server it carries no auth of its own, so it goes behind the same proxy rules (`auth_request` on `/cache/` with the nginx setup from #3184).

A Postgres `LISTEN/NOTIFY` hook so a trigger can do this in-band is the natural next step, but this small piece works on its own, so I'll save the trigger for a follow-up to close out the ticket.

