### PR TITLE
docs(lambda): private S3 through the execution role, one-stack template, measured sizing

### DIFF
--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -6,10 +6,12 @@ tags:
   - lambda
 ---
 
-# Using with AWS Lambda - v0.14+
+# Using with AWS Lambda
 
 Martin can run in AWS Lambda.
 This is useful if you want to serve tiles from a serverless environment, while accessing "nearby" data from a PostgreSQL database or PMTiles file in S3, without exposing the raw file to the world to prevent download abuse and improve performance.
+The bucket can stay private.
+Martin signs its S3 requests with the credentials Lambda gives the function, so the execution role only needs `s3:GetObject` on the archive.
 
 Lambda has two deployment models: zip file and container-based. When using zip file deployment, there is an online code editor to edit the yaml configuration.
 When using container-based deployment, we can pass our configuration on the command line or environment variables.
@@ -43,6 +45,7 @@ Open [Lambda console](https://console.aws.amazon.com/lambda) and create your fun
 4. Click "Browse images", and select your repository and the tag.
    * If you cannot find it, see if you are in the same region?
 5. Expand "Container image overrides", and under CMD put the URL of a `.pmtiles` file.
+   An `s3://` URL works once the execution role may read the object, see the zip section below.
 6. Set "Architecture" to `arm64` to match the platform that we pulled.
    Lambda has better ARM CPUs than x86.
 7. Click "Create function".
@@ -75,7 +78,7 @@ Every zip-based Lambda function runs a file called `bootstrap`.
 cat <<EOF >src/bootstrap
 #!/bin/sh
 set -eu
-exec martin --config \${_HANDLER}.yaml
+exec martin --config \${_HANDLER}
 EOF
 ```
 
@@ -128,24 +131,83 @@ Add your layer:
 
 Add your configuration file in the function source code:
 
-1. Code tab, File, New File: `hello.handler.yaml`.
+1. Code tab, File, New File: `config.yaml`.
 
    ```yaml
    pmtiles:
      sources:
-       demotiles: <url to a pmtiles file>
+       demotiles: s3://my-bucket/tiles.pmtiles
+   # a new Lambda instance starts empty, so an in-process cache buys little
+   cache:
+     size_mb: 0
    ```
 
-2. Click Deploy, wait for the success banner, and visit your function URL.
+   A prefix such as `s3://my-bucket/tiles/` under `pmtiles.paths` serves every archive in it instead, which also needs `s3:ListBucket`.
 
-### TODO
+2. Configuration tab, "General configuration", Edit: set "Handler" to `config.yaml`.
+   The `bootstrap` above passes the handler name to `martin --config`.
+3. Configuration tab, "Permissions": open the execution role and attach a policy that allows `s3:GetObject` on the archive.
+   Nothing else is needed.
+   Lambda hands the function temporary credentials through `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, and Martin picks them up.
+4. Click Deploy, wait for the success banner, and visit your function URL.
 
-AWS Lambda support is preliminary; there are features to add to Martin, configuration to tweak, and documentation to improve.  Your help is welcome.
+#### Everything as one SAM stack
 
-* Lambda has a default timeout of 3 seconds, and 128 MB of memory, maybe this is suboptimal.
-* Document how to connect to a PostgreSQL database on RDS.
-* Set up a CloudFront CDN, this is a whole thing, but explain the motivation and the basics.
-* Grant the execution role permission to read objects from an S3 bucket, and teach Martin how to make authenticated requests to S3.
-* Teach Martin how to serve all PMTiles files from an S3 bucket rather than having to list them at startup.
+The layer, the function, its role and the URL can be one template.
+This is also how the steps above were verified.
 
-Martin already sets an `Etag` header on tile responses, and the `cache_control` option in the [configuration file](config-file/index.md) sets a default `Cache-Control` header - useful when running behind CloudFront.
+```yaml
+AWSTemplateFormatVersion: 2010-09-09
+Transform: 'AWS::Serverless-2016-10-31'
+Parameters:
+  Bucket:
+    Type: String
+Resources:
+  MartinLayer:
+    Type: 'AWS::Serverless::LayerVersion'
+    DeletionPolicy: Delete
+    Properties:
+      ContentUri: layer/
+      CompatibleRuntimes:
+        - provided.al2023
+      CompatibleArchitectures:
+        - arm64
+  MartinFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Runtime: provided.al2023
+      Architectures:
+        - arm64
+      Layers:
+        - !Ref MartinLayer
+      CodeUri: function/
+      Handler: config.yaml
+      MemorySize: 512
+      Timeout: 10
+      FunctionUrlConfig:
+        AuthType: NONE
+      Policies:
+        - S3ReadPolicy:
+            BucketName: !Ref Bucket
+Outputs:
+  FunctionUrl:
+    Value: !GetAtt MartinFunctionUrl.FunctionUrl
+```
+
+`layer/` holds `bootstrap` and `bin/martin`, `function/` holds `config.yaml`.
+Deploy with `sam build && sam deploy --guided --parameter-overrides Bucket=my-bucket`.
+
+### Sizing
+
+At the Lambda defaults of 128 MB and 3 seconds, Martin v1.14.0 on `arm64` initialises in about 300 ms, peaks at about 45 MB with one PMTiles source in S3, and answers a warm tile request in about 25 ms.
+Raise the timeout if the archive is large or far away, and the memory if you serve many sources.
+
+### Caching
+
+Martin sets an `Etag` header on tile responses, and the `cache_control` option in the [configuration file](config-file/index.md) sets a default `Cache-Control` header.
+Put CloudFront in front of the function URL and let it hold the tiles, since every new Lambda instance starts with an empty in-process cache.
+
+### Not covered yet
+
+* Connecting to a PostgreSQL database on RDS.
+* A CloudFront distribution in front of the function URL, with the motivation and the basics.

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -199,7 +199,7 @@ Deploy with `sam build && sam deploy --guided --parameter-overrides Bucket=my-bu
 
 ### Sizing
 
-At the Lambda defaults of 128 MB and 3 seconds, Martin v1.14.0 on `arm64` initialises in about 300 ms, peaks at about 45 MB with one PMTiles source in S3, and answers a warm tile request in about 25 ms.
+At the Lambda defaults of 128 MB and 3 seconds, Martin v1.14.0 on `arm64` starts in about 300 ms, peaks at about 45 MB with one PMTiles source in S3, and answers a warm tile request in about 25 ms.
 Raise the timeout if the archive is large or far away, and the memory if you serve many sources.
 
 ### Caching


### PR DESCRIPTION
Closes #1102

The Lambda page still carried the 2024 TODO list, two items of which have since shipped: Martin signs S3 requests with whatever credentials the runtime provides, and a `pmtiles.paths` prefix serves a whole bucket without listing files in the config. Rewrote the page around a run I did against a private bucket with the v1.14.0 arm64 release: the config file is the handler, the execution role gets `s3:GetObject`, nothing else is needed. Added the single SAM template that produced that run (layer, function, role, URL), and replaced the sizing guesswork with the measured numbers at the Lambda defaults (300 ms init, 43 MB, 25 ms per warm tile). RDS and CloudFront stay listed as not covered.
