### PR TITLE
fix(contour): run traced tiles through the MLT transcoder

### DIFF
--- a/e2e-tests/tests/contour.rs
+++ b/e2e-tests/tests/contour.rs
@@ -287,6 +287,29 @@ async fn a_contoured_source_accepts_a_vector_tile_accept_header() {
 }
 
 #[tokio::test]
+async fn a_contoured_source_transcodes_to_mlt_on_request() {
+    let files = upstream().await;
+    let martin = start(
+        &files,
+        "convert_to_contour: auto\n      convert_to_mlt: auto",
+    )
+    .await;
+
+    let response = martin
+        .get_with_headers(&tile_path(), &[("Accept", "application/vnd.maplibre-tile")])
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.header("content-type"),
+        Some("application/vnd.maplibre-tile"),
+        "the traced tile must run through the MLT transcoder like any other MVT"
+    );
+    let layers = response.mlt();
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].name(), "contour");
+}
+
+#[tokio::test]
 async fn a_disabled_source_still_advertises_the_raster() {
     let files = upstream().await;
     let martin = start(&files, "convert_to_contour: disabled").await;

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -457,13 +457,20 @@ impl<'a> DynTileSource<'a> {
 
         #[cfg(all(feature = "contour", feature = "_tiles"))]
         if let Some(settings) = self.resolve_contour(pc)? {
-            return match trace_contour(s, settings.clone(), xyz, self.cache).await {
+            let traced = match trace_contour(s, settings.clone(), xyz, self.cache).await {
                 Err(ProcessError::ContourSourceNeedsReload) => {
                     let fresh_src = self.reload_source(s, pc).await?;
-                    Ok(trace_contour(&fresh_src, settings, xyz, self.cache).await?)
+                    trace_contour(&fresh_src, settings, xyz, self.cache).await?
                 }
-                result => Ok(result?),
+                result => result?,
             };
+            return Ok(apply_pre_cache_processors(
+                traced,
+                #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                pc,
+                #[cfg(all(feature = "mlt", feature = "_tiles"))]
+                self.accepted_format,
+            )?);
         }
 
         match self.fetch_tile_content_with_cache(s, pc, xyz).await {


### PR DESCRIPTION
The contour path in `get_tile_content_from_one_source` returned the traced tile before `apply_pre_cache_processors`, so a contoured source with `convert_to_mlt` set answered an MLT `Accept` header with an MVT body labelled `application/x-protobuf`. This routes traced tiles through the same processor step other vector tiles already take. Follow-up to #3183, docs already recommend pairing contours with MLT.