### PR TITLE
feat(fonts): add font aliases (named font stacks)

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -121,6 +121,12 @@ endpoints:
   purge_cache: false
 # Font configuration
 fonts:
+  # Named font stacks.
+  #
+  # Each alias can be requested like a font and serves the listed fonts combined, in fallback order.
+  # Aliases may only reference discovered fonts, not other aliases.
+  # An alias sharing the name of a discovered font takes precedence over it.
+  aliases: {}
   # Cache configuration for fonts.
   # Use `cache: disable` to disable font caching.
   cache:

--- a/docs/content/sources-fonts.md
+++ b/docs/content/sources-fonts.md
@@ -88,9 +88,12 @@ fonts:
 
 ### Font Aliases
 
-The config file can also define aliases, which are named font stacks that clients request like a single font.
-Each alias combines the listed fonts in the given fallback order, exactly like a [composite font request](#composite-font-request).
-This keeps stylesheets short when text needs many fallback fonts (e.g. for multiple writing systems).
+!!! tip "Supporting multiple writing systems via `aliases`"
+    Working in an global world means that there are multiple languages that you will need to support in modern cartography.
+    Sadly, not every font that you might want to use supports this or looks good in every language.
+    To support this, we have `aliases`.
+    Each alias combines the listed fonts in the given fallback order, exactly like a [composite font request](#composite-font-request).
+
 
 ```yaml
 fonts:

--- a/docs/content/sources-fonts.md
+++ b/docs/content/sources-fonts.md
@@ -94,7 +94,6 @@ fonts:
     To support this, we have `aliases`.
     Each alias combines the listed fonts in the given fallback order, exactly like a [composite font request](#composite-font-request).
 
-
 ```yaml
 fonts:
   paths:

--- a/docs/content/sources-fonts.md
+++ b/docs/content/sources-fonts.md
@@ -85,3 +85,34 @@ fonts:
   - /path/to/font/file.ttf
   - /path/to/font_dir
 ```
+
+### Font Aliases
+
+The config file can also define aliases, which are named font stacks that clients request like a single font.
+Each alias combines the listed fonts in the given fallback order, exactly like a [composite font request](#composite-font-request).
+This keeps stylesheets short when text needs many fallback fonts (e.g. for multiple writing systems).
+
+```yaml
+fonts:
+  paths:
+    - /path/to/font_dir
+  # Each alias can be requested like a font and serves the listed fonts combined, in fallback order.
+  aliases:
+    Noto Sans Stack: [Noto Sans Regular, Noto Sans Arabic Regular, Noto Sans Thai Regular]
+```
+
+Aliases may only reference discovered fonts, not other aliases.
+An alias may share the name of a font it references; requests for that name then serve the alias.
+This extends an existing font with fallbacks without changing the name a style uses:
+
+```yaml
+fonts:
+  paths:
+    - /path/to/font_dir
+  aliases:
+    # Requests for "Noto Sans Bold Italic" also get the Arabic glyphs as fallback.
+    Noto Sans Bold Italic: [Noto Sans Bold Italic, Noto Sans Arabic Bold]
+```
+
+Aliases are listed in the catalog under their own name.
+The `glyphs` value of an alias counts the distinct code points covered by its fonts.

--- a/e2e-tests/tests/fonts.rs
+++ b/e2e-tests/tests/fonts.rs
@@ -1,6 +1,6 @@
 //! Font glyph ranges rendered from `.ttf`/`.otf` files.
 
-use martin_e2e_tests::{Martin, TestResponse, fixture};
+use martin_e2e_tests::{Martin, StartError, TestResponse, fixture};
 use pbf_font_tools::prost::Message as _;
 use pbf_font_tools::{Fontstack, Glyphs};
 use rstest::rstest;
@@ -321,4 +321,109 @@ async fn a_font_configured_from_two_paths_is_registered_once() {
         "Ignoring duplicate font: already configured from another path font.name=Overpass Mono Regular",
     );
     martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_alias_serves_the_fonts_it_combines() {
+    let mut martin = Martin::builder()
+        .config(
+            "
+fonts:
+  paths: tests/fixtures/fonts
+  aliases:
+    Overpass Mono: [Overpass Mono Regular, Overpass Mono Light]
+",
+        )
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["fonts"], @r#"
+    {
+      "Overpass Mono": {
+        "end": 128276,
+        "family": "Overpass Mono",
+        "glyphs": 934,
+        "start": 0
+      },
+      "Overpass Mono Light": {
+        "end": 128276,
+        "family": "Overpass Mono",
+        "format": "otf",
+        "glyphs": 988,
+        "start": 0,
+        "style": "Light"
+      },
+      "Overpass Mono Regular": {
+        "end": 128276,
+        "family": "Overpass Mono",
+        "format": "ttf",
+        "glyphs": 988,
+        "start": 0,
+        "style": "Regular"
+      }
+    }
+    "#);
+
+    let aliased = martin.get("/font/Overpass%20Mono/0-255").await;
+    assert_eq!(aliased.status(), 200);
+    let explicit = martin.get(&format!("/font/{REGULAR},{LIGHT}/0-255")).await;
+    assert_eq!(aliased.body(), explicit.body());
+    let stack = fontstack(&aliased);
+    assert_eq!(stack.name, "Overpass Mono Regular, Overpass Mono Light");
+
+    martin.stop().await;
+    martin.assert_log_contains("Configured font alias");
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_alias_may_shadow_the_font_it_extends() {
+    let mut martin = Martin::builder()
+        .config(
+            "
+fonts:
+  paths: tests/fixtures/fonts
+  aliases:
+    Overpass Mono Regular: [Overpass Mono Regular, Overpass Mono Light]
+",
+        )
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let response = martin.get(&format!("/font/{REGULAR}/0-255")).await;
+    assert_eq!(response.status(), 200);
+    let stack = fontstack(&response);
+    assert_eq!(stack.name, "Overpass Mono Regular, Overpass Mono Light");
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        "Font alias shadows a font of the same name; requests for it will serve the alias",
+    );
+    martin.assert_log_clean();
+}
+
+#[tokio::test]
+async fn an_alias_naming_an_unknown_font_fails_startup() {
+    let error = Martin::builder()
+        .config(
+            "
+fonts:
+  paths: tests/fixtures/fonts
+  aliases:
+    Overpass Mono: [Overpass Mono Regular, Nonexistent]
+",
+        )
+        .start()
+        .await
+        .expect_err("martin must reject an alias naming an unknown font");
+    let StartError::EarlyExit { status, log } = error else {
+        panic!("expected an early exit, got: {error}");
+    };
+    assert!(!status.success(), "exit status must be a failure: {status}");
+    assert!(
+        log.contains(r#"Font alias "Overpass Mono" references unknown font "Nonexistent""#),
+        "log must name the alias and the missing font; log:\n{log}"
+    );
 }

--- a/martin-core/src/resources/fonts/cache.rs
+++ b/martin-core/src/resources/fonts/cache.rs
@@ -12,9 +12,10 @@ pub const NO_FONT_CACHE: OptFontCache = None;
 /// Cache key for a font glyph range.
 ///
 /// `ids` is the [`crate::fonts::normalize_font_ids`]-normalized font stack
-/// from the request path. Invalidation by font ID matches by token (not
-/// substring): invalidating `"Open Sans"` does not invalidate entries keyed
-/// against `"Open Sans Bold"`.
+/// from the request path, with aliases already expanded to their member fonts
+/// so invalidating a font also evicts entries reached through an alias.
+/// Invalidation by font ID matches by token (not substring): invalidating
+/// `"Open Sans"` does not invalidate entries keyed against `"Open Sans Bold"`.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct FontCacheKey {
     ids: String,

--- a/martin-core/src/resources/fonts/error.rs
+++ b/martin-core/src/resources/fonts/error.rs
@@ -22,6 +22,47 @@ pub enum FontError {
         max: usize,
     },
 
+    /// A font alias name is empty or contains a comma.
+    #[error(
+        "Font alias {0:?} is invalid: alias names must be non-empty and must not contain commas"
+    )]
+    InvalidAliasName(String),
+
+    /// A font alias does not reference any fonts.
+    #[error("Font alias {0:?} does not reference any fonts")]
+    EmptyAlias(String),
+
+    /// A font alias references more fonts than a single request may use.
+    #[error("Font alias {alias:?} references {requested} fonts, but at most {max} are allowed")]
+    TooManyFontsInAlias {
+        /// Alias name.
+        alias: String,
+        /// Referenced font count.
+        requested: usize,
+        /// Allowed maximum.
+        max: usize,
+    },
+
+    /// A font alias references another alias instead of a font.
+    #[error(
+        "Font alias {alias:?} references {font:?}, which is itself an alias; aliases may only reference fonts"
+    )]
+    AliasWithinAlias {
+        /// Alias name.
+        alias: String,
+        /// The referenced alias.
+        font: String,
+    },
+
+    /// A font alias references a font that was not discovered.
+    #[error("Font alias {alias:?} references unknown font {font:?}")]
+    AliasFontNotFound {
+        /// Alias name.
+        alias: String,
+        /// The referenced font.
+        font: String,
+    },
+
     /// The font range start value is greater than the end value.
     #[error("Font range start ({start}) must be <= end ({end})")]
     InvalidFontRangeStartEnd {
@@ -85,7 +126,12 @@ impl crate::Classify for FontError {
             | Self::InvalidFontRangeStartEnd { .. }
             | Self::InvalidFontRangeStart(_)
             | Self::InvalidFontRangeEnd(_)
-            | Self::InvalidFontRange(_, _) => InvalidInput,
+            | Self::InvalidFontRange(_, _)
+            | Self::InvalidAliasName(_)
+            | Self::EmptyAlias(_)
+            | Self::TooManyFontsInAlias { .. }
+            | Self::AliasWithinAlias { .. }
+            | Self::AliasFontNotFound { .. } => InvalidInput,
             Self::FreeType(_)
             | Self::IoError(..)
             | Self::InvalidFontFilePath(_)

--- a/martin-core/src/resources/fonts/mod.rs
+++ b/martin-core/src/resources/fonts/mod.rs
@@ -179,6 +179,8 @@ pub struct CatalogFontEntry {
 pub struct FontSources {
     /// Map of font name to font source data.
     fonts: DashMap<String, FontSource>,
+    /// Map of alias name to the font names it combines, in fallback order.
+    aliases: DashMap<String, Vec<String>>,
 }
 
 impl FontSources {
@@ -188,18 +190,129 @@ impl FontSources {
         discover_fonts(&lib, path, &mut self.fonts)
     }
 
-    /// Returns a catalog of all loaded fonts
+    /// Registers a named font stack that serves the given fonts combined, in fallback order.
+    ///
+    /// Every member must name an already discovered font, not another alias.
+    /// An alias may share the name of a discovered font it references.
+    /// Requests for such a name serve the alias.
+    pub fn add_alias(&mut self, name: String, fonts: Vec<String>) -> Result<(), FontError> {
+        if name.is_empty() || name.contains(',') {
+            return Err(FontError::InvalidAliasName(name));
+        }
+        if fonts.is_empty() {
+            return Err(FontError::EmptyAlias(name));
+        }
+        if fonts.len() > MAX_FONT_IDS_PER_REQUEST {
+            return Err(FontError::TooManyFontsInAlias {
+                alias: name,
+                requested: fonts.len(),
+                max: MAX_FONT_IDS_PER_REQUEST,
+            });
+        }
+        for font in &fonts {
+            if self.aliases.contains_key(font) {
+                return Err(FontError::AliasWithinAlias {
+                    alias: name,
+                    font: font.clone(),
+                });
+            }
+            if !self.fonts.contains_key(font) {
+                return Err(FontError::AliasFontNotFound {
+                    alias: name,
+                    font: font.clone(),
+                });
+            }
+        }
+        if self.fonts.contains_key(&name) {
+            info!(
+                font.alias = %name,
+                "Font alias shadows a font of the same name; requests for it will serve the alias"
+            );
+        }
+        info!(
+            font.alias = %name,
+            font.names = %fonts.join(", "),
+            "Configured font alias"
+        );
+        self.aliases.insert(name, fonts);
+        Ok(())
+    }
+
+    /// Replaces every alias in a comma-separated font id list with its member
+    /// fonts, preserving order and deduplicating.
+    fn expanded_ids(&self, ids: &str) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut expanded = Vec::new();
+        for id in split_and_dedup_ids(ids) {
+            if let Some(alias) = self.aliases.get(id) {
+                for font in alias.value() {
+                    if seen.insert(font.clone()) {
+                        expanded.push(font.clone());
+                    }
+                }
+            } else if seen.insert(id.to_owned()) {
+                expanded.push(id.to_owned());
+            }
+        }
+        expanded
+    }
+
+    /// Expands every alias in a comma-separated font id list into its member fonts,
+    /// preserving order and deduplicating.
+    ///
+    /// Callers that need the fonts a request actually resolves to use this,
+    /// e.g. to build cache keys that can be invalidated per font.
+    #[must_use]
+    pub fn expand_font_ids(&self, ids: &str) -> String {
+        if self.aliases.is_empty() {
+            return ids.to_owned();
+        }
+        self.expanded_ids(ids).join(",")
+    }
+
+    /// Returns a catalog of all loaded fonts and aliases.
+    ///
+    /// An alias is listed under its own name.
+    /// The `glyphs` value of an alias counts the distinct codepoints its member fonts cover.
     #[must_use]
     pub fn get_catalog(&self) -> FontCatalog {
-        self.fonts
+        let mut catalog: FontCatalog = self
+            .fonts
             .iter()
             .map(|v| (v.key().clone(), v.catalog_entry.clone()))
-            .collect()
+            .collect();
+        for alias in &self.aliases {
+            let mut codepoints = BitSet::new();
+            let mut start = usize::MAX;
+            let mut end = 0;
+            for font in alias.value() {
+                if let Some(font) = self.fonts.get(font) {
+                    codepoints.union_with(&font.codepoints);
+                    start = start.min(font.catalog_entry.start);
+                    end = end.max(font.catalog_entry.end);
+                }
+            }
+            let glyphs = u32::try_from(codepoints.count()).expect("codepoint count fits in u32");
+            catalog.insert(
+                alias.key().clone(),
+                CatalogFontEntry {
+                    family: alias.key().clone(),
+                    style: None,
+                    glyphs,
+                    start,
+                    end,
+                    format: None,
+                    last_modified_at: None,
+                },
+            );
+        }
+        catalog
     }
 
     /// Generates Protocol Buffer encoded font data for a 256-character Unicode range.
     ///
     /// Combines multiple fonts (comma-separated) with later fonts filling gaps.
+    /// Ids may name aliases registered via [`Self::add_alias`], which expand to their member fonts.
     /// Range must be exactly 256 characters (e.g., 0-255, 256-511).
     #[expect(clippy::cast_possible_truncation)]
     #[instrument(
@@ -229,7 +342,7 @@ impl FontSources {
             return Err(FontError::InvalidFontRange(start, end));
         }
 
-        let unique_ids = split_and_dedup_ids(ids);
+        let unique_ids = self.expanded_ids(ids);
         if unique_ids.len() > MAX_FONT_IDS_PER_REQUEST {
             return Err(FontError::TooManyFontIds {
                 requested: unique_ids.len(),
@@ -238,13 +351,13 @@ impl FontSources {
         }
 
         let fonts = unique_ids
-            .into_iter()
+            .iter()
             .map(|id| {
-                if self.fonts.get(id).is_none() {
-                    return Err(FontError::FontNotFound(id.to_owned()));
+                if self.fonts.get(id.as_str()).is_none() {
+                    return Err(FontError::FontNotFound(id.clone()));
                 }
 
-                Ok(id)
+                Ok(id.as_str())
             })
             .collect::<Result<Vec<&str>, FontError>>()?;
 
@@ -449,10 +562,143 @@ mod tests {
 
     use super::*;
 
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("tests")
+            .join("fixtures")
+            .join(name)
+    }
+
+    fn overpass_sources() -> FontSources {
+        let mut sources = FontSources::default();
+        sources.recursively_add_directory(fixture("fonts")).unwrap();
+        sources
+    }
+
     #[test]
     fn normalize_font_ids_collapses_order_and_duplicates() {
         assert_eq!(normalize_font_ids("b,a,b"), "a,b");
         assert_eq!(normalize_font_ids("a"), "a");
+    }
+
+    #[test]
+    fn an_alias_serves_the_same_bytes_as_the_explicit_fontstack() {
+        let mut sources = overpass_sources();
+        sources
+            .add_alias(
+                "Overpass Mono".to_owned(),
+                vec![
+                    "Overpass Mono Regular".to_owned(),
+                    "Overpass Mono Light".to_owned(),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(
+            sources.expand_font_ids("Overpass Mono"),
+            "Overpass Mono Regular,Overpass Mono Light"
+        );
+        assert_eq!(
+            sources.expand_font_ids("Overpass Mono Light,Overpass Mono"),
+            "Overpass Mono Light,Overpass Mono Regular",
+            "a font shared between the request and the alias appears once"
+        );
+        let aliased = sources.get_font_range("Overpass Mono", 0, 255).unwrap();
+        let explicit = sources
+            .get_font_range("Overpass Mono Regular,Overpass Mono Light", 0, 255)
+            .unwrap();
+        assert_eq!(aliased, explicit);
+    }
+
+    #[test]
+    fn an_alias_may_shadow_a_font_and_include_it() {
+        let mut sources = overpass_sources();
+        sources
+            .add_alias(
+                "Overpass Mono Regular".to_owned(),
+                vec![
+                    "Overpass Mono Regular".to_owned(),
+                    "Overpass Mono Light".to_owned(),
+                ],
+            )
+            .unwrap();
+
+        let shadowed = sources
+            .get_font_range("Overpass Mono Regular", 0, 255)
+            .unwrap();
+        // A fresh source set without the alias provides the explicit baseline.
+        let explicit = overpass_sources()
+            .get_font_range("Overpass Mono Regular,Overpass Mono Light", 0, 255)
+            .unwrap();
+        assert_eq!(shadowed, explicit);
+
+        let catalog = sources.get_catalog();
+        let entry = catalog
+            .get("Overpass Mono Regular")
+            .expect("the shadowed name stays cataloged");
+        assert_eq!(entry.style, None, "the alias entry replaces the font's");
+    }
+
+    #[test]
+    fn invalid_aliases_are_rejected() {
+        let mut sources = overpass_sources();
+
+        let err = sources
+            .add_alias(
+                "has,comma".to_owned(),
+                vec!["Overpass Mono Regular".to_owned()],
+            )
+            .unwrap_err();
+        assert_matches!(err, FontError::InvalidAliasName(_));
+
+        let err = sources.add_alias("Empty".to_owned(), vec![]).unwrap_err();
+        assert_matches!(err, FontError::EmptyAlias(_));
+
+        let err = sources
+            .add_alias("Unknown".to_owned(), vec!["Nonexistent".to_owned()])
+            .unwrap_err();
+        assert_matches!(err, FontError::AliasFontNotFound { .. });
+
+        sources
+            .add_alias("Stack".to_owned(), vec!["Overpass Mono Regular".to_owned()])
+            .unwrap();
+        let err = sources
+            .add_alias("Nested".to_owned(), vec!["Stack".to_owned()])
+            .unwrap_err();
+        assert_matches!(err, FontError::AliasWithinAlias { .. });
+
+        let too_many = vec!["Overpass Mono Regular".to_owned(); MAX_FONT_IDS_PER_REQUEST + 1];
+        let err = sources.add_alias("Big".to_owned(), too_many).unwrap_err();
+        assert_matches!(err, FontError::TooManyFontsInAlias { .. });
+    }
+
+    #[test]
+    fn the_catalog_lists_aliases_with_merged_coverage() {
+        let mut sources = overpass_sources();
+        sources
+            .recursively_add_directory(fixture("fonts2/u+3320.ttf"))
+            .unwrap();
+        sources
+            .add_alias(
+                "My Stack".to_owned(),
+                vec![
+                    "Overpass Mono Regular".to_owned(),
+                    "DummyTestFont Regular".to_owned(),
+                ],
+            )
+            .unwrap();
+
+        let catalog = sources.get_catalog();
+        let entry = catalog.get("My Stack").expect("alias is cataloged");
+        insta::assert_json_snapshot!(entry, @r#"
+        {
+          "family": "My Stack",
+          "glyphs": 935,
+          "start": 0,
+          "end": 128276
+        }
+        "#);
     }
 
     #[test]

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -93,6 +93,10 @@ pub enum ConfigFileError {
     #[error("Failed to load fonts from {1}: {0}")]
     FontResolutionFailed(#[source] FontError, PathBuf),
 
+    #[cfg(feature = "fonts")]
+    #[error("Failed to configure font alias: {0}")]
+    FontAliasResolutionFailed(#[source] FontError),
+
     #[cfg(feature = "pmtiles")]
     #[error("Failed to parse object store URL of {1}: {0}")]
     ObjectStoreUrlParsing(object_store::Error, String),
@@ -280,6 +284,8 @@ impl Diagnostic for ConfigFileError {
             Self::PostgresPoolCreationFailed(_) => "martin::config::postgres::pool_creation",
             #[cfg(feature = "fonts")]
             Self::FontResolutionFailed(..) => "martin::config::fonts::resolution",
+            #[cfg(feature = "fonts")]
+            Self::FontAliasResolutionFailed(_) => "martin::config::fonts::alias",
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) => "martin::config::pmtiles::object_store_url",
             #[cfg(feature = "pmtiles")]
@@ -328,6 +334,10 @@ impl Diagnostic for ConfigFileError {
             }
             #[cfg(feature = "fonts")]
             Self::FontResolutionFailed(..) => return None,
+            #[cfg(feature = "fonts")]
+            Self::FontAliasResolutionFailed(_) => {
+                "Check the `fonts.aliases` block: every alias must list at least one discovered font by its catalog name, and aliases cannot reference other aliases."
+            }
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) | Self::ObjectStoreList(..) => return None,
             #[cfg(all(feature = "rendering", target_os = "linux"))]

--- a/martin/src/config/file/resources/fonts.rs
+++ b/martin/src/config/file/resources/fonts.rs
@@ -30,6 +30,14 @@ pub struct InnerFontConfig {
     )]
     pub cache: CacheSizeConfig,
 
+    /// Named font stacks.
+    ///
+    /// Each alias can be requested like a font and serves the listed fonts combined, in fallback order.
+    /// Aliases may only reference discovered fonts, not other aliases.
+    /// An alias sharing the name of a discovered font takes precedence over it.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aliases: BTreeMap<String, Vec<String>>,
+
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
@@ -61,6 +69,12 @@ impl FontConfig {
             results
                 .recursively_add_directory(base_path.clone())
                 .map_err(|e| ConfigFileError::FontResolutionFailed(e, base_path.clone()))?;
+        }
+
+        for (alias, fonts) in &cfg.custom.aliases {
+            results
+                .add_alias(alias.clone(), fonts.clone())
+                .map_err(ConfigFileError::FontAliasResolutionFailed)?;
         }
 
         *self = Self::new_extended(directories, configs, cfg.custom);

--- a/martin/src/srv/fonts.rs
+++ b/martin/src/srv/fonts.rs
@@ -56,9 +56,12 @@ pub async fn get_font(
     cache: Data<OptFontCache>,
 ) -> ActixResult<HttpResponse> {
     let result = if let Some(cache) = cache.as_ref() {
+        // Key the cache by the fonts the request resolves to, not by the alias,
+        // so invalidating a font also evicts entries reached through an alias.
+        let expanded_ids = fonts.expand_font_ids(&path.fontstack);
         cache
             .get_or_insert(
-                FontCacheKey::new(normalize_font_ids(&path.fontstack), path.start, path.end),
+                FontCacheKey::new(normalize_font_ids(&expanded_ids), path.start, path.end),
                 async || fonts.get_font_range(&path.fontstack, path.start, path.end),
             )
             .await

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -503,6 +503,16 @@
     },
     "FileConfig6": {
       "properties": {
+        "aliases": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Named font stacks.\n\nEach alias can be requested like a font and serves the listed fonts combined, in fallback order.\nAliases may only reference discovered fonts, not other aliases.\nAn alias sharing the name of a discovered font takes precedence over it.",
+          "type": "object"
+        },
         "cache": {
           "$ref": "#/$defs/CacheSizeConfigShape",
           "description": "Cache configuration for fonts.\nUse `cache: disable` to disable font caching."


### PR DESCRIPTION
Closes #2386

Adds `fonts.aliases` to the config: named font stacks a client requests like a single font, served in the listed fallback order. One server-side name replaces listing every fallback font on every layer, and it sidesteps the font-name mangling MapLibre does to multi-font `text-font` values for styled fonts (see #2386).

This is the fonts part of #1076, with two deviations. The map is flat (`alias: [font, ...]`) since aliases carry no other options yet. An alias may shadow a font it references, so an existing name can gain fallbacks without touching styles. Aliases are listed in the catalog, and cache keys store the expanded fonts, so `DELETE /cache/{font}` also evicts entries reached through an alias. Sprites and tiles can follow the same pattern later if this shape works.
