### PR TITLE
feat(duckdb): read GeoParquet from s3 and the other object stores DuckDB supports

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,4 +1,5 @@
 abfs
+abfss
 actix
 addext
 antimeridian
@@ -68,6 +69,7 @@ noto
 onthegomap
 openlayers
 openmaptiles
+overturemaps
 peucker
 pfor
 pgpassword

--- a/docs/content/sources-duckdb.md
+++ b/docs/content/sources-duckdb.md
@@ -92,7 +92,7 @@ Each GeoParquet source supports:
 
 - **`geoparquet`**
   - a remote URL of the GeoParquet file (`http`, `https`, `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` URLs). A remote URL may be a glob such as `s3://bucket/prefix/*.parquet`, which DuckDB expands into every matching part file.
-  - a local path or `file://` URLs. Local paths must name a single file. 
+  - a local path or `file://` URLs. Local paths must name a single file.
 - **`layer_id`** - MVT `source-layer` and the base for the source id (defaults to the file or URL stem).
 - **`geometry_column`** - geometry column name. Auto-detected when the file has exactly one geometry column.
 - **`id_column`** - optional table column to use as the MVT feature id.

--- a/docs/content/sources-duckdb.md
+++ b/docs/content/sources-duckdb.md
@@ -90,7 +90,9 @@ The top-level `pool_size`, `threads`, `memory_limit_mb`, and `auto_bounds` apply
 
 Each GeoParquet source supports:
 
-- **`geoparquet`** - local path, or a remote URL of the GeoParquet file. `http`, `https`, `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` URLs are read remotely; `file://` URLs and everything else are read as local paths. A remote URL may be a glob such as `s3://bucket/prefix/*.parquet`, which DuckDB expands into every matching part file. Local paths must name a single file.
+- **`geoparquet`**
+  - a remote URL of the GeoParquet file (`http`, `https`, `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` URLs). A remote URL may be a glob such as `s3://bucket/prefix/*.parquet`, which DuckDB expands into every matching part file.
+  - a local path or `file://` URLs. Local paths must name a single file. 
 - **`layer_id`** - MVT `source-layer` and the base for the source id (defaults to the file or URL stem).
 - **`geometry_column`** - geometry column name. Auto-detected when the file has exactly one geometry column.
 - **`id_column`** - optional table column to use as the MVT feature id.

--- a/docs/content/sources-duckdb.md
+++ b/docs/content/sources-duckdb.md
@@ -24,8 +24,7 @@ tags:
     - DuckDB sources are not included in default binaries, Homebrew, or the Docker image
     - There is no CLI shorthand for `.parquet` or `.duckdb` files
     - DuckDB database sources (`database:`) are not yet supported
-    - Local GeoParquet must be a file; directories are rejected
-    - Remote GeoParquet is `http://` / `https://` only
+    - Local GeoParquet must be a single file; directories and globs are rejected
     - Hot reload is not implemented
     - MLT postprocessing is not supported
     - The published configuration schema does not yet include DuckDB sources
@@ -72,6 +71,11 @@ duckdb:
     # Remote GeoParquet over HTTP(S)
     - geoparquet: https://example.org/data/places.parquet
       layer_id: places
+    # Remote GeoParquet in an object store, optionally a glob over many part files
+    - geoparquet: s3://overturemaps-us-west-2/release/2026-08-19.0/theme=places/type=place/*.parquet
+      layer_id: overture_places
+      geometry_column: geometry
+      srid: 4326
 ```
 
 The top-level `pool_size`, `threads`, `memory_limit_mb`, and `auto_bounds` apply to every DuckDB source unless overridden on that source:
@@ -86,7 +90,7 @@ The top-level `pool_size`, `threads`, `memory_limit_mb`, and `auto_bounds` apply
 
 Each GeoParquet source supports:
 
-- **`geoparquet`** - local path or `http://` / `https://` URL of the GeoParquet file.
+- **`geoparquet`** - local path, or a remote URL of the GeoParquet file. `http`, `https`, `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` URLs are read remotely; `file://` URLs and everything else are read as local paths. A remote URL may be a glob such as `s3://bucket/prefix/*.parquet`, which DuckDB expands into every matching part file. Local paths must name a single file.
 - **`layer_id`** - MVT `source-layer` and the base for the source id (defaults to the file or URL stem).
 - **`geometry_column`** - geometry column name. Auto-detected when the file has exactly one geometry column.
 - **`id_column`** - optional table column to use as the MVT feature id.
