### PR TITLE
feat(postgres): serve a function's key column as the tile ETag

### DIFF
--- a/docs/content/sources-pg-functions.md
+++ b/docs/content/sources-pg-functions.md
@@ -12,7 +12,7 @@ A Function Source is a database function which can be used to
 query [vector tiles](https://github.com/mapbox/vector-tile-spec). When started, Martin will look for the functions with
 a suitable signature.
 
-A function can be used as a Function Source if it returns either a `bytea` value, or a record with `bytea` and a `text` values.  The `text` value is expected to be a user-defined hash, e.g. an MD5 value, and it will eventually be used as an [ETag](https://developer.mozilla.org/de/docs/Web/HTTP/Reference/Headers/ETag).
+A function can be used as a Function Source if it returns either a `bytea` value, or a record with `bytea` and a `text` values.  The `text` value is expected to be a user-defined hash, e.g. an MD5 value, and it is served as the tile's [ETag](https://developer.mozilla.org/de/docs/Web/HTTP/Reference/Headers/ETag).
 
 A valid function must also have these arguments:
 

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -358,6 +358,28 @@ async fn every_function_calling_convention_serves_the_same_tile() {
 }
 
 #[tokio::test]
+async fn a_function_returning_a_key_column_serves_it_as_the_etag() {
+    let mut martin = martin_with_postgres().await;
+
+    let response = martin.get("/function_zxy_row_key/6/57/29").await;
+    assert_eq!(response.status(), 200);
+    // the function's `key` column, `md5(mvt)`, not a hash Martin computed
+    let etag = response
+        .header("etag")
+        .expect("a keyed function tile must carry an etag")
+        .to_owned();
+    insta::assert_snapshot!(etag, @r#""2cab831e0c201dcbd5f081954ab45562""#);
+
+    let cached = martin
+        .get_with_headers("/function_zxy_row_key/6/57/29", &[("if-none-match", &etag)])
+        .await;
+    assert_eq!(cached.status(), 304);
+
+    martin.stop().await;
+    assert_discovery_warnings(&mut martin);
+}
+
+#[tokio::test]
 async fn a_table_keeps_its_own_srid_and_one_without_a_srid_gets_the_default() {
     let mut martin = martin_with_postgres().await;
 

--- a/martin-core/src/tiles/postgres/source.rs
+++ b/martin-core/src/tiles/postgres/source.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use deadpool_postgres::tokio_postgres::Row;
 use deadpool_postgres::tokio_postgres::types::{ToSql, Type};
 use martin_tile_utils::{TileCoord, TileData, TileInfo};
 use tilejson::TileJSON;
@@ -10,7 +11,7 @@ use crate::tiles::postgres::PostgresError::{
 };
 use crate::tiles::postgres::utils::query_to_json;
 use crate::tiles::postgres::{ActiveQueryRegistry, PostgresPool};
-use crate::tiles::{BoxedSource, MartinCoreResult, Source, UrlQuery};
+use crate::tiles::{BoxedSource, MartinCoreResult, Source, Tile, UrlQuery};
 
 #[derive(Clone, Debug)]
 /// `PostgreSQL` tile source that executes SQL queries to generate tiles.
@@ -84,6 +85,44 @@ impl Source for PostgresSource {
         Some(self.pool.active_query_registry().clone())
     }
 
+    async fn get_tile(
+        &self,
+        xyz: TileCoord,
+        url_query: Option<&UrlQuery>,
+    ) -> MartinCoreResult<TileData> {
+        Ok(self
+            .query_row(xyz, url_query)
+            .await?
+            .and_then(|row| row.get::<_, Option<TileData>>(0))
+            .unwrap_or_default())
+    }
+
+    async fn get_tile_with_etag(
+        &self,
+        xyz: TileCoord,
+        url_query: Option<&UrlQuery>,
+    ) -> MartinCoreResult<Tile> {
+        if !self.info.has_etag_column {
+            let data = self.get_tile(xyz, url_query).await?;
+            return Ok(Tile::new_hash_etag(data, self.tile_info));
+        }
+        let row = self.query_row(xyz, url_query).await?;
+        let data: TileData = row
+            .as_ref()
+            .and_then(|row| row.get::<_, Option<TileData>>(0))
+            .unwrap_or_default();
+        let etag: Option<String> = row.and_then(|row| row.get::<_, Option<String>>(1));
+        match etag {
+            Some(etag) if !data.is_empty() && !etag.is_empty() => {
+                Ok(Tile::new_with_etag(data, self.tile_info, etag))
+            }
+            _ => Ok(Tile::new_hash_etag(data, self.tile_info)),
+        }
+    }
+}
+
+impl PostgresSource {
+    /// Runs the tile query, returning the row when the query produced one.
     #[instrument(
         level = "debug",
         skip_all,
@@ -95,11 +134,11 @@ impl Source for PostgresSource {
         ),
         err(Debug),
     )]
-    async fn get_tile(
+    async fn query_row(
         &self,
         xyz: TileCoord,
         url_query: Option<&UrlQuery>,
-    ) -> MartinCoreResult<TileData> {
+    ) -> MartinCoreResult<Option<Row>> {
         let conn = self.pool.get().await?;
 
         let cancel_token = conn.cancel_token();
@@ -143,21 +182,13 @@ impl Source for PostgresSource {
             .await
         };
 
-        let tile = tile
-            .map(|row| {
-                let r = row?;
-                r.get::<_, Option<TileData>>(0)
-            })
-            .map_err(|e| {
-                if self.support_url_query() {
-                    GetTileWithQueryError(e, self.id.clone(), xyz, url_query.cloned())
-                } else {
-                    GetTileError(e, self.id.clone(), xyz)
-                }
-            })?
-            .unwrap_or_default();
-
-        Ok(tile)
+        Ok(tile.map_err(|e| {
+            if self.support_url_query() {
+                GetTileWithQueryError(e, self.id.clone(), xyz, url_query.cloned())
+            } else {
+                GetTileError(e, self.id.clone(), xyz)
+            }
+        })?)
     }
 }
 
@@ -172,6 +203,8 @@ pub struct PostgresSqlInfo {
     pub empty_tile_implies_empty_children: bool,
     /// Signature of the query.
     pub signature: String,
+    /// Whether the query's second column is the tile's `ETag`.
+    pub has_etag_column: bool,
 }
 
 impl PostgresSqlInfo {
@@ -182,12 +215,14 @@ impl PostgresSqlInfo {
         has_query_params: bool,
         empty_tile_implies_empty_children: bool,
         signature: String,
+        has_etag_column: bool,
     ) -> Self {
         Self {
             sql_query: query,
             use_url_query: has_query_params,
             empty_tile_implies_empty_children,
             signature,
+            has_etag_column,
         }
     }
 }

--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -911,6 +911,7 @@ mod tests {
             use_url_query: false,
             empty_tile_implies_empty_children: false,
             signature: "public.my_func(integer, integer, integer) -> bytea",
+            has_etag_column: false,
         }
         "#);
 

--- a/martin/src/config/file/tiles/postgres/resolver/query_functions.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_functions.rs
@@ -85,11 +85,17 @@ pub async fn query_available_function(pool: &PostgresPool) -> PostgresResult<Sql
             query.push(')');
 
             // TODO: Rewrite as a if-let chain:  if Some(names) = output_record_names && output_type == "record" { ... }
+            let mut has_etag_column = false;
             let ret_inf = if let (Some(names), "record") = (output_record_names, output_type.as_str()) {
-                 // SELECT mvt FROM "public"."function_zxy_row2"(
+                 // SELECT "mvt", "key" FROM "public"."function_zxy_row_key"(
                  //    "z" => $1::integer, "x" => $2::integer, "y" => $3::integer
                  // );
                  query.insert_str(0, " FROM ");
+                 if let Some(key) = names.get(1) {
+                     has_etag_column = true;
+                     query.insert_str(0, &escape_identifier(key.as_str()));
+                     query.insert_str(0, ", ");
+                 }
                  query.insert_str(0, &escape_identifier(names[0].as_str()));
                  query.insert_str(0, "SELECT ");
                  format!("[{}]", names.join(", "))
@@ -114,6 +120,7 @@ input_types.len() == 4,
                                 "{schema}.{function}({}) -> {ret_inf}",
                                 input_types.join(", ")
                             ),
+                            has_etag_column,
                         ),
                         FunctionInfo::new(schema, function, tilejson)
                     ),

