### PR TITLE
feat(discovery): scan paths recursively with recursive: true

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -146,6 +146,8 @@ geojson:
   extent: 4096
   # A list of file paths
   paths: []
+  # Whether `paths` are scanned recursively
+  recursive: false
   # A map of source IDs to file paths or config objects
   sources: {}
 # Connection keep alive timeout [default: 75]
@@ -176,6 +178,8 @@ mbtiles:
   convert_to_mvt: {}
   # A list of file paths
   paths: []
+  # Whether `paths` are scanned recursively
+  recursive: false
   # A map of source IDs to file paths or config objects
   sources: {}
 # Advanced monitoring options
@@ -280,6 +284,8 @@ pmtiles:
     size_mb: 64
   # A list of file paths
   paths: []
+  # Whether `paths` are scanned recursively
+  recursive: false
   # How often remote URL prefixes (`s3://bucket/`, `gs://bucket/`, etc.) re-`LIST` for source discovery.
   # Has no effect on local directories, which are watched via filesystem events.
   #

--- a/docs/content/sources-cog-files.md
+++ b/docs/content/sources-cog-files.md
@@ -85,8 +85,9 @@ cog:
     - /path/to/cog/directory
 ```
 
-Set `recursive: true` next to `paths` to scan subdirectories too.
-A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.tif` becomes `2024.roads`.
+!!! tip "Scanning subdirectories"
+    Set `recursive: true` next to `paths` to scan subdirectories too.
+    A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.tif` becomes `2024.roads`.
 
 The following events are handled automatically:
 

--- a/docs/content/sources-cog-files.md
+++ b/docs/content/sources-cog-files.md
@@ -85,6 +85,9 @@ cog:
     - /path/to/cog/directory
 ```
 
+Set `recursive: true` next to `paths` to scan subdirectories too.
+A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.tif` becomes `2024.roads`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-geojson.md
+++ b/docs/content/sources-geojson.md
@@ -76,6 +76,9 @@ geojson:
     foo: /path/to/file.geojson
 ```
 
+Set `recursive: true` next to `paths` to scan subdirectories too.
+A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.geojson` becomes `2024.roads`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-geojson.md
+++ b/docs/content/sources-geojson.md
@@ -76,8 +76,9 @@ geojson:
     foo: /path/to/file.geojson
 ```
 
-Set `recursive: true` next to `paths` to scan subdirectories too.
-A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.geojson` becomes `2024.roads`.
+!!! tip "Scanning subdirectories"
+    Set `recursive: true` next to `paths` to scan subdirectories too.
+    A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.geojson` becomes `2024.roads`.
 
 The following events are handled automatically:
 

--- a/docs/content/sources-mbtiles.md
+++ b/docs/content/sources-mbtiles.md
@@ -41,8 +41,9 @@ mbtiles:
     - /path/to/mbtiles/directory
 ```
 
-Set `recursive: true` next to `paths` to scan subdirectories too.
-A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.mbtiles` becomes `2024.roads`.
+!!! tip "Scanning subdirectories"
+    Set `recursive: true` next to `paths` to scan subdirectories too.
+    A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.mbtiles` becomes `2024.roads`.
 
 The following events are handled automatically:
 

--- a/docs/content/sources-mbtiles.md
+++ b/docs/content/sources-mbtiles.md
@@ -41,6 +41,9 @@ mbtiles:
     - /path/to/mbtiles/directory
 ```
 
+Set `recursive: true` next to `paths` to scan subdirectories too.
+A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.mbtiles` becomes `2024.roads`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-pmtiles.md
+++ b/docs/content/sources-pmtiles.md
@@ -36,8 +36,9 @@ pmtiles:
     - /path/to/pmtiles/directory
 ```
 
-Set `recursive: true` next to `paths` to scan subdirectories too.
-A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads`.
+!!! tip "Scanning subdirectories"
+    Set `recursive: true` next to `paths` to scan subdirectories too.
+    A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads`.
 
 For remote object-storage prefixes (`s3://bucket/prefix/`, `gs://bucket/prefix/`, `https://host/prefix/`, etc.) Martin periodically re-lists the prefix and diffs against the previous snapshot, taking into account
 object `ETag` or `Last-Modified` headers to detect updates to an existing source.

