### PR TITLE
docs(cache): the zoom default is overridable per source, not per source type

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -37,7 +37,7 @@ cache:
   maxzoom: 14
   # Default minimum zoom level (inclusive) for tile caching.
   # Tiles further zoomed out than this will bypass the cache entirely.
-  # Can be overridden per-source (e.g. `cache.minzoom` on a type of source or an individual source).
+  # Can be overridden with `cache.minzoom` on an individual source.
   # default: null (no lower bound, all zoom levels cached)
   minzoom: 0
   # Total amount of cache we use [default: 512, 0 to disable]

--- a/martin-core/src/cache_zoom_range.rs
+++ b/martin-core/src/cache_zoom_range.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct CacheZoomRange {
     /// Default minimum zoom level (inclusive) for tile caching.
     /// Tiles further zoomed out than this will bypass the cache entirely.
-    /// Can be overridden per-source (e.g. `cache.minzoom` on a type of source or an individual source).
+    /// Can be overridden with `cache.minzoom` on an individual source.
     /// default: null (no lower bound, all zoom levels cached)
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &0u8))]
     minzoom: Option<u8>,

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.9.0",
         "@radix-ui/react-dialog": "1.1.23",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -119,7 +119,7 @@
           "type": ["integer", "null"]
         },
         "minzoom": {
-          "description": "Default minimum zoom level (inclusive) for tile caching.\nTiles further zoomed out than this will bypass the cache entirely.\nCan be overridden per-source (e.g. `cache.minzoom` on a type of source or an individual source).\ndefault: null (no lower bound, all zoom levels cached)",
+          "description": "Default minimum zoom level (inclusive) for tile caching.\nTiles further zoomed out than this will bypass the cache entirely.\nCan be overridden with `cache.minzoom` on an individual source.\ndefault: null (no lower bound, all zoom levels cached)",
           "examples": [0],
           "format": "uint8",
           "maximum": 255,
@@ -823,7 +823,7 @@
           "type": ["integer", "null"]
         },
         "minzoom": {
-          "description": "Default minimum zoom level (inclusive) for tile caching.\nTiles further zoomed out than this will bypass the cache entirely.\nCan be overridden per-source (e.g. `cache.minzoom` on a type of source or an individual source).\ndefault: null (no lower bound, all zoom levels cached)",
+          "description": "Default minimum zoom level (inclusive) for tile caching.\nTiles further zoomed out than this will bypass the cache entirely.\nCan be overridden with `cache.minzoom` on an individual source.\ndefault: null (no lower bound, all zoom levels cached)",
           "examples": [0],
           "format": "uint8",
           "maximum": 255,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.14.0"
+    "version": "1.15.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
Part of #1137

The generated config doc claimed `cache.minzoom`/`cache.maxzoom` can be overridden on a type of source. Only the global default and the individual source exist.