@@ -157,7 +161,11 @@ Parquet is a columnar file format.
 GeoParquet adds a standard way to store geometry columns and CRS information inside that file.
 
 Martin reads GeoParquet with DuckDB `read_parquet`, loads the DuckDB `spatial` extension, and generates MVT tiles on each request.
-Remote `http://` / `https://` URLs also load the DuckDB `httpfs` extension.
+Remote URLs also load the DuckDB `httpfs` extension.
+
+Martin passes remote URLs to DuckDB unchanged and does not manage credentials for them.
+Public buckets work with no further configuration.
+Private ones need DuckDB's own credential configuration, such as the standard AWS environment variables.
 
 You may want to visit these specs:
 

--- a/e2e-tests/tests/cog.rs
+++ b/e2e-tests/tests/cog.rs
@@ -69,7 +69,7 @@ async fn a_directory_publishes_a_source_per_file() {
 
     let saved = fs::read_to_string(&save_config).expect("martin did not write --save-config");
     let saved = saved.replace(std::path::MAIN_SEPARATOR, "/");
-    insta::assert_snapshot!(saved, @r"
+    insta::assert_snapshot!(saved, @"
     listen_addresses: 127.0.0.1:0
     cog:
       paths: tests/fixtures/cog

--- a/e2e-tests/tests/duckdb.rs
+++ b/e2e-tests/tests/duckdb.rs
@@ -83,12 +83,12 @@ async fn the_catalog_names_the_geoparquet_file() {
 
     let catalog = martin.get("/catalog").await;
     assert_eq!(catalog.status(), 200);
-    insta::assert_snapshot!(catalog.headers_snapshot_masking_etag(), @r"
-      content-encoding: br
-      content-type: application/json
-      etag: [ETAG]
-      transfer-encoding: chunked
-      vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+    insta::assert_snapshot!(catalog.headers_snapshot_masking_etag(), @"
+    content-encoding: br
+    content-type: application/json
+    etag: [ETAG]
+    transfer-encoding: chunked
+    vary: accept-encoding, Origin, Access-Control-Request-Method, Access-Control-Request-Headers
     ");
     insta::assert_json_snapshot!(catalog.json()["tiles"], @r#"
     {
@@ -110,7 +110,7 @@ async fn a_tilejson_describes_the_parquet_columns() {
     let response = martin.get("/polygons").await;
     assert_eq!(response.status(), 200);
     insta::with_settings!({filters => vec![(r"(?m)^etag: .*$", "etag: [ETAG]")]}, {
-        insta::assert_snapshot!(response.headers_snapshot(), @r"
+        insta::assert_snapshot!(response.headers_snapshot(), @"
         content-encoding: br
         content-type: application/json
         etag: [ETAG]
@@ -199,7 +199,7 @@ async fn the_saved_config_fills_in_the_source_defaults() {
         .expect("failed to start martin");
 
     let saved = fs::read_to_string(&save_config).expect("martin did not write --save-config");
-    insta::assert_snapshot!(saved, @r"
+    insta::assert_snapshot!(saved, @"
     listen_addresses: 127.0.0.1:0
     duckdb:
       sources:

--- a/martin/src/config/file/source_location.rs
+++ b/martin/src/config/file/source_location.rs
@@ -6,14 +6,6 @@ use url::Url;
 
 use crate::config::file::{ConfigFileError, ConfigFileResult};
 
-/// Schemes served through `object_store`.
-const OBJECT_STORE_SCHEMES: &[&str] = &[
-    "s3", "s3a", "gs", "az", "adl", "azure", "abfs", "abfss", "file",
-];
-
-/// Schemes served over plain HTTP.
-const HTTP_SCHEMES: &[&str] = &["http", "https"];
-
 /// Where a configured tile source lives.
 ///
 /// Produced by [`SourceLocation::classify`], which owns the scheme table and the URL parsing
@@ -39,20 +31,39 @@ impl SourceLocation {
     /// Returns [`ConfigFileError::InvalidSourceUrl`] if the string carries a recognised remote
     /// scheme but is not a valid URL.
     pub fn classify(raw: &str) -> ConfigFileResult<Self> {
-        let Some(scheme) = raw.split_once("://").map(|(scheme, _)| scheme) else {
-            return Ok(Self::Local(PathBuf::from(raw)));
-        };
-        let is_http = HTTP_SCHEMES.contains(&scheme);
-        if !is_http && !OBJECT_STORE_SCHEMES.contains(&scheme) {
-            return Ok(Self::Local(PathBuf::from(raw)));
+        if let Some(url) = Self::parse_remote(raw, &["http", "https"])? {
+            return Ok(Self::Http(url));
         }
-        let url =
-            Url::parse(raw).map_err(|e| ConfigFileError::InvalidSourceUrl(e, raw.to_owned()))?;
-        Ok(if is_http {
-            Self::Http(url)
-        } else {
-            Self::ObjectStore(url)
-        })
+        if let Some(url) = Self::parse_remote(
+            raw,
+            &[
+                "s3", "s3a", "gs", "az", "adl", "azure", "abfs", "abfss", "file",
+            ],
+        )? {
+            return Ok(Self::ObjectStore(url));
+        }
+        Ok(Self::Local(PathBuf::from(raw)))
+    }
+
+    /// Parse `raw` as a URL if it carries one of `schemes` in `scheme://` form, and `None`
+    /// otherwise - a local path.
+    ///
+    /// Callers that reach a store through something other than `object_store` - `DuckDB`, which
+    /// knows its own set of schemes - pass their own table and get the same parsing rules.
+    ///
+    /// # Errors
+    /// Returns [`ConfigFileError::InvalidSourceUrl`] if the string carries one of `schemes` but is
+    /// not a valid URL.
+    pub fn parse_remote(raw: &str, schemes: &[&str]) -> ConfigFileResult<Option<Url>> {
+        let Some((scheme, _)) = raw.split_once("://") else {
+            return Ok(None);
+        };
+        if !schemes.contains(&scheme) {
+            return Ok(None);
+        }
+        Url::parse(raw)
+            .map(Some)
+            .map_err(|e| ConfigFileError::InvalidSourceUrl(e, raw.to_owned()))
     }
 
     /// Classify a configured source path. Paths that are not valid UTF-8 are always local.
@@ -96,7 +107,7 @@ mod tests {
     use rstest::rstest;
     use url::Url;
 
-    use super::{HTTP_SCHEMES, OBJECT_STORE_SCHEMES, SourceLocation};
+    use super::*;
 
     #[rstest]
     #[case::s3("s3")]
@@ -129,13 +140,6 @@ mod tests {
             SourceLocation::Http(raw.parse().expect("valid url"))
         );
         assert!(location.is_remote());
-    }
-
-    #[test]
-    fn the_two_scheme_sets_are_disjoint() {
-        for scheme in OBJECT_STORE_SCHEMES {
-            assert!(!HTTP_SCHEMES.contains(scheme), "{scheme}");
-        }
     }
 
     #[rstest]
@@ -192,6 +196,21 @@ mod tests {
             location.into_url().map(|url| url.to_string()),
             Some("s3://bucket/tiles.pmtiles".to_owned())
         );
+    }
+
+    #[rstest]
+    #[case::in_the_table(
+        "hf://datasets/org/set/data.parquet",
+        Some("hf://datasets/org/set/data.parquet")
+    )]
+    #[case::not_in_the_table("s3://bucket/data.parquet", None)]
+    #[case::without_authority("hf:datasets/org/set/data.parquet", None)]
+    fn a_caller_table_parses_the_schemes_it_lists_and_no_others(
+        #[case] raw: &str,
+        #[case] expected: Option<&str>,
+    ) {
+        let url = SourceLocation::parse_remote(raw, &["hf"]).expect("parsing should succeed");
+        assert_eq!(url.as_ref().map(Url::as_str), expected);
     }
 
     #[test]

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -288,7 +288,7 @@ sources:
         };
         assert_eq!(entry.geoparquet, GEOPARQUET_FIXTURE);
         assert_matches!(entry.location, Some(GeoParquetLocation::Local(_)));
-        insta::assert_debug_snapshot!(entry.settings, @r#"
+        insta::assert_debug_snapshot!(entry.settings, @"
         DuckDbSourceSettings {
             pool_size: Some(
                 3,
@@ -303,7 +303,7 @@ sources:
                 Skip,
             ),
         }
-        "#);
+        ");
     }
 
     #[test]
@@ -395,7 +395,7 @@ sources:
 
         insta::assert_snapshot!(
             serde_saphyr::to_string(&config).expect("serialize config"),
-            @r#"
+            @"
         duckdb:
           pool_size: 8
           threads: 2
@@ -412,7 +412,7 @@ sources:
             threads: 2
             memory_limit_mb: 256
             auto_bounds: skip
-        "#
+        "
         );
     }
 }

--- a/martin/src/config/file/tiles/duckdb/resolver/geoparquet/sql.rs
+++ b/martin/src/config/file/tiles/duckdb/resolver/geoparquet/sql.rs
@@ -123,6 +123,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(sql, @r#"
+
         WITH tile AS (
             SELECT
                 ?::INTEGER AS z,
@@ -162,6 +163,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(sql, @r#"
+
         WITH tile AS (
             SELECT
                 ?::INTEGER AS z,
@@ -205,6 +207,7 @@ mod tests {
         );
 
         insta::assert_snapshot!(sql, @r#"
+
         WITH tile AS (
             SELECT
                 ?::INTEGER AS z,

--- a/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
+++ b/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
@@ -6,17 +6,8 @@ use url::Url;
 
 use crate::config::file::tiles::duckdb::sources::DuckDbSourceSettings;
 use crate::config::file::{
-    CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, UnrecognizedValues,
+    CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, SourceLocation, UnrecognizedValues,
 };
-
-/// URL schemes `DuckDB` reads remotely through `read_parquet`.
-///
-/// This is deliberately not the table behind [`crate::config::file::SourceLocation`]: that list
-/// describes the object stores Martin reaches through `object_store`, so it carries Hadoop-style
-/// schemes (`s3a`, `adl`, `abfs`) `DuckDB` does not recognise while missing ones it does.
-const REMOTE_SCHEMES: &[&str] = &[
-    "http", "https", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "hf",
-];
 
 /// Characters that make a path segment a `DuckDB` glob rather than a file name.
 ///
@@ -38,14 +29,19 @@ pub enum GeoParquetLocation {
 impl GeoParquetLocation {
     /// Parse a config string and, for local paths, canonicalize to an existing file.
     pub fn from_config(raw: &str) -> ConfigFileResult<Self> {
-        let path = match Url::parse(raw) {
-            Ok(url) if REMOTE_SCHEMES.contains(&url.scheme()) => return Ok(Self::Remote(url)),
-            // `file://` names a local file; hand it to the local branch as a plain path so it
-            // gets a local pool instead of one that loads httpfs.
-            Ok(url) if url.scheme() == "file" => url
+        if let Some(url) = SourceLocation::parse_remote(
+            raw,
+            &[
+                "http", "https", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "hf",
+            ],
+        )? {
+            return Ok(Self::Remote(url));
+        }
+        let path = match SourceLocation::parse_remote(raw, &["file"])? {
+            Some(url) => url
                 .to_file_path()
                 .map_err(|()| ConfigFileError::InvalidFilePath(PathBuf::from(raw)))?,
-            _ => PathBuf::from(raw),
+            None => PathBuf::from(raw),
         };
 
         let canonical = path
@@ -226,13 +222,13 @@ mod tests {
         assert_matches!(location, GeoParquetLocation::Local(_));
     }
 
-    #[test]
-    fn from_config_rejects_schemes_duckdb_cannot_read() {
-        let error = GeoParquetLocation::from_config("ftp://example.org/data.parquet")
-            .expect_err("ftp is not a DuckDB remote scheme");
-        assert!(
-            error.to_string().contains("ftp://example.org/data.parquet"),
-            "unexpected error: {error}"
-        );
+    #[rstest]
+    #[case::unsupported_scheme("ftp://example.org/data.parquet")]
+    #[case::hadoop_scheme_duckdb_lacks("s3a://bucket/data.parquet")]
+    #[case::without_authority("s3:bucket/data.parquet")]
+    #[case::uppercase_scheme("S3://bucket/data.parquet")]
+    fn from_config_treats_anything_else_as_a_local_path(#[case] raw: &str) {
+        let error = GeoParquetLocation::from_config(raw).expect_err("not a DuckDB remote URL");
+        assert!(error.to_string().contains(raw), "unexpected error: {error}");
     }
 }

--- a/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
+++ b/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
@@ -9,9 +9,25 @@ use crate::config::file::{
     CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, UnrecognizedValues,
 };
 
-/// Resolved `GeoParquet` location after finalize: a concrete local file or an http(s) URL.
+/// URL schemes `DuckDB` reads remotely through `read_parquet`.
 ///
-/// Directories are not represented here; discovery (later) must expand them into
+/// This is deliberately not [`crate::config::file::is_remote_url`]: that list describes the
+/// object stores Martin reaches through `object_store`, so it carries Hadoop-style schemes
+/// (`s3a`, `adl`, `abfs`) `DuckDB` does not recognise while missing ones it does.
+const REMOTE_SCHEMES: &[&str] = &[
+    "http", "https", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "hf",
+];
+
+/// Characters that make a path segment a `DuckDB` glob rather than a file name.
+///
+/// `?` is a `DuckDB` glob too, but inside a URL it opens the query string, so it never reaches
+/// a path segment and needs no filtering here.
+const GLOB_CHARS: &[char] = &['*', '[', ']'];
+
+/// Resolved `GeoParquet` location after finalize: a concrete local file, or a remote URL that
+/// may expand to many files.
+///
+/// Local directories are not represented here; discovery (later) must expand them into
 /// [`GeoParquetLocation::Local`] file entries before resolve/SQL.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GeoParquetLocation {
@@ -22,13 +38,16 @@ pub enum GeoParquetLocation {
 impl GeoParquetLocation {
     /// Parse a config string and, for local paths, canonicalize to an existing file.
     pub fn from_config(raw: &str) -> ConfigFileResult<Self> {
-        if let Ok(url) = Url::parse(raw)
-            && matches!(url.scheme(), "http" | "https")
-        {
-            return Ok(Self::Remote(url));
-        }
+        let path = match Url::parse(raw) {
+            Ok(url) if REMOTE_SCHEMES.contains(&url.scheme()) => return Ok(Self::Remote(url)),
+            // `file://` names a local file; hand it to the local branch as a plain path so it
+            // gets a local pool instead of one that loads httpfs.
+            Ok(url) if url.scheme() == "file" => url
+                .to_file_path()
+                .map_err(|()| ConfigFileError::InvalidFilePath(PathBuf::from(raw)))?,
+            _ => PathBuf::from(raw),
+        };
 
-        let path = PathBuf::from(raw);
         let canonical = path
             .canonicalize()
             .map_err(|error| ConfigFileError::IoError(error, path))?;
@@ -48,15 +67,24 @@ impl GeoParquetLocation {
     }
 
     /// Default layer/source id stem from the file name or URL path.
+    ///
+    /// A remote URL may be a glob covering many files, so the last segment can be `*.parquet`.
+    /// The last segment that is not itself a glob names the set well enough to build an id from,
+    /// falling back to the bucket or host when every segment is a glob.
     #[must_use]
     pub fn stem(&self) -> String {
         let stem = match self {
             Self::Local(path) => path.file_stem().and_then(|value| value.to_str()),
             Self::Remote(url) => url
                 .path_segments()
-                .and_then(|mut segments| segments.next_back())
-                .and_then(|segment| Path::new(segment).file_stem())
-                .and_then(|value| value.to_str()),
+                .and_then(|segments| {
+                    segments
+                        .filter(|segment| !segment.contains(GLOB_CHARS))
+                        .filter_map(|segment| Path::new(segment).file_stem())
+                        .filter_map(|value| value.to_str())
+                        .rfind(|value| !value.is_empty())
+                })
+                .or_else(|| url.host_str()),
         };
         stem.filter(|value| !value.is_empty())
             .unwrap_or("duckdb")
@@ -128,6 +156,8 @@ impl GeoParquetEntry {
 mod tests {
     use std::assert_matches;
 
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -152,11 +182,57 @@ mod tests {
         assert_matches!(entry.location, Some(GeoParquetLocation::Local(_)));
     }
 
-    #[test]
-    fn from_config_classifies_http_urls_as_remote() {
-        let location = GeoParquetLocation::from_config("https://example.org/data.parquet")
-            .expect("parse remote");
+    #[rstest]
+    #[case::http("https://example.org/data.parquet", "data")]
+    #[case::s3("s3://bucket/data.parquet", "data")]
+    #[case::gs("gs://bucket/nested/data.parquet", "data")]
+    #[case::r2("r2://bucket/data.parquet", "data")]
+    #[case::azure("az://account/container/data.parquet", "data")]
+    #[case::huggingface("hf://datasets/org/set/data.parquet", "data")]
+    fn from_config_classifies_duckdb_remote_schemes_as_remote(
+        #[case] raw: &str,
+        #[case] stem: &str,
+    ) {
+        let location = GeoParquetLocation::from_config(raw).expect("parse remote");
         assert_matches!(location, GeoParquetLocation::Remote(_));
-        assert_eq!(location.stem(), "data");
+        assert_eq!(location.to_source_string(), raw);
+        assert_eq!(location.stem(), stem);
+    }
+
+    #[rstest]
+    #[case::single_star(
+        "s3://overturemaps-us-west-2/release/2026-08-19.0/theme=places/type=place/*.parquet",
+        "type=place"
+    )]
+    #[case::nested_globs("s3://bucket/year=*/month=*/part-*.parquet", "bucket")]
+    #[case::question_mark_opens_a_query_string("s3://bucket/tiles/part-?.parquet", "part-")]
+    fn a_remote_glob_survives_parsing_and_names_the_source_after_its_last_fixed_segment(
+        #[case] raw: &str,
+        #[case] stem: &str,
+    ) {
+        let location = GeoParquetLocation::from_config(raw).expect("parse glob");
+        assert_eq!(location.to_source_string(), raw);
+        assert_eq!(location.stem(), stem);
+    }
+
+    #[test]
+    fn from_config_reads_file_urls_as_local_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("points.parquet");
+        std::fs::write(&path, b"").expect("touch parquet");
+        let url = Url::from_file_path(&path).expect("absolute path");
+
+        let location = GeoParquetLocation::from_config(url.as_str()).expect("parse file url");
+        assert_matches!(location, GeoParquetLocation::Local(_));
+    }
+
+    #[test]
+    fn from_config_rejects_schemes_duckdb_cannot_read() {
+        let error = GeoParquetLocation::from_config("ftp://example.org/data.parquet")
+            .expect_err("ftp is not a DuckDB remote scheme");
+        assert!(
+            error.to_string().contains("ftp://example.org/data.parquet"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
+++ b/martin/src/config/file/tiles/duckdb/sources/geoparquet.rs
@@ -11,9 +11,9 @@ use crate::config::file::{
 
 /// URL schemes `DuckDB` reads remotely through `read_parquet`.
 ///
-/// This is deliberately not [`crate::config::file::is_remote_url`]: that list describes the
-/// object stores Martin reaches through `object_store`, so it carries Hadoop-style schemes
-/// (`s3a`, `adl`, `abfs`) `DuckDB` does not recognise while missing ones it does.
+/// This is deliberately not the table behind [`crate::config::file::SourceLocation`]: that list
+/// describes the object stores Martin reaches through `object_store`, so it carries Hadoop-style
+/// schemes (`s3a`, `adl`, `abfs`) `DuckDB` does not recognise while missing ones it does.
 const REMOTE_SCHEMES: &[&str] = &[
     "http", "https", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "hf",
 ];


### PR DESCRIPTION
`GeoParquetLocation::from_config` accepted only `http` and `https`, so every other
URL fell through to `PathBuf::canonicalize` and failed with `No such file or
directory`. An `s3://` path - the form the Overture Maps documentation gives -
could not be configured at all.

This matters beyond ergonomics: DuckDB refuses globs over plain HTTP
(`Globs ('*') for generic HTTP file is are not supported`) but expands them over
`s3://`, and object-store datasets are routinely split across part files. Overture
alone ranges from 16 files for `places` to 513 for `buildings`, so without a glob
one Martin source is one part file.

`http`, `https`, `s3`, `gs`, `gcs`, `r2`, `az`, `azure`, `abfss` and `hf` are now
read remotely, `file://` resolves to a local path, and any other scheme still falls
through to the local branch so drive letters and relative paths keep working. The
default source id walks past glob segments to the last fixed one, falling back to
the bucket, so a glob source is not named `*`.

The scheme list is deliberately not `is_remote_url`: that one describes what
`object_store` reaches, so it carries Hadoop-style schemes DuckDB does not know
(`s3a`, `adl`, `abfs`) and omits ones it does (`gcs`, `r2`, `hf`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>