--- a/docs/content/sources-pmtiles.md
+++ b/docs/content/sources-pmtiles.md
@@ -36,6 +36,9 @@ pmtiles:
     - /path/to/pmtiles/directory
 ```
 
+Set `recursive: true` next to `paths` to scan subdirectories too.
+A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads`.
+
 For remote object-storage prefixes (`s3://bucket/prefix/`, `gs://bucket/prefix/`, `https://host/prefix/`, etc.) Martin periodically re-lists the prefix and diffs against the previous snapshot, taking into account
 object `ETag` or `Last-Modified` headers to detect updates to an existing source.
 There is no event channel from blob storage to subscribe to.

--- a/e2e-tests/tests/pmtiles.rs
+++ b/e2e-tests/tests/pmtiles.rs
@@ -548,6 +548,51 @@ async fn route_prefix_keeps_root_health() {
 }
 
 #[tokio::test]
+async fn recursive_paths_publish_nested_files_under_dotted_ids() {
+    let watched = WatchedDir::new();
+    fs::create_dir_all(watched.dir().join("2024")).expect("failed to create 2024");
+    watched.seed(fixture("pmtiles2/webp2.pmtiles"), "webp2.pmtiles");
+    watched.seed(fixture("pmtiles/png.pmtiles"), "2024/roads.pmtiles");
+    let mut martin = Martin::builder()
+        .config(&format!(
+            "pmtiles:\n  paths: {}\n  recursive: true\n",
+            watched.dir().display()
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["tiles"], @r#"
+    {
+      "2024.roads": {
+        "content_type": "image/png",
+        "name": "ne2sr"
+      },
+      "webp2": {
+        "content_type": "image/webp",
+        "name": "ne2sr"
+      }
+    }
+    "#);
+    assert_eq!(martin.get("/2024.roads/0/0/0").await.status(), 200);
+
+    fs::create_dir_all(watched.dir().join("2025")).expect("failed to create 2025");
+    fs::create_dir_all(watched.outside("2025")).expect("failed to create the staging dir");
+    watched.install(fixture("pmtiles/png.pmtiles"), "2025/rivers.pmtiles");
+    martin.wait_for_source("2025.rivers").await;
+    assert_eq!(martin.get("/2025.rivers/0/0/0").await.status(), 200);
+
+    watched.remove("2025/rivers.pmtiles");
+    martin.wait_for_source_removed("2025.rivers").await;
+
+    martin.stop().await;
+    martin.assert_log_contains("Added source source.id=2025.rivers");
+    martin.assert_log_contains("Removed source source.id=2025.rivers");
+    martin.assert_startup_warnings();
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
 async fn reload_adds_updates_and_removes_a_source() {
     let watched = WatchedDir::new();
     let mut martin = Martin::builder()

--- a/e2e-tests/tests/save_config.rs
+++ b/e2e-tests/tests/save_config.rs
@@ -19,6 +19,7 @@ cors:
   max_age: null
 tilejson_url_version_param: version
 pmtiles:
+  recursive: true
   sources:
     pmt:
       path: tests/fixtures/pmtiles/stamen_toner__raster_CC-BY+ODbL_z3.pmtiles

--- a/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
+++ b/e2e-tests/tests/snapshots/save_config__every_documented_setting_survives_the_round_trip.snap
@@ -25,6 +25,7 @@ pmtiles:
         minzoom: 0
         maxzoom: 3
       cache_control: no-store
+  recursive: true
 geojson: {}
 sprites:
   paths: tests/fixtures/sprites/src1

--- a/martin/src/config/file/tiles/cog.rs
+++ b/martin/src/config/file/tiles/cog.rs
@@ -23,6 +23,10 @@ use crate::config::file::{
 )]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct CogConfig {
+    /// Whether `paths` are scanned recursively
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub recursive: bool,
+
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,

--- a/martin/src/config/file/tiles/cog.rs
+++ b/martin/src/config/file/tiles/cog.rs
@@ -24,8 +24,9 @@ use crate::config::file::{
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct CogConfig {
     /// Whether `paths` are scanned recursively
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub recursive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub recursive: Option<bool>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -49,6 +49,8 @@ pub struct FsDiscovery {
     kind: FileKind,
     /// The watched directories as configured.
     directories: Vec<PathBuf>,
+    /// Whether the watched directories are scanned recursively.
+    recursive: bool,
     extensions: &'static [&'static str],
     /// Canonical path -> configured entry for explicitly-configured sources.
     configured: BTreeMap<PathBuf, ConfiguredSource>,
@@ -66,6 +68,7 @@ impl FsDiscovery {
     pub fn from_config<C>(
         kind: FileKind,
         config: &FileConfigEnum<C>,
+        recursive: bool,
         extensions: &'static [&'static str],
         id_resolver: IdResolver,
         process: &ProcessConfig,
@@ -136,6 +139,7 @@ impl FsDiscovery {
         Self {
             kind,
             directories,
+            recursive,
             extensions,
             configured,
             id_resolver,
@@ -154,6 +158,12 @@ impl FsDiscovery {
             .iter()
             .filter_map(|dir| dir.canonicalize().ok())
             .collect()
+    }
+
+    /// Whether the watched directories are scanned recursively, for wiring a `NotifyTrigger`.
+    #[must_use]
+    pub fn recursive(&self) -> bool {
+        self.recursive
     }
 
     /// The config-file entry for a discovered file.
@@ -208,6 +218,7 @@ impl Discovery for FsDiscovery {
     async fn discover(&self) -> SourceBuildResult<Discovered<Self::Args>> {
         let discovered = discover_sources_by_ext(
             &self.directories,
+            self.recursive,
             self.extensions,
             &self.configured,
             &self.id_resolver,
@@ -253,9 +264,22 @@ impl Discovery for FsDiscovery {
 
 struct ResolvedEntry {
     path: PathBuf,
-    stem: String,
     path_str: String,
     modified_ms: u128,
+}
+
+/// The source name for a discovered file.
+/// A file directly under `root` is named by its stem.
+/// A nested file is named by its path relative to `root`, extension stripped and `/` replaced with `.`.
+fn source_name(root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(root).ok()?;
+    let mut parts: Vec<&str> = relative
+        .parent()?
+        .components()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Option<_>>()?;
+    parts.push(relative.file_stem()?.to_str()?);
+    Some(parts.join("."))
 }
 
 fn path_modified_ms(path: &Path) -> Option<u128> {
@@ -285,11 +309,6 @@ fn resolve_dir_entry(entry: &DirEntry) -> Option<ResolvedEntry> {
         return None;
     };
 
-    let Some(stem) = path.file_stem().and_then(|o| o.to_str()) else {
-        tracing::warn!(path = ?path, "failed to resolve file stem");
-        return None;
-    };
-
     let Ok(path_str) = path.clone().into_os_string().into_string() else {
         tracing::warn!(path = ?path, "failed to resolve path string");
         return None;
@@ -298,8 +317,7 @@ fn resolve_dir_entry(entry: &DirEntry) -> Option<ResolvedEntry> {
     let modified_ms = path_modified_ms(&path)?;
 
     Some(ResolvedEntry {
-        path: path.clone(),
-        stem: stem.to_owned(),
+        path,
         path_str,
         modified_ms,
     })
@@ -308,32 +326,47 @@ fn resolve_dir_entry(entry: &DirEntry) -> Option<ResolvedEntry> {
 /// Scans `directories` for files matching `extensions`, resolving ids and cache policies.
 async fn discover_sources_by_ext(
     directories: &[PathBuf],
+    recursive: bool,
     extensions: &[&str],
     configured: &BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: &IdResolver,
 ) -> SourceBuildResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
     let mut out = BTreeMap::new();
     for directory in directories {
-        let mut entries = fs::read_dir(directory)
-            .await
-            .map_err(SourceBuildError::Io)?;
-        while let Some(entry) = entries.next_entry().await.map_err(SourceBuildError::Io)? {
-            let Some(e) = resolve_dir_entry(&entry) else {
-                continue;
-            };
-            if !e.path.is_file()
-                || e.path
-                    .extension()
-                    .is_none_or(|ext| !extensions.iter().any(|ex| *ex == ext))
-            {
+        let root = directory.canonicalize().map_err(SourceBuildError::Io)?;
+        let mut visited: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut pending = vec![root.clone()];
+        while let Some(dir) = pending.pop() {
+            if !visited.insert(dir.clone()) {
                 continue;
             }
-            let policy = configured
-                .get(&e.path)
-                .map(|cfg| cfg.policy)
-                .unwrap_or_default();
-            let id = id_resolver.resolve(&e.stem, e.path_str.clone());
-            out.insert(id, (e.path, e.modified_ms, policy));
+            let mut entries = fs::read_dir(&dir).await.map_err(SourceBuildError::Io)?;
+            while let Some(entry) = entries.next_entry().await.map_err(SourceBuildError::Io)? {
+                let Some(e) = resolve_dir_entry(&entry) else {
+                    continue;
+                };
+                if recursive && e.path.is_dir() {
+                    pending.push(e.path);
+                    continue;
+                }
+                if !e.path.is_file()
+                    || e.path
+                        .extension()
+                        .is_none_or(|ext| !extensions.iter().any(|ex| *ex == ext))
+                {
+                    continue;
+                }
+                let Some(name) = source_name(&root, &e.path) else {
+                    tracing::warn!(path = ?e.path, "failed to resolve source name");
+                    continue;
+                };
+                let policy = configured
+                    .get(&e.path)
+                    .map(|cfg| cfg.policy)
+                    .unwrap_or_default();
+                let id = id_resolver.resolve(&name, e.path_str.clone());
+                out.insert(id, (e.path, e.modified_ms, policy));
+            }
         }
     }
     Ok(out)
@@ -430,6 +463,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),
@@ -450,6 +484,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recursive_discovery_names_nested_files_by_their_dotted_relative_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("gfs/temperature")).expect("create nested dirs");
+        File::create(dir.path().join("top.mbtiles")).expect("create top");
+        File::create(dir.path().join("gfs/wind.mbtiles")).expect("create wind");
+        File::create(dir.path().join("gfs/temperature/202606300100.mbtiles"))
+            .expect("create temperature");
+
+        let recursive = FsDiscovery::from_config(
+            FileKind::Mbtiles,
+            &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            true,
+            &["mbtiles"],
+            IdResolver::new(&[]),
+            &ProcessConfig::default(),
+            unreachable_builder(),
+        );
+        let mut ids: Vec<String> = recursive
+            .discover()
+            .await
+            .expect("discover")
+            .sources
+            .into_keys()
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["gfs.temperature.202606300100", "gfs.wind", "top"]);
+
+        let flat = FsDiscovery::from_config(
+            FileKind::Mbtiles,
+            &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            false,
+            &["mbtiles"],
+            IdResolver::new(&[]),
+            &ProcessConfig::default(),
+            unreachable_builder(),
+        );
+        let ids: Vec<String> = flat
+            .discover()
+            .await
+            .expect("discover")
+            .sources
+            .into_keys()
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["top"],
+            "nested files stay hidden unless recursive is set"
+        );
+    }
+
+    #[tokio::test]
     async fn init_publishes_the_good_files_and_skips_the_bad_one_under_warn() {
         let dir = tempfile::tempdir().expect("tempdir");
         File::create(dir.path().join("good_0.mbtiles")).expect("create good_0");
@@ -459,6 +544,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),
@@ -485,6 +571,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),
@@ -547,6 +634,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &config,
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &kind_level,
@@ -602,6 +690,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &config,
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),
@@ -636,6 +725,7 @@ mod tests {
                 readable.path().to_path_buf(),
                 unreadable.path().to_path_buf(),
             ]),
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),
@@ -673,6 +763,7 @@ mod tests {
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             &FileConfigEnum::<()>::Path(dir.path().to_path_buf()),
+            false,
             &["mbtiles"],
             IdResolver::new(&[]),
             &ProcessConfig::default(),

--- a/martin/src/config/file/tiles/driver/trigger.rs
+++ b/martin/src/config/file/tiles/driver/trigger.rs
@@ -19,7 +19,7 @@ pub struct NotifyTrigger {
 }
 
 impl NotifyTrigger {
-    pub fn new(directories: &[PathBuf]) -> notify::Result<Self> {
+    pub fn new(directories: &[PathBuf], recursive: bool) -> notify::Result<Self> {
         let (tx, rx) = mpsc::channel::<Event>(256);
 
         let mut watcher = RecommendedWatcher::new(
@@ -32,9 +32,13 @@ impl NotifyTrigger {
             },
             Config::default(),
         )?;
+        let mode = if recursive {
+            notify::RecursiveMode::Recursive
+        } else {
+            notify::RecursiveMode::NonRecursive
+        };
         for dir in directories {
-            // FIXME: find a naming scheme for paths that makes sense under recursive and enable it
-            watcher.watch(dir, notify::RecursiveMode::NonRecursive)?;
+            watcher.watch(dir, mode)?;
         }
 
         Ok(Self {
@@ -105,7 +109,7 @@ mod tests {
     #[tokio::test]
     async fn notify_trigger_fires_on_file_creation() {
         let dir = tempfile::tempdir().unwrap();
-        let mut trigger = NotifyTrigger::new(&[dir.path().to_path_buf()]).unwrap();
+        let mut trigger = NotifyTrigger::new(&[dir.path().to_path_buf()], false).unwrap();
 
         // Let the watcher register before mutating the directory.
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -130,7 +134,7 @@ mod tests {
         std::fs::write(&file, b"hi").unwrap();
 
         // Start watching only after the file exists, so the create event is not observed.
-        let mut trigger = NotifyTrigger::new(&[dir.path().to_path_buf()]).unwrap();
+        let mut trigger = NotifyTrigger::new(&[dir.path().to_path_buf()], false).unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Reading the file mutates nothing; the trigger must stay silent.

--- a/martin/src/config/file/tiles/geojson.rs
+++ b/martin/src/config/file/tiles/geojson.rs
@@ -59,6 +59,10 @@ pub struct GeoJsonConfig {
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &64u32))]
     pub buffer: u32,
 
+    /// Whether `paths` are scanned recursively
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub recursive: bool,
+
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
@@ -69,6 +73,7 @@ impl Default for GeoJsonConfig {
         Self {
             extent: default_extent(),
             buffer: default_buffer(),
+            recursive: false,
             unrecognized: UnrecognizedValues::default(),
         }
     }

--- a/martin/src/config/file/tiles/geojson.rs
+++ b/martin/src/config/file/tiles/geojson.rs
@@ -60,8 +60,9 @@ pub struct GeoJsonConfig {
     pub buffer: u32,
 
     /// Whether `paths` are scanned recursively
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub recursive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub recursive: Option<bool>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -73,7 +74,7 @@ impl Default for GeoJsonConfig {
         Self {
             extent: default_extent(),
             buffer: default_buffer(),
-            recursive: false,
+            recursive: None,
             unrecognized: UnrecognizedValues::default(),
         }
     }

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -38,6 +38,10 @@ pub struct MbtConfig {
     #[serde(default)]
     pub convert_to_mvt: Option<MvtProcessConfig>,
 
+    /// Whether `paths` are scanned recursively
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub recursive: bool,
+
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -39,8 +39,9 @@ pub struct MbtConfig {
     pub convert_to_mvt: Option<MvtProcessConfig>,
 
     /// Whether `paths` are scanned recursively
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub recursive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub recursive: Option<bool>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -119,6 +119,10 @@ pub struct PmtConfig {
     #[serde(default)]
     pub convert_to_mvt: Option<MvtProcessConfig>,
 
+    /// Whether `paths` are scanned recursively
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub recursive: bool,
+
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
@@ -154,6 +158,7 @@ impl Default for PmtConfig {
             convert_to_mlt: None,
             #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mvt: None,
+            recursive: false,
             unrecognized: UnrecognizedValues::default(),
             pmtiles_directory_cache: PmtCache::default(),
             aws_credentials: None,
@@ -170,6 +175,7 @@ impl PartialEq for PmtConfig {
             && self.reload_interval == other.reload_interval
             && self.profile == other.profile
             && self.options == other.options
+            && self.recursive == other.recursive
             && self.unrecognized == other.unrecognized;
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
         let base = base

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -120,8 +120,9 @@ pub struct PmtConfig {
     pub convert_to_mvt: Option<MvtProcessConfig>,
 
     /// Whether `paths` are scanned recursively
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub recursive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
+    pub recursive: Option<bool>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -158,7 +159,7 @@ impl Default for PmtConfig {
             convert_to_mlt: None,
             #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mvt: None,
-            recursive: false,
+            recursive: None,
             unrecognized: UnrecognizedValues::default(),
             pmtiles_directory_cache: PmtCache::default(),
             aws_credentials: None,

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -30,9 +30,11 @@ impl CogReloader {
                 Ok(Box::new(src) as BoxedSource)
             })
         });
+        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive);
         let discovery = FsDiscovery::from_config(
             FileKind::Cog,
             config,
+            recursive,
             &["tif", "tiff"],
             id_resolver,
             &ProcessConfig::default(),
@@ -51,10 +53,11 @@ impl CogReloader {
     /// Spawns the reload driver. Does nothing if no directories are configured.
     pub fn start(self) -> notify::Result<()> {
         let directories = self.driver.discovery().directories();
+        let recursive = self.driver.discovery().recursive();
         if directories.is_empty() {
             return Ok(());
         }
-        let trigger = NotifyTrigger::new(&directories)?;
+        let trigger = NotifyTrigger::new(&directories, recursive)?;
         self.driver.spawn(trigger, Baseline::Initialized);
         Ok(())
     }

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -30,7 +30,7 @@ impl CogReloader {
                 Ok(Box::new(src) as BoxedSource)
             })
         });
-        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive);
+        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive.unwrap_or_default());
         let discovery = FsDiscovery::from_config(
             FileKind::Cog,
             config,

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -29,7 +29,7 @@ impl GeoJsonReloader {
                 GeoJsonConfig::default()
             }
         };
-        let recursive = geojson_config.recursive;
+        let recursive = geojson_config.recursive.unwrap_or_default();
         let build: FsSourceBuilder = Box::new(move |id, path, policy| {
             let config = geojson_config.clone();
             Box::pin(async move { config.new_sources(id, path, policy).await })

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -29,6 +29,7 @@ impl GeoJsonReloader {
                 GeoJsonConfig::default()
             }
         };
+        let recursive = geojson_config.recursive;
         let build: FsSourceBuilder = Box::new(move |id, path, policy| {
             let config = geojson_config.clone();
             Box::pin(async move { config.new_sources(id, path, policy).await })
@@ -36,6 +37,7 @@ impl GeoJsonReloader {
         let discovery = FsDiscovery::from_config(
             FileKind::GeoJson,
             config,
+            recursive,
             &["json", "geojson"],
             id_resolver,
             &ProcessConfig::default(),
@@ -54,10 +56,11 @@ impl GeoJsonReloader {
     /// Spawns the reload driver. Does nothing if no directories are configured.
     pub fn start(self) -> notify::Result<()> {
         let directories = self.driver.discovery().directories();
+        let recursive = self.driver.discovery().recursive();
         if directories.is_empty() {
             return Ok(());
         }
-        let trigger = NotifyTrigger::new(&directories)?;
+        let trigger = NotifyTrigger::new(&directories, recursive)?;
         self.driver.spawn(trigger, Baseline::Initialized);
         Ok(())
     }

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -57,9 +57,11 @@ impl MbtilesReloader {
                 Ok(Box::new(src) as BoxedSource)
             })
         });
+        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive);
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             config,
+            recursive,
             &["mbtiles"],
             id_resolver,
             &process,
@@ -79,10 +81,11 @@ impl MbtilesReloader {
     /// Spawns the reload driver. Does nothing if no directories are configured.
     pub fn start(self) -> notify::Result<()> {
         let directories = self.driver.discovery().directories();
+        let recursive = self.driver.discovery().recursive();
         if directories.is_empty() {
             return Ok(());
         }
-        let trigger = NotifyTrigger::new(&directories)?;
+        let trigger = NotifyTrigger::new(&directories, recursive)?;
         self.driver.spawn(trigger, Baseline::Initialized);
         Ok(())
     }

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -57,7 +57,7 @@ impl MbtilesReloader {
                 Ok(Box::new(src) as BoxedSource)
             })
         });
-        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive);
+        let recursive = matches!(config, FileConfigEnum::Config(cfg) if cfg.custom.recursive.unwrap_or_default());
         let discovery = FsDiscovery::from_config(
             FileKind::Mbtiles,
             config,

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -69,6 +69,7 @@ impl PmtilesReloader {
         let local = FsDiscovery::from_config(
             FileKind::Pmtiles,
             config,
+            pmt_config.recursive,
             &[PMTILES_EXT],
             id_resolver.clone(),
             &process,
@@ -93,6 +94,7 @@ impl PmtilesReloader {
         let Self { local, remote } = self;
 
         let directories = local.discovery().directories();
+        let recursive = local.discovery().recursive();
         let has_remote = !remote.discovery().remote_prefixes().is_empty();
         let interval = remote.discovery().reload_interval();
 
@@ -101,7 +103,7 @@ impl PmtilesReloader {
         }
 
         if !directories.is_empty() {
-            let trigger = NotifyTrigger::new(&directories)?;
+            let trigger = NotifyTrigger::new(&directories, recursive)?;
             local.spawn(trigger, Baseline::Initialized);
         }
 

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -69,7 +69,7 @@ impl PmtilesReloader {
         let local = FsDiscovery::from_config(
             FileKind::Pmtiles,
             config,
-            pmt_config.recursive,
+            pmt_config.recursive.unwrap_or_default(),
             &[PMTILES_EXT],
             id_resolver.clone(),
             &process,

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -365,7 +365,8 @@
         },
         "recursive": {
           "description": "Whether `paths` are scanned recursively",
-          "type": "boolean"
+          "examples": [false],
+          "type": ["boolean", "null"]
         },
         "reload_interval": {
           "description": "How often remote URL prefixes (`s3://bucket/`, `gs://bucket/`, etc.) re-`LIST` for source discovery.\nHas no effect on local directories, which are watched via filesystem events.\n\nSupports human-readable formats: \"10m\", \"1h\", \"30s\".\nDefaults to \"10m\". Set to \"0s\" to disable remote polling.",
@@ -412,7 +413,8 @@
         },
         "recursive": {
           "description": "Whether `paths` are scanned recursively",
-          "type": "boolean"
+          "examples": [false],
+          "type": ["boolean", "null"]
         },
         "sources": {
           "additionalProperties": {
@@ -446,7 +448,8 @@
         },
         "recursive": {
           "description": "Whether `paths` are scanned recursively",
-          "type": "boolean"
+          "examples": [false],
+          "type": ["boolean", "null"]
         },
         "sources": {
           "additionalProperties": {

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -363,6 +363,10 @@
           "$ref": "#/$defs/OptOneMany2",
           "description": "A list of file paths"
         },
+        "recursive": {
+          "description": "Whether `paths` are scanned recursively",
+          "type": "boolean"
+        },
         "reload_interval": {
           "description": "How often remote URL prefixes (`s3://bucket/`, `gs://bucket/`, etc.) re-`LIST` for source discovery.\nHas no effect on local directories, which are watched via filesystem events.\n\nSupports human-readable formats: \"10m\", \"1h\", \"30s\".\nDefaults to \"10m\". Set to \"0s\" to disable remote polling.",
           "examples": ["10m"],
@@ -406,6 +410,10 @@
           "$ref": "#/$defs/OptOneMany2",
           "description": "A list of file paths"
         },
+        "recursive": {
+          "description": "Whether `paths` are scanned recursively",
+          "type": "boolean"
+        },
         "sources": {
           "additionalProperties": {
             "$ref": "#/$defs/FileConfigSrc"
@@ -435,6 +443,10 @@
         "paths": {
           "$ref": "#/$defs/OptOneMany2",
           "description": "A list of file paths"
+        },
+        "recursive": {
+          "description": "Whether `paths` are scanned recursively",
+          "type": "boolean"
         },
         "sources": {
           "additionalProperties": {


### PR DESCRIPTION
Adds an opt-in `recursive: true` setting next to `paths` for the mbtiles, pmtiles, cog and geojson kinds. A nested file is published under its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads`, and files directly under the directory keep their bare stem so no existing id or URL moves. The watcher follows the same flag, so files dropped into a subdirectory hot-reload like top-level ones. Answers the naming question from #2937 and removes the FIXME in `NotifyTrigger`.