--- a/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
+++ b/martin/src/config/file/tiles/postgres/resolver/query_tables.rs
@@ -260,6 +260,7 @@ FROM (
             // a table tile is empty only when no geometry intersects its envelope, which contains the envelopes of its children
             true,
             info.format_id(),
+            false,
         ),
         info,
     ))

--- a/martin/src/config/file/tiles/postgres/spec.rs
+++ b/martin/src/config/file/tiles/postgres/spec.rs
@@ -214,6 +214,7 @@ mod tests {
             false,
             false,
             "public.tiles(integer,integer,integer)".to_owned(),
+            false,
         );
         (info, sql)
     }


### PR DESCRIPTION
Closes #1917

Functions returning `(bytea, text)` are discovered with their key column (#380), but the generated query only selected the first column and every tile was hashed again with xxh3, which dericke and tuananh0707 both ran into on #580. The query now selects both and the key is the ETag. The hash stays the fallback for empty tiles, a `NULL` or empty key, and plain `bytea` functions. Table sources don't change. A byte hash isn't a stable identity for a PostGIS tile anyway, since PostgreSQL won't fix feature order without an `ORDER BY` (#1783), and a key column lets the function decide what "changed" means.

| Unchanged tile, 20 identical requests (Martin 1.15.0, table sources) | Distinct ETags |
|---|---:|
| buildings z14 (2,123 polygons) | 5 |
| roads z14 | 2 |
| pois z14 | 2 |
| boundaries z9 | 2 |