### PR TITLE
fix(pmtiles): stop calling the AWS SDK's own variables deprecated

### DIFF
--- a/e2e-tests/src/martin.rs
+++ b/e2e-tests/src/martin.rs
@@ -452,13 +452,12 @@ impl Martin {
     }
 
     /// Assert the warnings a martin start that resolves pmtiles configuration emits under this
-    /// harness: `pmtiles.allow_http` defaults, plus the deprecation of the two `AWS_*` variables
-    /// [`MartinBuilder::start`] sets.
+    /// harness: `pmtiles.allow_http` defaults, plus the deprecation of the `AWS_SKIP_CREDENTIALS`
+    /// variable [`MartinBuilder::start`] sets.
     /// Must be called after [`Martin::stop`].
     pub fn assert_startup_warnings(&mut self) {
         self.assert_log_contains("Defaulting `pmtiles.allow_http` to `true`");
         self.assert_log_contains("Environment variable AWS_SKIP_CREDENTIALS is deprecated");
-        self.assert_log_contains("Environment variable AWS_REGION is deprecated");
     }
 
     /// Assert that no unexpected `WARN` or `ERROR` lines remain in the log

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.9.0",
         "@radix-ui/react-dialog": "1.1.23",

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -436,7 +436,8 @@ impl PmtConfig {
             }
         }
 
-        // lowercase(env_key) => new key
+        // The AWS SDK's own variables, injected by Lambda, ECS and CI runners.
+        // Adopted silently: they are the documented SDK contract, not a deprecated spelling.
         for env_key in [
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
@@ -448,7 +449,7 @@ impl PmtConfig {
                 let new_key_without_aws_prefix = new_key_with_aws_prefix
                     .strip_prefix("aws_")
                     .expect("all our keys start with aws_");
-                self.migrate_aws_value(
+                self.adopt_aws_value(
                     "Environment variable",
                     env_key,
                     new_key_without_aws_prefix,
@@ -471,7 +472,24 @@ impl PmtConfig {
         }
     }
 
+    /// [`Self::adopt_aws_value`] plus a deprecation warning when the value is taken.
     fn migrate_aws_value(&mut self, r#type: &'static str, key: &str, new_key: &str, value: String) {
+        if self.adopt_aws_value(r#type, key, new_key, value) {
+            warn!(
+                "{type} {key} is deprecated. Please use pmtiles.{new_key} in the configuration file instead."
+            );
+        }
+    }
+
+    /// Takes `value` for `new_key` unless the configuration already sets it, warning only then.
+    /// Returns whether the value was taken.
+    fn adopt_aws_value(
+        &mut self,
+        r#type: &'static str,
+        key: &str,
+        new_key: &str,
+        value: String,
+    ) -> bool {
         let new_key_with_aws_prefix = format!("aws_{new_key}");
         if self.options.contains_key(new_key) {
             warn!(
@@ -482,11 +500,10 @@ impl PmtConfig {
                 "{type} {key} is ignored in favor of the new configuration value pmtiles.{new_key_with_aws_prefix}."
             );
         } else {
-            warn!(
-                "{type} {key} is deprecated. Please use pmtiles.{new_key} in the configuration file instead."
-            );
             self.options.insert(new_key.to_owned(), value);
+            return true;
         }
+        false
     }
 
     /// Forwards the credential-discovery variables to the S3 client so task roles work without configuration.

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.14.0"
+    "version": "1.15.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
Every cold start on Lambda, every ECS/EKS task and every CI job with AWS credentials logged four warnings claiming `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION` are deprecated and should be moved into the config file. Those four are the AWS SDK's own contract, injected by the runtime rather than written by the operator, and a session token that rotates hourly cannot live in a config file. They are now adopted silently; the warning stays for the martin-specific spellings (`AWS_SKIP_CREDENTIALS`, `AWS_NO_CREDENTIALS`, `AWS_S3_FORCE_PATH_STYLE`, `AWS_PROFILE`) and for the ignored-in-favor-of-config case. Seen while verifying the Lambda docs (#3195), logs there.
