### PR TITLE
chore: release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,8 @@ repos:
             sed -i "s/version\": \".*\"/version\": \"$VERSION\"/" martin/martin-ui/package.json
             grep -rl "ghcr.io/maplibre/martin:" docs demo justfile \
               | xargs -r sed -i "s%ghcr.io/maplibre/martin:[^[:space:]]*%ghcr.io/maplibre/martin:$VERSION%"
+            grep -rl "Martin v[0-9]" martin/src/tui/snapshots \
+              | xargs -r sed -i "s/Martin v[0-9][^[:space:]]*/Martin v$VERSION/g"
             echo "Synced version to $VERSION"
           '
         language: system

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "actix-web",
  "approx",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "martin-tile-utils"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "approx",
  "brotli 8.0.4",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.9.0"
 martin-config-macros = { path = "./martin-config-macros", version = "0.1.1" }
-martin-core = { path = "./martin-core", version = "0.11.1", default-features = false }
-martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.7" }
-mbtiles = { path = "./mbtiles", version = "0.19.2" }
+martin-core = { path = "./martin-core", version = "0.11.2", default-features = false }
+martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.8" }
+mbtiles = { path = "./mbtiles", version = "0.19.3" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12.3", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.15.0
+    image: ghcr.io/maplibre/martin:1.16.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/files/compose.nginx.yaml
+++ b/docs/content/files/compose.nginx.yaml
@@ -11,7 +11,7 @@ services:
       - martin
 
   martin:
-    image: ghcr.io/maplibre/martin:1.15.0
+    image: ghcr.io/maplibre/martin:1.16.0
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgres://postgres:password@db/db

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.15.0 \
+           ghcr.io/maplibre/martin:1.16.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.15.0
+    image: ghcr.io/maplibre/martin:1.16.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.15.0
+  ghcr.io/maplibre/martin:1.16.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.15.0 \
+  ghcr.io/maplibre/martin:1.16.0 \
   /files
 ```
 
@@ -36,7 +36,7 @@ You can also pass any [CLI flags](run-with-cli.md) after the image name, for exa
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.15.0 \
+  ghcr.io/maplibre/martin:1.16.0 \
   --webui enable-for-all \
   /files
 ```
@@ -53,7 +53,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.15.0
+  ghcr.io/maplibre/martin:1.16.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -64,7 +64,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.15.0
+  ghcr.io/maplibre/martin:1.16.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -75,5 +75,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.15.0
+  ghcr.io/maplibre/martin:1.16.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -24,13 +24,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.15.0 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.16.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.15.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.16.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -387,7 +387,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.15.0 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.16.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/maplibre/martin/compare/martin-core-v0.11.1...martin-core-v0.11.2) - 2026-09-06
+
+### Added
+
+- *(cog)* stream configured remote objects ([#3266](https://github.com/maplibre/martin/pull/3266))
+- *(postgres)* add a CQL2 filter to table sources ([#3238](https://github.com/maplibre/martin/pull/3238))
+- *(postgres)* publish every overload of a function ([#3243](https://github.com/maplibre/martin/pull/3243))
+- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
+- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
+- *(postgres)* retry the first database connection at startup ([#3231](https://github.com/maplibre/martin/pull/3231))
+- *(postgres)* serve a function's key column as the tile ETag ([#3219](https://github.com/maplibre/martin/pull/3219))
+- *(sprites)* add sprite aliases ([#3220](https://github.com/maplibre/martin/pull/3220))
+- *(fonts)* add font aliases (named font stacks) ([#3210](https://github.com/maplibre/martin/pull/3210))
+- *(cache)* cache tiles in the encoding the client receives ([#3211](https://github.com/maplibre/martin/pull/3211))
+- *(martin-cp)* skip the tiles below an empty tile ([#3208](https://github.com/maplibre/martin/pull/3208))
+
+### Other
+
+- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
+- make the Windows-only unit test job pass again ([#3269](https://github.com/maplibre/martin/pull/3269))
+- *(duckdb)* prune GeoParquet row groups with the file's covering bbox ([#3215](https://github.com/maplibre/martin/pull/3215))
+- *(cache)* the zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
+
 ## [0.11.1](https://github.com/maplibre/martin/compare/martin-core-v0.11.0...martin-core-v0.11.1) - 2026-08-31
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin-tile-utils/Cargo.toml
+++ b/martin-tile-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-tile-utils"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Utilities to help with map tile processing, such as type and compression detection. Used by the MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -9,62 +9,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.16.0](https://github.com/maplibre/martin/compare/martin-v1.15.0...martin-v1.16.0) - 2026-09-06
 
+### Aliases for fonts, sprites and tile sources
+
+A style no longer has to spell out a combination of sources on every request.
+`fonts.aliases`, `sprites.aliases` and the top-level `aliases` block each name a combination of sources that a client requests like a single one: a named font stack served in the listed fallback order, one sprite name covering several sprite sources, and `/{alias}/{z}/{x}/{y}` serving exactly what `/{a},{b}` serves.
+
+```yaml
+aliases:
+  basemap: [roads, buildings]
+fonts:
+  aliases:
+    Noto Sans Stack: [Noto Sans Regular, Noto Sans Arabic Regular]
+sprites:
+  aliases:
+    icons: [transit, poi]
+```
+
+An alias may only reference real sources, never another alias, and it may share the name of a source it references, so an existing name can gain fallbacks or icons without touching a single style.
+Every alias is validated at startup, listed in the catalog under its own name, and its cache keys are the expanded sources, so purging a source also drops what its aliases served.
+See the documentation for [tile](https://maplibre.org/martin/sources-composite/), [font](https://maplibre.org/martin/sources-fonts/) and [sprite](https://maplibre.org/martin/sources-sprites/) aliases.
+Done in [#3229](https://github.com/maplibre/martin/pull/3229), [#3210](https://github.com/maplibre/martin/pull/3210) and [#3220](https://github.com/maplibre/martin/pull/3220).
+
+### CQL2 filters on table sources
+
+A table source serves every row of its table, and narrowing it down used to mean writing a function source that re-declares by hand what table discovery already knows.
+A configured table now takes a `filter` written in CQL2 text, which Martin validates at startup and translates to SQL for the tile query, so a typo fails at load rather than on the first tile.
+
+```yaml
+postgres:
+  tables:
+    large_cities:
+      filter: population > 100000 AND name NOT LIKE 'Old %'
+```
+
+The filter also narrows the computed bounds, and two entries on the same table with different filters are two distinct sources instead of the duplicate they used to warn about.
+See the [documentation](https://maplibre.org/martin/sources-pg-tables/).
+Done in [#3238](https://github.com/maplibre/martin/pull/3238).
+
+### A terminal dashboard behind `--tui`
+
+`martin --tui` turns the terminal Martin runs in into a live view of the server: the sources with their request counts and timings, the request rate, the tile requests of the last minute on a world map, and the log in a pane at the bottom, with `q` stopping the server.
+It is meant for the moments where Prometheus and Grafana are too much setup, such as a demo, a first run against a new database, or a look at a deployment over ssh.
+The flag refuses a stdout that is not a terminal, so a service or a container keeps its plain log stream.
+See the [documentation](https://maplibre.org/martin/run-with-cli/).
+Done in [#3244](https://github.com/maplibre/martin/pull/3244).
+
 ### Added
 
-- *(cog)* stream configured remote objects ([#3266](https://github.com/maplibre/martin/pull/3266))
-- add a terminal dashboard behind --tui ([#3244](https://github.com/maplibre/martin/pull/3244))
-- *(postgres)* add a CQL2 filter to table sources ([#3238](https://github.com/maplibre/martin/pull/3238))
-- *(postgres)* publish every overload of a function ([#3243](https://github.com/maplibre/martin/pull/3243))
-- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
-- *(sprites, styles)* publish each subdirectory of a collection as its own source ([#3230](https://github.com/maplibre/martin/pull/3230))
-- *(postgres)* retry the first database connection at startup ([#3231](https://github.com/maplibre/martin/pull/3231))
-- *(duckdb)* read GeoParquet from s3 and the other object stores DuckDB supports ([#3214](https://github.com/maplibre/martin/pull/3214))
-- add tile source aliases ([#3229](https://github.com/maplibre/martin/pull/3229))
-- *(postgres)* add a connection-level cache zoom default ([#3221](https://github.com/maplibre/martin/pull/3221))
-- *(config)* add a per-kind cache zoom default for file and passthrough sources ([#3223](https://github.com/maplibre/martin/pull/3223))
-- *(postgres)* serve a function's key column as the tile ETag ([#3219](https://github.com/maplibre/martin/pull/3219))
-- *(sprites)* add sprite aliases ([#3220](https://github.com/maplibre/martin/pull/3220))
-- *(fonts)* add font aliases (named font stacks) ([#3210](https://github.com/maplibre/martin/pull/3210))
-- *(cache)* cache tiles in the encoding the client receives ([#3211](https://github.com/maplibre/martin/pull/3211))
-- *(martin-cp)* skip the tiles below an empty tile ([#3208](https://github.com/maplibre/martin/pull/3208))
-- *(discovery)* scan paths recursively with recursive: true ([#3203](https://github.com/maplibre/martin/pull/3203))
-- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
-- *(mbtiles)* record and honour the tile hash algorithm ([#3262](https://github.com/maplibre/martin/pull/3262))
-- *(mbtiles)* copy several source files into one destination ([#3239](https://github.com/maplibre/martin/pull/3239))
-- *(mbtiles)* show progress for the long commands ([#3235](https://github.com/maplibre/martin/pull/3235))
+- *(unstable-cog)* an explicitly configured remote HTTP or S3-compatible COG object is read through a new async, range-based reader over the object-store configuration PMTiles uses, so authentication, endpoint, proxy and client options carry over, credentials are redacted from logs, errors and `--save-config` output, and malformed metadata is an error rather than a panic. This is a step of [#875](https://github.com/maplibre/martin/issues/875): such an object is loaded once at startup, and replacement detection, remote prefix listing and the matching docs are not yet implemented ([#3266](https://github.com/maplibre/martin/pull/3266))
+- *(unstable-duckdb)* GeoParquet sources became usable on the datasets they are meant for. Locations accept `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` URLs on top of `http(s)` and are handed to DuckDB to read: an `s3://` path (see Overture Maps documentation) could not be configured at all before, and DuckDB expands globs over it but not over plain HTTP, so one source can cover a dataset split across part files. Tile queries then prune row groups with the file's covering bbox, so a tile reads the parts of the file that can contain it instead of all of them. duckdb lacks this due to the interop between `duckdb-spatial` <-> `duckdb-parquet` this would require by default. ([#3214](https://github.com/maplibre/martin/pull/3214), [#3215](https://github.com/maplibre/martin/pull/3215))
+- *(discovery)* an opt-in `recursive: true` next to `paths` for the mbtiles, pmtiles, cog and geojson kinds. A nested file is published under its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads` and no existing id moves. The watcher follows the same flag ([#3203](https://github.com/maplibre/martin/pull/3203))
+- *(sprites, styles)* `collections`, which publishes every directory inside a listed root as its own source: a sprite per directory, and every `.json` inside one as `<directory>.<file>`. That is a per-project layout in one line of config, without the single merged sprite a recursive `paths` entry produces ([#3230](https://github.com/maplibre/martin/pull/3230))
+- *(cache)* a second cache entry keyed by the negotiated encoding, so a tile a source hands over uncompressed is no longer compressed again on every request. On a warm cache against PostgreSQL sources, `get_tile_content` dropped from 107 µs to 29 µs on average and throughput rose from 103k to 114k req/s ([#3211](https://github.com/maplibre/martin/pull/3211))
+- *(postgres)* an overloaded function is one source that routes on the request: a bare URL runs the queryless variant, a URL with a query string the query-taking one, and any further variant becomes its own source with a `.1` suffix. Previously whichever variant the discovery query listed last won, behind a warning nobody could act on ([#3243](https://github.com/maplibre/martin/pull/3243))
+- *(postgres)* functions returning gzip- or zlib-compressed tiles are detected by magic bytes and passed through to clients that accept the encoding, instead of being compressed a second time ([#3236](https://github.com/maplibre/martin/pull/3236))
+- *(postgres)* a function's key column is served as the tile ETag instead of a hash of the tile bytes, which was never stable for a PostGIS tile since PostgreSQL does not fix feature order without an `ORDER BY` ([#3219](https://github.com/maplibre/martin/pull/3219))
+- *(postgres)* `postgres.connection_retries` (`--pg-connection-retries`) retries the first connection once per second, 30 times by default, so Martin no longer exits when the database is not accepting connections yet a few seconds into a container stack boot. A wrong password or database name still fails at once ([#3231](https://github.com/maplibre/martin/pull/3231))
+- *(cache)* a per-connection `postgres.cache` and a per-kind `cache` in the `mbtiles`, `pmtiles`, `cog`, `geojson`, `duckdb` and `passthrough` blocks, layered over the global bounds. Keeping a whole discovered schema or kind out of the cache no longer means declaring every source ([#3221](https://github.com/maplibre/martin/pull/3221), [#3223](https://github.com/maplibre/martin/pull/3223))
+- *(martin-cp)* copying zoom by zoom and skipping the tiles below an empty tile, wherever the source promises that an empty tile only has empty tiles below it, which PostgreSQL table sources do. On the test database's `table_source` over z0-z10, a world-bbox run went from 243 s and 1,398,101 fetched tiles to 11 s and 15,557, writing the same 14,619 tiles ([#3208](https://github.com/maplibre/martin/pull/3208))
+- *(mbtiles)* a startup warning naming the missing `CREATE UNIQUE INDEX` when a served file has no index on `(zoom_level, tile_column, tile_row)`, which made every tile request scan the table ([#3234](https://github.com/maplibre/martin/pull/3234))
+- *(mbtiles)* every hash is computed with the algorithm the file records in `hash_algorithm`, and every file the tool creates records one. `fnv1a`, `xxh64`, `xxh3` and tippecanoe's `fnv1a-decimal` join `md5`, which stays the meaning of a file without the key ([#3262](https://github.com/maplibre/martin/pull/3262))
+- *(mbtiles)* `copy` takes any number of source files before the destination and copies them in order, with `--on-duplicate` deciding which file wins ([#3239](https://github.com/maplibre/martin/pull/3239))
+- *(mbtiles)* progress for the long commands: a bar for `unpack`, a running tile count for `pack`, and a spinner with the elapsed time for `copy`, `diff`, `apply-patch` and `validate`. Nothing is drawn when stderr is not a terminal ([#3235](https://github.com/maplibre/martin/pull/3235))
 
 ### Fixed
 
-- *(reload)* flake fix: skip a collection project removed mid-rescan ([#3263](https://github.com/maplibre/martin/pull/3263))
-- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))
-- *(reload)* flake fix: recover when a project directory is removed mid-rescan ([#3258](https://github.com/maplibre/martin/pull/3258))
-- *(deps)* update npm dependencies ([#3249](https://github.com/maplibre/martin/pull/3249))
-- *(reload)* fix recursive-paths CI flake, recheck when a new dir appears  ([#3240](https://github.com/maplibre/martin/pull/3240))
-- *(duckdb)* cast or drop property columns ST_AsMVT cannot encode ([#3213](https://github.com/maplibre/martin/pull/3213))
+- *(duckdb)* cast or drop the property columns `ST_AsMVT` cannot encode, instead of failing the tile ([#3213](https://github.com/maplibre/martin/pull/3213))
+- *(contour)* run traced tiles through the MLT transcoder, so a contour source honours `convert_to_mlt` ([#3202](https://github.com/maplibre/martin/pull/3202))
 - *(reload)* apply the global cache zoom bounds to discovered files ([#3222](https://github.com/maplibre/martin/pull/3222))
-- *(contour)* run traced tiles through the MLT transcoder ([#3202](https://github.com/maplibre/martin/pull/3202))
-- *(deps)* update npm dependencies ([#3205](https://github.com/maplibre/martin/pull/3205))
-- *(mbtiles)* drop the kind-level convert_to_hillshade and convert_to_contour fields ([#3199](https://github.com/maplibre/martin/pull/3199))
+- *(mbtiles)* drop the kind-level `convert_to_hillshade` and `convert_to_contour` fields, which an inherited value would also have applied to sources that cannot be shaded ([#3199](https://github.com/maplibre/martin/pull/3199))
+- *(reload)* recover when a project or collection directory is removed mid-rescan, and recheck when a new directory appears ([#3263](https://github.com/maplibre/martin/pull/3263), [#3258](https://github.com/maplibre/martin/pull/3258), [#3240](https://github.com/maplibre/martin/pull/3240))
+- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))
+- *(deps)* update npm dependencies ([#3249](https://github.com/maplibre/martin/pull/3249), [#3205](https://github.com/maplibre/martin/pull/3205))
 
 ### Other
 
-- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
-- reduce ci time a bit ([#3267](https://github.com/maplibre/martin/pull/3267))
-- make the Windows-only unit test job pass again ([#3269](https://github.com/maplibre/martin/pull/3269))
-- *(just)* make `gen-schemas` lighter ([#3265](https://github.com/maplibre/martin/pull/3265))
-- *(pmtiles)* extract shared object-store configuration ([#3242](https://github.com/maplibre/martin/pull/3242))
-- minor ci hardening and codeql cleanup ([#3256](https://github.com/maplibre/martin/pull/3256))
-- *(deps)* update npm dependencies to v5 ([#3253](https://github.com/maplibre/martin/pull/3253))
-- enable serde_json preserve_order ([#3241](https://github.com/maplibre/martin/pull/3241))
-- *(duckdb)* prune GeoParquet row groups with the file's covering bbox ([#3215](https://github.com/maplibre/martin/pull/3215))
-- *(deps-dev)* bump the npm_and_yarn group across 2 directories with 1 update ([#3233](https://github.com/maplibre/martin/pull/3233))
-- *(postgres)* linearize only geometry columns that can hold arcs ([#3224](https://github.com/maplibre/martin/pull/3224))
-- *(reload)* start the PostgreSQL poll one interval after init ([#3226](https://github.com/maplibre/martin/pull/3226))
-- *(postgres)* skip the catalog queries for source kinds nothing publishes ([#3225](https://github.com/maplibre/martin/pull/3225))
-- *(config)* classify source paths through a `SourceLocation` type ([#3218](https://github.com/maplibre/martin/pull/3218))
-- *(deps)* update cargo dependencies ([#3204](https://github.com/maplibre/martin/pull/3204))
-- *(deps)* autoupdate pre-commit ([#3201](https://github.com/maplibre/martin/pull/3201))
-- *(cache)* the zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
+- *(postgres)* startup and query work that is not needed is skipped: only geometry columns that can hold arcs are linearized, the catalog queries for source kinds nothing publishes are not run, and the reload poll starts one interval after init ([#3224](https://github.com/maplibre/martin/pull/3224), [#3225](https://github.com/maplibre/martin/pull/3225), [#3226](https://github.com/maplibre/martin/pull/3226))
+- *(pmtiles)* extract the shared object-store configuration the remote COG reader builds on ([#3242](https://github.com/maplibre/martin/pull/3242))
+- *(config)* classify source paths through a `SourceLocation` type ([#3218](https://github.com/maplibre/martin/pull/3218)) and enable the serde_json `preserve_order` that cql2 requires ([#3241](https://github.com/maplibre/martin/pull/3241))
+- CI and lints: clippy fixes, a lighter `gen-schemas`, a shorter pipeline, a Windows-only unit test job that passes again, and some hardening and codeql cleanup ([#3272](https://github.com/maplibre/martin/pull/3272), [#3265](https://github.com/maplibre/martin/pull/3265), [#3267](https://github.com/maplibre/martin/pull/3267), [#3269](https://github.com/maplibre/martin/pull/3269), [#3256](https://github.com/maplibre/martin/pull/3256))
+- *(deps)* cargo and npm dependency updates and pre-commit autoupdates ([#3253](https://github.com/maplibre/martin/pull/3253), [#3233](https://github.com/maplibre/martin/pull/3233), [#3204](https://github.com/maplibre/martin/pull/3204), [#3201](https://github.com/maplibre/martin/pull/3201))
+- *(docs)* the cache zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
 
 ## [1.15.0](https://github.com/maplibre/martin/compare/martin-v1.14.0...martin-v1.15.0) - 2026-08-31
 

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0](https://github.com/maplibre/martin/compare/martin-v1.15.0...martin-v1.16.0) - 2026-09-06
+
+### Added
+
+- *(cog)* stream configured remote objects ([#3266](https://github.com/maplibre/martin/pull/3266))
+- add a terminal dashboard behind --tui ([#3244](https://github.com/maplibre/martin/pull/3244))
+- *(postgres)* add a CQL2 filter to table sources ([#3238](https://github.com/maplibre/martin/pull/3238))
+- *(postgres)* publish every overload of a function ([#3243](https://github.com/maplibre/martin/pull/3243))
+- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
+- *(sprites, styles)* publish each subdirectory of a collection as its own source ([#3230](https://github.com/maplibre/martin/pull/3230))
+- *(postgres)* retry the first database connection at startup ([#3231](https://github.com/maplibre/martin/pull/3231))
+- *(duckdb)* read GeoParquet from s3 and the other object stores DuckDB supports ([#3214](https://github.com/maplibre/martin/pull/3214))
+- add tile source aliases ([#3229](https://github.com/maplibre/martin/pull/3229))
+- *(postgres)* add a connection-level cache zoom default ([#3221](https://github.com/maplibre/martin/pull/3221))
+- *(config)* add a per-kind cache zoom default for file and passthrough sources ([#3223](https://github.com/maplibre/martin/pull/3223))
+- *(postgres)* serve a function's key column as the tile ETag ([#3219](https://github.com/maplibre/martin/pull/3219))
+- *(sprites)* add sprite aliases ([#3220](https://github.com/maplibre/martin/pull/3220))
+- *(fonts)* add font aliases (named font stacks) ([#3210](https://github.com/maplibre/martin/pull/3210))
+- *(cache)* cache tiles in the encoding the client receives ([#3211](https://github.com/maplibre/martin/pull/3211))
+- *(martin-cp)* skip the tiles below an empty tile ([#3208](https://github.com/maplibre/martin/pull/3208))
+- *(discovery)* scan paths recursively with recursive: true ([#3203](https://github.com/maplibre/martin/pull/3203))
+- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
+- *(mbtiles)* record and honour the tile hash algorithm ([#3262](https://github.com/maplibre/martin/pull/3262))
+- *(mbtiles)* copy several source files into one destination ([#3239](https://github.com/maplibre/martin/pull/3239))
+- *(mbtiles)* show progress for the long commands ([#3235](https://github.com/maplibre/martin/pull/3235))
+
+### Fixed
+
+- *(reload)* flake fix: skip a collection project removed mid-rescan ([#3263](https://github.com/maplibre/martin/pull/3263))
+- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))
+- *(reload)* flake fix: recover when a project directory is removed mid-rescan ([#3258](https://github.com/maplibre/martin/pull/3258))
+- *(deps)* update npm dependencies ([#3249](https://github.com/maplibre/martin/pull/3249))
+- *(reload)* fix recursive-paths CI flake, recheck when a new dir appears  ([#3240](https://github.com/maplibre/martin/pull/3240))
+- *(duckdb)* cast or drop property columns ST_AsMVT cannot encode ([#3213](https://github.com/maplibre/martin/pull/3213))
+- *(reload)* apply the global cache zoom bounds to discovered files ([#3222](https://github.com/maplibre/martin/pull/3222))
+- *(contour)* run traced tiles through the MLT transcoder ([#3202](https://github.com/maplibre/martin/pull/3202))
+- *(deps)* update npm dependencies ([#3205](https://github.com/maplibre/martin/pull/3205))
+- *(mbtiles)* drop the kind-level convert_to_hillshade and convert_to_contour fields ([#3199](https://github.com/maplibre/martin/pull/3199))
+
+### Other
+
+- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
+- reduce ci time a bit ([#3267](https://github.com/maplibre/martin/pull/3267))
+- make the Windows-only unit test job pass again ([#3269](https://github.com/maplibre/martin/pull/3269))
+- *(just)* make `gen-schemas` lighter ([#3265](https://github.com/maplibre/martin/pull/3265))
+- *(pmtiles)* extract shared object-store configuration ([#3242](https://github.com/maplibre/martin/pull/3242))
+- minor ci hardening and codeql cleanup ([#3256](https://github.com/maplibre/martin/pull/3256))
+- *(deps)* update npm dependencies to v5 ([#3253](https://github.com/maplibre/martin/pull/3253))
+- enable serde_json preserve_order ([#3241](https://github.com/maplibre/martin/pull/3241))
+- *(duckdb)* prune GeoParquet row groups with the file's covering bbox ([#3215](https://github.com/maplibre/martin/pull/3215))
+- *(deps-dev)* bump the npm_and_yarn group across 2 directories with 1 update ([#3233](https://github.com/maplibre/martin/pull/3233))
+- *(postgres)* linearize only geometry columns that can hold arcs ([#3224](https://github.com/maplibre/martin/pull/3224))
+- *(reload)* start the PostgreSQL poll one interval after init ([#3226](https://github.com/maplibre/martin/pull/3226))
+- *(postgres)* skip the catalog queries for source kinds nothing publishes ([#3225](https://github.com/maplibre/martin/pull/3225))
+- *(config)* classify source paths through a `SourceLocation` type ([#3218](https://github.com/maplibre/martin/pull/3218))
+- *(deps)* update cargo dependencies ([#3204](https://github.com/maplibre/martin/pull/3204))
+- *(deps)* autoupdate pre-commit ([#3201](https://github.com/maplibre/martin/pull/3201))
+- *(cache)* the zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
+
 ## [1.15.0](https://github.com/maplibre/martin/compare/martin-v1.14.0...martin-v1.15.0) - 2026-08-31
 
 ### Hillshade postprocessing

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.15.0"
+version = "1.16.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.9.0",
         "@radix-ui/react-dialog": "1.1.23",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.15.0"
+  "version": "1.16.0"
 }

--- a/martin/src/tui/snapshots/martin__tui__tests__a_fresh_dashboard_shows_the_address_and_an_empty_map.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__a_fresh_dashboard_shows_the_address_and_an_empty_map.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render(&dashboard, started + Duration::from_secs(5))"
 ---
-" Martin v1.15.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
+" Martin v1.16.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
 "┌ Sources ─────────────────────────────┐┌ Tile requests, last minute ──────────────────────────────┐"
 "│source   requests errors avg ms last z││             ⢀⣀⣤⢤⣤⣤⣄⣠⣠⠤⢄⢠⣠⣀⡀  ⢀⣀⣀⡀  ⣀⡀     ⢀⣀⡀            │"
 "│                                      ││⣤⡀⣀⠤⠤⢄⣀⣀⣤⣾⣿⣿⣿⣿⣿⣟⣿⡭⣗⠒⣦  ⢀⣠⡾⠁   ⠈⣉⡭⢤⣀⣀⣀⢴⣖⣻⣤⠴⠖⠒⠋⠉⠛⠒⠴⠢⠴⠶⠲⠆⢤⣀⣀⣠│"

--- a/martin/src/tui/snapshots/martin__tui__tests__an_expanded_log_takes_the_screen.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__an_expanded_log_takes_the_screen.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render_with(&dashboard, started + Duration::from_secs(5), LogView\n{ size: LogSize::Expanded, scroll: 0, })"
 ---
-" Martin v1.15.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
+" Martin v1.16.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
 "┌ Log   l shrink ──────────────────────────────────────────────────────────────────────────────────┐"
 "│INFO Starting Martin                                                                              │"
 "│                                                                                                  │"

--- a/martin/src/tui/snapshots/martin__tui__tests__requests_fill_the_sources_the_map_and_the_rate.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__requests_fill_the_sources_the_map_and_the_rate.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render(&dashboard, at(20))"
 ---
-" Martin v1.15.0  http://127.0.0.1:3000/  up 00:00:20  7 requests  1 error q quit   c clear counters "
+" Martin v1.16.0  http://127.0.0.1:3000/  up 00:00:20  7 requests  1 error q quit   c clear counters "
 "┌ Sources ─────────────────────────────┐┌ Tile requests, last minute ──────────────────────────────┐"
 "│source   requests errors avg ms last z││             ⢀⣀⣤⢤⣤⣤⣄⣠⣠⠤⢄⢠⣠⣀⡀  ⢀⣀⣀⡀  ⣀⡀     ⢀⣀⡀            │"
 "│berlin   3        0      9.7    14    ││⣤⡀⣀⠤⠤⢄⣀⣀⣤⣾⣿⣿⣿⣿⣿⣟⣿⡭⣗⠒⣦  ⢀⣠⡾⠁   ⠈⣉⡭⢤⣀⣀⣀⢴⣖⣻⣤⠴⠖⠒⠋⠉⠛⠒⠴⠢⠴⠶⠲⠆⢤⣀⣀⣠│"

--- a/martin/src/tui/snapshots/martin__tui__tests__the_log_paints_the_parts_of_a_line_the_way_pretty_does.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__the_log_paints_the_parts_of_a_line_the_way_pretty_does.snap
@@ -5,7 +5,7 @@ expression: terminal.backend().buffer()
 Buffer {
     area: Rect { x: 0, y: 0, width: 110, height: 8 },
     content: [
-        " Martin v1.15.0  http://127.0.0.1:3000/  up 00:00:01  0 requests  0 errors  0.0 req q quit   c clear counters ",
+        " Martin v1.16.0  http://127.0.0.1:3000/  up 00:00:01  0 requests  0 errors  0.0 req q quit   c clear counters ",
         "┌ Log   l shrink ────────────────────────────────────────────────────────────────────────────────────────────┐",
         "│  2026-09-05T09:41:12.123456Z  INFO martin::srv::server: Starting Martin, port: 3000                        │",
         "│    at martin/src/srv/server.rs:120                                                                         │",

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/maplibre/martin/compare/mbtiles-v0.19.2...mbtiles-v0.19.3) - 2026-09-06
+
+### Added
+
+- *(mbtiles)* record and honour the tile hash algorithm ([#3262](https://github.com/maplibre/martin/pull/3262))
+- *(mbtiles)* copy several source files into one destination ([#3239](https://github.com/maplibre/martin/pull/3239))
+- *(mbtiles)* show progress for the long commands ([#3235](https://github.com/maplibre/martin/pull/3235))
+- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
+- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
+
+### Fixed
+
+- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))
+
+### Other
+
+- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
+- enable serde_json preserve_order ([#3241](https://github.com/maplibre/martin/pull/3241))
+
 ## [0.19.2](https://github.com/maplibre/martin/compare/mbtiles-v0.19.1...mbtiles-v0.19.2) - 2026-08-31
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.15.0"
+    "version": "1.16.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `martin-tile-utils`: 0.7.7 -> 0.7.8 (✓ API compatible changes)
* `mbtiles`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `martin-core`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `martin`: 1.15.0 -> 1.16.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mbtiles`

<blockquote>

## [0.19.3](https://github.com/maplibre/martin/compare/mbtiles-v0.19.2...mbtiles-v0.19.3) - 2026-09-06

### Added

- *(mbtiles)* record and honour the tile hash algorithm ([#3262](https://github.com/maplibre/martin/pull/3262))
- *(mbtiles)* copy several source files into one destination ([#3239](https://github.com/maplibre/martin/pull/3239))
- *(mbtiles)* show progress for the long commands ([#3235](https://github.com/maplibre/martin/pull/3235))
- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))

### Fixed

- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))

### Other

- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
- enable serde_json preserve_order ([#3241](https://github.com/maplibre/martin/pull/3241))
</blockquote>

## `martin-core`

<blockquote>

## [0.11.2](https://github.com/maplibre/martin/compare/martin-core-v0.11.1...martin-core-v0.11.2) - 2026-09-06

### Added

- *(cog)* stream configured remote objects ([#3266](https://github.com/maplibre/martin/pull/3266))
- *(postgres)* add a CQL2 filter to table sources ([#3238](https://github.com/maplibre/martin/pull/3238))
- *(postgres)* publish every overload of a function ([#3243](https://github.com/maplibre/martin/pull/3243))
- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
- *(postgres)* retry the first database connection at startup ([#3231](https://github.com/maplibre/martin/pull/3231))
- *(postgres)* serve a function's key column as the tile ETag ([#3219](https://github.com/maplibre/martin/pull/3219))
- *(sprites)* add sprite aliases ([#3220](https://github.com/maplibre/martin/pull/3220))
- *(fonts)* add font aliases (named font stacks) ([#3210](https://github.com/maplibre/martin/pull/3210))
- *(cache)* cache tiles in the encoding the client receives ([#3211](https://github.com/maplibre/martin/pull/3211))
- *(martin-cp)* skip the tiles below an empty tile ([#3208](https://github.com/maplibre/martin/pull/3208))

### Other

- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
- make the Windows-only unit test job pass again ([#3269](https://github.com/maplibre/martin/pull/3269))
- *(duckdb)* prune GeoParquet row groups with the file's covering bbox ([#3215](https://github.com/maplibre/martin/pull/3215))
- *(cache)* the zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
</blockquote>

## `martin`

<blockquote>

## [1.16.0](https://github.com/maplibre/martin/compare/martin-v1.15.0...martin-v1.16.0) - 2026-09-06

### Added

- *(cog)* stream configured remote objects ([#3266](https://github.com/maplibre/martin/pull/3266))
- add a terminal dashboard behind --tui ([#3244](https://github.com/maplibre/martin/pull/3244))
- *(postgres)* add a CQL2 filter to table sources ([#3238](https://github.com/maplibre/martin/pull/3238))
- *(postgres)* publish every overload of a function ([#3243](https://github.com/maplibre/martin/pull/3243))
- *(postgres)* serve gzip-compressed tiles returned by functions ([#3236](https://github.com/maplibre/martin/pull/3236))
- *(sprites, styles)* publish each subdirectory of a collection as its own source ([#3230](https://github.com/maplibre/martin/pull/3230))
- *(postgres)* retry the first database connection at startup ([#3231](https://github.com/maplibre/martin/pull/3231))
- *(duckdb)* read GeoParquet from s3 and the other object stores DuckDB supports ([#3214](https://github.com/maplibre/martin/pull/3214))
- add tile source aliases ([#3229](https://github.com/maplibre/martin/pull/3229))
- *(postgres)* add a connection-level cache zoom default ([#3221](https://github.com/maplibre/martin/pull/3221))
- *(config)* add a per-kind cache zoom default for file and passthrough sources ([#3223](https://github.com/maplibre/martin/pull/3223))
- *(postgres)* serve a function's key column as the tile ETag ([#3219](https://github.com/maplibre/martin/pull/3219))
- *(sprites)* add sprite aliases ([#3220](https://github.com/maplibre/martin/pull/3220))
- *(fonts)* add font aliases (named font stacks) ([#3210](https://github.com/maplibre/martin/pull/3210))
- *(cache)* cache tiles in the encoding the client receives ([#3211](https://github.com/maplibre/martin/pull/3211))
- *(martin-cp)* skip the tiles below an empty tile ([#3208](https://github.com/maplibre/martin/pull/3208))
- *(discovery)* scan paths recursively with recursive: true ([#3203](https://github.com/maplibre/martin/pull/3203))
- *(mbtiles)* warn when a served file has no tile index ([#3234](https://github.com/maplibre/martin/pull/3234))
- *(mbtiles)* record and honour the tile hash algorithm ([#3262](https://github.com/maplibre/martin/pull/3262))
- *(mbtiles)* copy several source files into one destination ([#3239](https://github.com/maplibre/martin/pull/3239))
- *(mbtiles)* show progress for the long commands ([#3235](https://github.com/maplibre/martin/pull/3235))

### Fixed

- *(reload)* flake fix: skip a collection project removed mid-rescan ([#3263](https://github.com/maplibre/martin/pull/3263))
- address misc static-analysis findings across docs, justfile, UI and tile-utils ([#3259](https://github.com/maplibre/martin/pull/3259))
- *(reload)* flake fix: recover when a project directory is removed mid-rescan ([#3258](https://github.com/maplibre/martin/pull/3258))
- *(deps)* update npm dependencies ([#3249](https://github.com/maplibre/martin/pull/3249))
- *(reload)* fix recursive-paths CI flake, recheck when a new dir appears  ([#3240](https://github.com/maplibre/martin/pull/3240))
- *(duckdb)* cast or drop property columns ST_AsMVT cannot encode ([#3213](https://github.com/maplibre/martin/pull/3213))
- *(reload)* apply the global cache zoom bounds to discovered files ([#3222](https://github.com/maplibre/martin/pull/3222))
- *(contour)* run traced tiles through the MLT transcoder ([#3202](https://github.com/maplibre/martin/pull/3202))
- *(deps)* update npm dependencies ([#3205](https://github.com/maplibre/martin/pull/3205))
- *(mbtiles)* drop the kind-level convert_to_hillshade and convert_to_contour fields ([#3199](https://github.com/maplibre/martin/pull/3199))

### Other

- fix clippy lints ([#3272](https://github.com/maplibre/martin/pull/3272))
- reduce ci time a bit ([#3267](https://github.com/maplibre/martin/pull/3267))
- make the Windows-only unit test job pass again ([#3269](https://github.com/maplibre/martin/pull/3269))
- *(just)* make `gen-schemas` lighter ([#3265](https://github.com/maplibre/martin/pull/3265))
- *(pmtiles)* extract shared object-store configuration ([#3242](https://github.com/maplibre/martin/pull/3242))
- minor ci hardening and codeql cleanup ([#3256](https://github.com/maplibre/martin/pull/3256))
- *(deps)* update npm dependencies to v5 ([#3253](https://github.com/maplibre/martin/pull/3253))
- enable serde_json preserve_order ([#3241](https://github.com/maplibre/martin/pull/3241))
- *(duckdb)* prune GeoParquet row groups with the file's covering bbox ([#3215](https://github.com/maplibre/martin/pull/3215))
- *(deps-dev)* bump the npm_and_yarn group across 2 directories with 1 update ([#3233](https://github.com/maplibre/martin/pull/3233))
- *(postgres)* linearize only geometry columns that can hold arcs ([#3224](https://github.com/maplibre/martin/pull/3224))
- *(reload)* start the PostgreSQL poll one interval after init ([#3226](https://github.com/maplibre/martin/pull/3226))
- *(postgres)* skip the catalog queries for source kinds nothing publishes ([#3225](https://github.com/maplibre/martin/pull/3225))
- *(config)* classify source paths through a `SourceLocation` type ([#3218](https://github.com/maplibre/martin/pull/3218))
- *(deps)* update cargo dependencies ([#3204](https://github.com/maplibre/martin/pull/3204))
- *(deps)* autoupdate pre-commit ([#3201](https://github.com/maplibre/martin/pull/3201))
- *(cache)* the zoom default is overridable per source, not per source type ([#3198](https://github.com/maplibre/martin/pull/3198))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).