### PR TITLE
feat(cache): cache tiles in the encoding the client receives

### DIFF
--- a/martin-core/src/cache.rs
+++ b/martin-core/src/cache.rs
@@ -98,6 +98,17 @@ impl<K: CacheKey, V: Cacheable> ResourceCache<K, V> {
         Ok(entry.into_value())
     }
 
+    /// Reads a cached value without computing one on a miss.
+    /// Records no hit or miss, that is left to the caller.
+    pub async fn get(&self, key: &K) -> Option<V> {
+        self.inner.get(key).await
+    }
+
+    /// Stores a value, replacing any entry under `key`.
+    pub async fn insert(&self, key: K, value: V) {
+        self.inner.insert(key, value).await;
+    }
+
     /// Invalidates entries whose key matches `source_id`.
     /// Eviction is asynchronous.
     /// Flush the cache via [`Self::run_pending_tasks`].

--- a/martin-core/src/tiles/cache.rs
+++ b/martin-core/src/tiles/cache.rs
@@ -1,10 +1,11 @@
-use martin_tile_utils::{Format, TileCoord};
+use martin_tile_utils::{Encoding, Format, TileCoord};
 
 use crate::cache::{CacheKey, Cacheable, ResourceCache};
 use crate::tiles::Tile;
 
 /// Tile cache for storing rendered tile data, keyed by source ID, tile
-/// coordinate, query string, and `Accept`-driven output format.
+/// coordinate, query string, `Accept`-driven output format, and the
+/// `Accept-Encoding`-negotiated encoding.
 pub type TileCache = ResourceCache<TileCacheKey, Tile>;
 
 /// Optional wrapper for [`TileCache`].
@@ -27,6 +28,9 @@ pub enum TileCacheKey {
         /// Format requested via the `Accept` header
         /// `None` if absent.
         format: Option<Format>,
+        /// Encoding negotiated via the `Accept-Encoding` header.
+        /// `None` for the tile as the pre-cache pipeline produced it.
+        encoding: Option<Encoding>,
     },
 
     /// A tile exactly as its source produced it, before any post-cache processing.
@@ -46,12 +50,14 @@ impl TileCacheKey {
         xyz: TileCoord,
         query: Option<String>,
         format: Option<Format>,
+        encoding: Option<Encoding>,
     ) -> Self {
         Self::Dynamic {
             source_id: source_id.into(),
             xyz,
             query,
             format,
+            encoding,
         }
     }
 

--- a/martin-core/tests/tiles_test.rs
+++ b/martin-core/tests/tiles_test.rs
@@ -114,7 +114,7 @@ async fn wait_and_flush(cache: &TileCache, duration: Duration) {
 }
 
 fn key(source: &str, xyz: TileCoord, query: Option<&str>, format: Option<Format>) -> TileCacheKey {
-    TileCacheKey::new_request_dynamic(source, xyz, query.map(Into::into), format)
+    TileCacheKey::new_request_dynamic(source, xyz, query.map(Into::into), format, None)
 }
 
 async fn insert(
@@ -228,7 +228,7 @@ async fn cache_differentiates_by_format() {
 async fn raw_and_rendered_entries_never_collide() {
     let cache = TileCache::new(CACHE_SIZE, None, None);
     let raw = TileCacheKey::new_request_static("src", ORIGIN);
-    let rendered = TileCacheKey::new_request_dynamic("src", ORIGIN, None, None);
+    let rendered = TileCacheKey::new_request_dynamic("src", ORIGIN, None, None, None);
 
     assert_ne!(raw, rendered, "the discriminator must distinguish the keys");
 
@@ -299,7 +299,7 @@ async fn invalidation_reaches_raw_and_rendered_entries() {
         .unwrap();
     cache
         .get_or_insert(
-            TileCacheKey::new_request_dynamic("src", ORIGIN, None, None),
+            TileCacheKey::new_request_dynamic("src", ORIGIN, None, None, None),
             async || Ok::<_, Infallible>(test_tile(b"baked")),
         )
         .await

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -228,6 +228,24 @@ impl ResolvedProcess {
         source
     }
 
+    /// Whether a post-cache processor shapes this source's tiles.
+    #[must_use]
+    #[cfg_attr(
+        not(all(any(feature = "hillshade", feature = "contour"), feature = "_tiles")),
+        expect(clippy::unused_self)
+    )]
+    pub fn is_post_processed(&self) -> bool {
+        #[cfg(all(feature = "hillshade", feature = "_tiles"))]
+        if self.hillshade.is_some() {
+            return true;
+        }
+        #[cfg(all(feature = "contour", feature = "_tiles"))]
+        if self.contour.is_some() {
+            return true;
+        }
+        false
+    }
+
     /// The [`TileJSON`] this source answers with once post-processing has run.
     #[must_use]
     pub fn advertised_tilejson(&self, tilejson: TileJSON) -> TileJSON {

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -10,7 +10,8 @@ use actix_web::http::header::{
 use actix_web::web::{Data, Path, Query};
 use actix_web::{HttpMessage as _, HttpRequest, HttpResponse, Result as ActixResult, route};
 use futures::stream::{self, StreamExt as _, TryStreamExt as _};
-use martin_core::tiles::{BoxedSource, MartinCoreError, Tile, TileCache, UrlQuery};
+use martin_core::cache::CacheKey as _;
+use martin_core::tiles::{BoxedSource, MartinCoreError, Tile, TileCache, TileCacheKey, UrlQuery};
 use martin_tile_utils::{
     Encoding, Format, TileCoord, TileInfo, decode_brotli, decode_gzip, decode_zlib, decode_zstd,
     encode_brotli_with_quality, encode_gzip, encode_zlib, encode_zstd,
@@ -429,13 +430,63 @@ impl<'a> DynTileSource<'a> {
         err(Debug),
     )]
     pub async fn get_tile_content(&self, xyz: TileCoord) -> ActixResult<Tile> {
+        let served = self.served_key(xyz);
+        if let Some((cache, key)) = &served
+            && let Some(tile) = cache.get(key).await
+        {
+            key.record_outcome(true);
+            return Ok(tile);
+        }
+
         let tiles: Vec<Tile> = stream::iter(&self.sources)
             .map(|(s, pc)| self.get_tile_content_from_one_source(s, pc, xyz))
             .buffered(MAX_CONCURRENT_TILE_FETCHES)
             .try_collect()
             .await?;
 
-        self.merge_tiles(tiles)
+        let produced = tiles.first().map(|t| t.info.encoding);
+        let tile = self.merge_tiles(tiles)?;
+        // Only a re-encoded tile earns a second entry, otherwise the produced one already is the response.
+        if let Some((cache, key)) = served
+            && produced != Some(tile.info.encoding)
+        {
+            cache.insert(key, tile.clone()).await;
+        }
+        Ok(tile)
+    }
+
+    /// The key of this request's response in the encoding the client receives.
+    /// `None` when the response is merged or stitched after the cache, or not cached at all.
+    fn served_key(&self, xyz: TileCoord) -> Option<(&'a TileCache, TileCacheKey)> {
+        let [(s, pc)] = self.sources.as_slice() else {
+            return None;
+        };
+        if pc.is_post_processed() {
+            return None;
+        }
+        let cache = self.cache.filter(|_| s.cache_zoom().contains(xyz.z))?;
+        let key = TileCacheKey::new_request_dynamic(
+            s.get_id(),
+            xyz,
+            self.source_query().map(|q| q.0.to_owned()),
+            self.accepted_format,
+            Some(self.negotiated_encoding()?),
+        );
+        Some((cache, key))
+    }
+
+    /// The encoding a tile is re-encoded into for this request.
+    /// `None` when the `Accept-Encoding` header cannot be negotiated.
+    fn negotiated_encoding(&self) -> Option<Encoding> {
+        let Some(accept_enc) = &self.headers.accept_enc else {
+            return Some(Encoding::Uncompressed);
+        };
+        let negotiated = self.decide_encoding(accept_enc).ok()?;
+        Some(
+            negotiated
+                .and_then(to_encoding)
+                .unwrap_or(Encoding::Uncompressed),
+        )
     }
 
     async fn get_tile_content_from_one_source(
@@ -547,11 +598,12 @@ impl<'a> DynTileSource<'a> {
         if let (Some(cache), true) = (self.cache, cache_zoom) {
             cache
                 .get_or_insert(
-                    martin_core::tiles::TileCacheKey::new_request_dynamic(
+                    TileCacheKey::new_request_dynamic(
                         src_id,
                         xyz,
                         self.source_query().map(|q| q.0.to_owned()),
                         self.accepted_format,
+                        None,
                     ),
                     compute,
                 )
@@ -1086,6 +1138,107 @@ mod tests {
             decoded, expected_raw,
             "decoded content mismatch for src={src_enc:?}, accept={accept:?}"
         );
+    }
+
+    const ORIGIN: TileCoord = TileCoord { z: 0, x: 0, y: 0 };
+
+    fn cached_test_manager(sources: Vec<BoxedSource>) -> TileSourceManager {
+        let sources = sources
+            .into_iter()
+            .map(|s| (s, ResolvedProcess::default()))
+            .collect();
+        TileSourceManager::from_sources(
+            Some(TileCache::new(1_000_000, None, None)),
+            OnInvalid::Abort,
+            vec![sources],
+        )
+    }
+
+    fn mvt_source(id: &'static str, raw: &[u8], encoding: Encoding) -> BoxedSource {
+        let data = if encoding == Encoding::Uncompressed {
+            raw.to_vec()
+        } else {
+            compress_with(raw, encoding)
+        };
+        Box::new(CompressedTestSource {
+            id,
+            tj: tilejson! { tiles: vec![] },
+            data,
+            encoding,
+        })
+    }
+
+    fn accept(accept_enc: Option<&str>) -> TileRequestHeaders {
+        TileRequestHeaders {
+            accept_enc: accept_enc.map(|s| AcceptEncoding(vec![s.parse().unwrap()])),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    #[case::uncompressed_to_gzip(Encoding::Uncompressed, Some("gzip"), Encoding::Gzip, 2)]
+    #[case::uncompressed_to_brotli(Encoding::Uncompressed, Some("br"), Encoding::Brotli, 2)]
+    #[case::gzip_served_as_produced(Encoding::Gzip, Some("gzip"), Encoding::Gzip, 1)]
+    #[case::gzip_decoded_without_header(Encoding::Gzip, None, Encoding::Uncompressed, 2)]
+    #[case::uncompressed_without_header(Encoding::Uncompressed, None, Encoding::Uncompressed, 1)]
+    #[actix_rt::test]
+    async fn a_re_encoded_tile_is_cached_in_the_encoding_it_is_served_in(
+        #[case] produced: Encoding,
+        #[case] accept_enc: Option<&str>,
+        #[case] served: Encoding,
+        #[case] entries: u64,
+    ) {
+        let raw = b"raw mvt bytes";
+        let mgr = cached_test_manager(vec![mvt_source("src", raw, produced)]);
+        let src = DynTileSource::new(&mgr, "src", None, "", accept(accept_enc)).unwrap();
+
+        let tile = src.get_tile_content(ORIGIN).await.unwrap();
+        assert_eq!(tile.info.encoding, served);
+        assert_eq!(decompress_tile(&tile.data, served), raw);
+
+        let cache = mgr.tile_cache().as_ref().unwrap();
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.entry_count(), entries);
+        let served_key = TileCacheKey::new_request_dynamic("src", ORIGIN, None, None, Some(served));
+        assert_eq!(
+            cache.contains_key(&served_key),
+            entries == 2,
+            "a served entry exists iff the tile was re-encoded"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn a_composite_keeps_only_the_produced_entries() {
+        let mgr = cached_test_manager(vec![
+            mvt_source("a", b"aaa", Encoding::Uncompressed),
+            mvt_source("b", b"bbb", Encoding::Uncompressed),
+        ]);
+        let src = DynTileSource::new(&mgr, "a,b", None, "", accept(Some("gzip"))).unwrap();
+        let tile = src.get_tile_content(ORIGIN).await.unwrap();
+        assert_eq!(tile.info.encoding, Encoding::Gzip);
+
+        let cache = mgr.tile_cache().as_ref().unwrap();
+        cache.run_pending_tasks().await;
+        assert_eq!(
+            cache.entry_count(),
+            2,
+            "the merge is re-encoded per request"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn an_empty_tile_earns_no_served_entry() {
+        let mgr = cached_test_manager(vec![mvt_source("src", b"", Encoding::Uncompressed)]);
+        let src = DynTileSource::new(&mgr, "src", None, "", accept(Some("gzip"))).unwrap();
+        let tile = src.get_tile_content(ORIGIN).await.unwrap();
+        assert!(
+            tile.data.is_empty(),
+            "an empty tile is never encoded, so it stays a 204"
+        );
+
+        let cache = mgr.tile_cache().as_ref().unwrap();
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.entry_count(), 1);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1112

A tile that its source hands over uncompressed, PostgreSQL by default, was gzipped or brotlied again on every request, because the cache only held the tile as the pre-cache pipeline produced it. That entry stays, and a second one keyed by the negotiated encoding now holds the bytes the client receives. A brotli client arriving after a gzip client re-encodes from the produced entry instead of going back to the source, the two inserts discussed in the issue. A tile served as produced, a composite, and a hillshaded or contoured tile keep one entry as before, and the cache metric still counts one lookup per request. Re-encoding stored gzip into brotli for clients that prefer it stays a follow-up.

Warm cache, PostgreSQL function and table sources, gzip and br clients, `just build-hotpath` binaries on both sides, 401,202 requests per side:

| | main | this PR |
|---|---:|---:|
| `get_tile_content` average | 107 µs | 29 µs |
| `get_tile_content` p95 | 183 µs | 7 µs |
| `encode` calls | 401,202 | 120 |
| throughput, 256 connections | 103k req/s | 114k req/s |
| p99 latency, 256 connections | 6.0 ms | 3.3 ms |