### PR TITLE
feat(sprites): add sprite aliases

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -440,6 +440,12 @@ preferred_encoding: brotli
 route_prefix: null
 # Sprite configuration
 sprites:
+  # Named combinations of sprite sources.
+  #
+  # Each alias can be requested like a sprite source and serves the listed sources combined.
+  # Aliases may only reference configured sprite sources, not other aliases.
+  # An alias sharing the name of a sprite source takes precedence over it.
+  aliases: {}
   # Cache configuration for sprites.
   # Use `cache: disable` to disable sprite caching.
   cache:

--- a/docs/content/sources-sprites.md
+++ b/docs/content/sources-sprites.md
@@ -96,3 +96,34 @@ sprites:
 ```
 
 The sprites are now available at `/sprite/my_images,some_dir.png`/ ...
+
+### Sprite Aliases
+
+An alias is a named combination of sprite sources that a style requests like a single source.
+Each alias combines the listed sources exactly like a [combined sprite request](#combining-multiple-sprites).
+
+```yaml
+sprites:
+  paths:
+    - /path/to/base_icons
+    - /path/to/brand_icons
+  # Each alias can be requested like a sprite source and serves the listed sources combined.
+  aliases:
+    icons: [base_icons, brand_icons]
+```
+
+Aliases may only reference configured sprite sources, not other aliases.
+An alias may share the name of a source it references; requests for that name then serve the alias.
+This extends an existing sprite source without changing the name a style uses:
+
+```yaml
+sprites:
+  paths:
+    - /path/to/base_icons
+    - /path/to/brand_icons
+  aliases:
+    # Requests for "base_icons" also get the brand icons.
+    base_icons: [base_icons, brand_icons]
+```
+
+Aliases are listed in the catalog under their own name with the images of every source they combine.

--- a/e2e-tests/tests/sprites.rs
+++ b/e2e-tests/tests/sprites.rs
@@ -1,6 +1,6 @@
 //! Spritesheets generated from directories of SVG files.
 
-use martin_e2e_tests::{Martin, fixture};
+use martin_e2e_tests::{Martin, StartError, fixture};
 use rstest::rstest;
 
 async fn martin_with_sprite_dirs() -> Martin {
@@ -235,4 +235,94 @@ async fn the_plural_sprites_path_redirects(#[case] path: &str, #[case] location:
     assert_eq!(martin.get(location).await.status(), 200);
 
     martin.stop().await;
+}
+
+async fn martin_with_sprite_alias(alias: &str) -> Result<Martin, StartError> {
+    Martin::builder()
+        .config(&format!(
+            "
+sprites:
+  paths:
+    - tests/fixtures/sprites/src1
+    - tests/fixtures/sprites/src2
+  aliases:
+    {alias}
+"
+        ))
+        .start()
+        .await
+}
+
+#[tokio::test]
+async fn an_alias_serves_the_sources_it_combines() {
+    let mut martin = martin_with_sprite_alias("icons: [src1, src2]")
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["sprites"], @r#"
+    {
+      "icons": {
+        "images": [
+          "another_bicycle",
+          "bear",
+          "bicycle",
+          "sub/circle"
+        ]
+      },
+      "src1": {
+        "images": [
+          "another_bicycle",
+          "bear",
+          "sub/circle"
+        ]
+      },
+      "src2": {
+        "images": [
+          "bicycle"
+        ]
+      }
+    }
+    "#);
+
+    for suffix in [".json", ".png", "@2x.json", "@2x.png"] {
+        let aliased = martin.get(&format!("/sprite/icons{suffix}")).await;
+        assert_eq!(aliased.status(), 200, "{suffix}");
+        let explicit = martin.get(&format!("/sprite/src1,src2{suffix}")).await;
+        assert_eq!(aliased.body(), explicit.body(), "{suffix}");
+    }
+
+    martin.stop().await;
+    martin.assert_log_contains("Configured sprite alias");
+}
+
+#[tokio::test]
+async fn an_alias_may_shadow_the_source_it_extends() {
+    let mut martin = martin_with_sprite_alias("src1: [src1, src2]")
+        .await
+        .expect("failed to start martin");
+
+    let shadowed = martin.get("/sprite/src1.json").await;
+    assert_eq!(shadowed.status(), 200);
+    let explicit = martin.get("/sprite/src1,src2.json").await;
+    assert_eq!(shadowed.body(), explicit.body());
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        "Sprite alias shadows a sprite source of the same name; requests for it will serve the alias",
+    );
+}
+
+#[tokio::test]
+async fn an_alias_naming_an_unknown_source_fails_startup() {
+    let error = martin_with_sprite_alias("icons: [src1, nonexistent]")
+        .await
+        .expect_err("martin must reject an alias naming an unknown sprite source");
+    let StartError::EarlyExit { status, log } = error else {
+        panic!("expected an early exit, got: {error}");
+    };
+    assert!(!status.success(), "exit status must be a failure: {status}");
+    assert!(
+        log.contains(r#"Sprite alias "icons" references unknown sprite source "nonexistent""#),
+        "log must name the alias and the missing source; log:\n{log}"
+    );
 }

--- a/martin-core/src/resources/sprites/cache.rs
+++ b/martin-core/src/resources/sprites/cache.rs
@@ -16,7 +16,9 @@ pub const NO_SPRITE_CACHE: OptSpriteCache = None;
 /// `ids` is the comma-joined list of sprite source IDs from the request path,
 /// normalized (sorted and deduplicated) via [`crate::sprites::normalize_sprite_ids`]
 /// so that equivalent requests - different id order, repeated ids - share one
-/// cache entry. Invalidation by source ID matches by token (not substring):
+/// cache entry, with aliases already expanded to their member sources so
+/// invalidating a source also evicts entries reached through an alias.
+/// Invalidation by source ID matches by token (not substring):
 /// invalidating `"foo"` does not invalidate entries keyed against `"foobar"`.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct SpriteCacheKey {

--- a/martin-core/src/resources/sprites/error.rs
+++ b/martin-core/src/resources/sprites/error.rs
@@ -22,6 +22,49 @@ pub enum SpriteError {
         max: usize,
     },
 
+    /// A sprite alias name is empty, contains a comma, or ends with `@2x`.
+    #[error(
+        "Sprite alias {0:?} is invalid: alias names must be non-empty, must not contain commas and must not end with @2x"
+    )]
+    InvalidAliasName(String),
+
+    /// A sprite alias does not reference any sprite sources.
+    #[error("Sprite alias {0:?} does not reference any sprite sources")]
+    EmptyAlias(String),
+
+    /// A sprite alias references more sources than a single request may use.
+    #[error(
+        "Sprite alias {alias:?} references {requested} sprite sources, but at most {max} are allowed"
+    )]
+    TooManySpritesInAlias {
+        /// Alias name.
+        alias: String,
+        /// Referenced source count.
+        requested: usize,
+        /// Allowed maximum.
+        max: usize,
+    },
+
+    /// A sprite alias references another alias instead of a sprite source.
+    #[error(
+        "Sprite alias {alias:?} references {sprite:?}, which is itself an alias; aliases may only reference sprite sources"
+    )]
+    AliasWithinAlias {
+        /// Alias name.
+        alias: String,
+        /// The referenced alias.
+        sprite: String,
+    },
+
+    /// A sprite alias references a sprite source that was not configured.
+    #[error("Sprite alias {alias:?} references unknown sprite source {sprite:?}")]
+    AliasSpriteNotFound {
+        /// Alias name.
+        alias: String,
+        /// The referenced sprite source.
+        sprite: String,
+    },
+
     /// I/O error accessing sprite file or directory.
     #[error("IO error {0}: {1}")]
     IoError(#[source] std::io::Error, PathBuf),
@@ -64,7 +107,12 @@ impl crate::Classify for SpriteError {
         use crate::ErrorKind::{Internal, InvalidInput, NotFound};
         match self {
             Self::SpriteNotFound(_) => NotFound,
-            Self::TooManySpriteIds { .. } => InvalidInput,
+            Self::TooManySpriteIds { .. }
+            | Self::InvalidAliasName(_)
+            | Self::EmptyAlias(_)
+            | Self::TooManySpritesInAlias { .. }
+            | Self::AliasWithinAlias { .. }
+            | Self::AliasSpriteNotFound { .. } => InvalidInput,
             Self::IoError(..)
             | Self::InvalidFilePath(_)
             | Self::InvalidSpriteFilePath(..)

--- a/martin-core/src/resources/sprites/mod.rs
+++ b/martin-core/src/resources/sprites/mod.rs
@@ -83,7 +83,12 @@ fn split_and_dedup_ids(ids: &str) -> (Vec<&str>, u8) {
 #[must_use]
 pub fn normalize_sprite_ids(ids: &str) -> String {
     let (unique_ids, dpi) = split_and_dedup_ids(ids);
-    let joined = unique_ids.join(",");
+    join_ids(&unique_ids, dpi)
+}
+
+/// Joins sprite ids back into request-path form, with the `@2x` suffix for the high-DPI ratio.
+fn join_ids<S: AsRef<str>>(ids: &[S], dpi: u8) -> String {
+    let joined = ids.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(",");
     if dpi == 2 {
         format!("{joined}@2x")
     } else {
@@ -122,14 +127,21 @@ pub type SpriteCatalog = BTreeMap<String, CatalogSpriteEntry>;
 
 /// Thread-safe sprite source manager for serving sprites as `.png` or `.json`.
 #[derive(Debug, Clone, Default)]
-pub struct SpriteSources(DashMap<String, SpriteSource>);
+pub struct SpriteSources {
+    /// Map of sprite source id to its directory.
+    sources: DashMap<String, SpriteSource>,
+    /// Map of alias name to the sprite source ids it combines.
+    aliases: DashMap<String, Vec<String>>,
+}
 
 impl SpriteSources {
-    /// Returns a catalog of all sprite sources.
+    /// Returns a catalog of all sprite sources and aliases.
+    ///
+    /// An alias is listed under its own name with the images of every source it combines.
     pub fn get_catalog(&self) -> Result<SpriteCatalog, SpriteError> {
         // TODO: all sprite generation should be pre-cached
         let mut entries = SpriteCatalog::new();
-        for source in &self.0 {
+        for source in &self.sources {
             let paths = discover_svgs(&source.path)?;
             let mut images = Vec::with_capacity(paths.len());
             for path in paths {
@@ -150,7 +162,109 @@ impl SpriteSources {
                 },
             );
         }
+        let aliases = self
+            .aliases
+            .iter()
+            .map(|alias| {
+                let mut images: Vec<String> = alias
+                    .value()
+                    .iter()
+                    .filter_map(|source| entries.get(source))
+                    .flat_map(|entry| entry.images.iter().cloned())
+                    .collect();
+                images.sort();
+                images.dedup();
+                (
+                    alias.key().clone(),
+                    CatalogSpriteEntry {
+                        images,
+                        size_in_bytes: None,
+                        last_modified_at: None,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        entries.extend(aliases);
         Ok(entries)
+    }
+
+    /// Registers a named combination of sprite sources that serves like a single source.
+    ///
+    /// Every member must name a configured sprite source, not another alias.
+    /// An alias may share the name of a source it references.
+    /// Requests for such a name serve the alias.
+    pub fn add_alias(&self, name: String, sprites: Vec<String>) -> Result<(), SpriteError> {
+        if name.is_empty() || name.contains(',') || name.ends_with("@2x") {
+            return Err(SpriteError::InvalidAliasName(name));
+        }
+        if sprites.is_empty() {
+            return Err(SpriteError::EmptyAlias(name));
+        }
+        if sprites.len() > MAX_SPRITE_IDS_PER_REQUEST {
+            return Err(SpriteError::TooManySpritesInAlias {
+                alias: name,
+                requested: sprites.len(),
+                max: MAX_SPRITE_IDS_PER_REQUEST,
+            });
+        }
+        for sprite in &sprites {
+            if self.aliases.contains_key(sprite) {
+                return Err(SpriteError::AliasWithinAlias {
+                    alias: name,
+                    sprite: sprite.clone(),
+                });
+            }
+            if !self.sources.contains_key(sprite) {
+                return Err(SpriteError::AliasSpriteNotFound {
+                    alias: name,
+                    sprite: sprite.clone(),
+                });
+            }
+        }
+        if self.sources.contains_key(&name) {
+            info!(
+                sprite.alias = %name,
+                "Sprite alias shadows a sprite source of the same name; requests for it will serve the alias"
+            );
+        }
+        info!(
+            sprite.alias = %name,
+            source.ids = %sprites.join(", "),
+            "Configured sprite alias"
+        );
+        self.aliases.insert(name, sprites);
+        Ok(())
+    }
+
+    /// Splits a request id list, replaces every alias with its member sources, and returns
+    /// the sorted, deduplicated ids with the requested pixel ratio.
+    fn expanded_ids(&self, ids: &str) -> (Vec<String>, u8) {
+        let (unique_ids, dpi) = split_and_dedup_ids(ids);
+        let mut expanded: Vec<String> = Vec::with_capacity(unique_ids.len());
+        for id in unique_ids {
+            if let Some(alias) = self.aliases.get(id) {
+                expanded.extend(alias.value().iter().cloned());
+            } else {
+                expanded.push(id.to_owned());
+            }
+        }
+        expanded.sort_unstable();
+        expanded.dedup();
+        (expanded, dpi)
+    }
+
+    /// Expands every alias in a request id list into its member sources, normalized like
+    /// [`normalize_sprite_ids`].
+    ///
+    /// Callers that need the sources a request actually resolves to use this,
+    /// e.g. to build cache keys that can be invalidated per source.
+    #[must_use]
+    pub fn expand_sprite_ids(&self, ids: &str) -> String {
+        if self.aliases.is_empty() {
+            return ids.to_owned();
+        }
+        let (expanded, dpi) = self.expanded_ids(ids);
+        join_ids(&expanded, dpi)
     }
 
     /// Adds a sprite source directory containing SVG files.
@@ -164,7 +278,7 @@ impl SpriteSources {
                 "Ignoring non-directory sprite source"
             );
         } else {
-            match self.0.entry(id) {
+            match self.sources.entry(id) {
                 Entry::Occupied(v) => {
                     warn!(
                         source.id = %v.key(),
@@ -197,6 +311,7 @@ impl SpriteSources {
 
     /// Generates a spritesheet from comma-separated sprite source IDs.
     ///
+    /// Ids may name aliases registered via [`Self::add_alias`], which expand to their member sources.
     /// Append "@2x" for high-DPI sprites.
     /// Set `as_sdf` for SDF sprites.
     #[instrument(
@@ -206,7 +321,7 @@ impl SpriteSources {
         err(Debug),
     )]
     pub async fn get_sprites(&self, ids: &str, as_sdf: bool) -> Result<Spritesheet, SpriteError> {
-        let (unique_ids, dpi) = split_and_dedup_ids(ids);
+        let (unique_ids, dpi) = self.expanded_ids(ids);
 
         if unique_ids.len() > MAX_SPRITE_IDS_PER_REQUEST {
             return Err(SpriteError::TooManySpriteIds {
@@ -216,7 +331,7 @@ impl SpriteSources {
         }
 
         let sprite_ids = unique_ids
-            .into_iter()
+            .iter()
             .map(|id| self.get(id))
             .collect::<Result<Vec<_>, SpriteError>>()?;
 
@@ -224,7 +339,7 @@ impl SpriteSources {
     }
 
     fn get(&self, id: &str) -> Result<SpriteSource, SpriteError> {
-        match self.0.get(id) {
+        match self.sources.get(id) {
             Some(v) => Ok(v.clone()),
             None => Err(SpriteError::SpriteNotFound(id.to_owned())),
         }
@@ -340,6 +455,98 @@ mod tests {
         assert_eq!(single.encode_png().unwrap(), repeated.encode_png().unwrap());
     }
 
+    fn two_sources() -> SpriteSources {
+        let sprites = SpriteSources::default();
+        sprites.add_source(
+            "src1".to_owned(),
+            PathBuf::from("../tests/fixtures/sprites/src1"),
+        );
+        sprites.add_source(
+            "src2".to_owned(),
+            PathBuf::from("../tests/fixtures/sprites/src2"),
+        );
+        sprites
+    }
+
+    #[tokio::test]
+    async fn an_alias_serves_the_same_sheet_as_the_explicit_composite() {
+        let sprites = two_sources();
+        sprites
+            .add_alias(
+                "icons".to_owned(),
+                vec!["src1".to_owned(), "src2".to_owned()],
+            )
+            .unwrap();
+
+        assert_eq!(sprites.expand_sprite_ids("icons"), "src1,src2");
+        assert_eq!(sprites.expand_sprite_ids("icons@2x"), "src1,src2@2x");
+        assert_eq!(
+            sprites.expand_sprite_ids("src2,icons"),
+            "src1,src2",
+            "a source shared between the request and the alias appears once"
+        );
+        let aliased = sprites.get_sprites("icons", false).await.unwrap();
+        let explicit = sprites.get_sprites("src1,src2", false).await.unwrap();
+        assert_eq!(
+            serde_json::to_value(aliased.get_index()).unwrap(),
+            serde_json::to_value(explicit.get_index()).unwrap()
+        );
+        assert_eq!(
+            aliased.encode_png().unwrap(),
+            explicit.encode_png().unwrap()
+        );
+    }
+
+    #[test]
+    fn invalid_aliases_are_rejected() {
+        let sprites = two_sources();
+
+        for name in ["", "has,comma", "icons@2x"] {
+            let err = sprites
+                .add_alias(name.to_owned(), vec!["src1".to_owned()])
+                .unwrap_err();
+            assert_matches!(err, SpriteError::InvalidAliasName(_), "{name:?}");
+        }
+
+        let err = sprites.add_alias("empty".to_owned(), vec![]).unwrap_err();
+        assert_matches!(err, SpriteError::EmptyAlias(_));
+
+        let err = sprites
+            .add_alias("unknown".to_owned(), vec!["nonexistent".to_owned()])
+            .unwrap_err();
+        assert_matches!(err, SpriteError::AliasSpriteNotFound { .. });
+
+        sprites
+            .add_alias("icons".to_owned(), vec!["src1".to_owned()])
+            .unwrap();
+        let err = sprites
+            .add_alias("nested".to_owned(), vec!["icons".to_owned()])
+            .unwrap_err();
+        assert_matches!(err, SpriteError::AliasWithinAlias { .. });
+
+        let too_many = vec!["src1".to_owned(); MAX_SPRITE_IDS_PER_REQUEST + 1];
+        let err = sprites.add_alias("big".to_owned(), too_many).unwrap_err();
+        assert_matches!(err, SpriteError::TooManySpritesInAlias { .. });
+    }
+
+    #[test]
+    fn the_catalog_lists_aliases_with_merged_images() {
+        let sprites = two_sources();
+        sprites
+            .add_alias(
+                "icons".to_owned(),
+                vec!["src1".to_owned(), "src2".to_owned()],
+            )
+            .unwrap();
+
+        let catalog = sprites.get_catalog().unwrap();
+        let entry = catalog.get("icons").expect("alias is cataloged");
+        assert_eq!(
+            entry.images,
+            ["another_bicycle", "bear", "bicycle", "sub/circle"]
+        );
+    }
+
     #[tokio::test]
     async fn too_many_ids_are_rejected_before_any_work() {
         let sprites = SpriteSources::default();
@@ -386,11 +593,11 @@ mod tests {
             PathBuf::from("../tests/fixtures/sprites/src2"),
         );
 
-        assert_eq!(sprites.0.len(), 2);
+        assert_eq!(sprites.sources.len(), 2);
 
         for generate_sdf in [true, false] {
             let paths = sprites
-                .0
+                .sources
                 .iter()
                 .map(|v| v.value().clone())
                 .collect::<Vec<_>>();

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 #[cfg(feature = "fonts")]
 use martin_core::fonts::FontError;
+#[cfg(feature = "sprites")]
+use martin_core::sprites::SpriteError;
 #[cfg(feature = "postgres")]
 use martin_core::tiles::postgres::PostgresError;
 use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode};
@@ -96,6 +98,10 @@ pub enum ConfigFileError {
     #[cfg(feature = "fonts")]
     #[error("Failed to configure font alias: {0}")]
     FontAliasResolutionFailed(#[source] FontError),
+
+    #[cfg(feature = "sprites")]
+    #[error("Failed to configure sprite alias: {0}")]
+    SpriteAliasResolutionFailed(#[source] SpriteError),
 
     #[cfg(feature = "pmtiles")]
     #[error("Failed to parse object store URL of {1}: {0}")]
@@ -286,6 +292,8 @@ impl Diagnostic for ConfigFileError {
             Self::FontResolutionFailed(..) => "martin::config::fonts::resolution",
             #[cfg(feature = "fonts")]
             Self::FontAliasResolutionFailed(_) => "martin::config::fonts::alias",
+            #[cfg(feature = "sprites")]
+            Self::SpriteAliasResolutionFailed(_) => "martin::config::sprites::alias",
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) => "martin::config::pmtiles::object_store_url",
             #[cfg(feature = "pmtiles")]
@@ -337,6 +345,10 @@ impl Diagnostic for ConfigFileError {
             #[cfg(feature = "fonts")]
             Self::FontAliasResolutionFailed(_) => {
                 "Check the `fonts.aliases` block: every alias must list at least one discovered font by its catalog name, and aliases cannot reference other aliases."
+            }
+            #[cfg(feature = "sprites")]
+            Self::SpriteAliasResolutionFailed(_) => {
+                "Check the `sprites.aliases` block: every alias must list at least one configured sprite source by its id, and aliases cannot reference other aliases."
             }
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) | Self::ObjectStoreList(..) => return None,

--- a/martin/src/config/file/resources/sprites.rs
+++ b/martin/src/config/file/resources/sprites.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::config::file::{
-    CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileResult, ConfigurationLivecycleHooks,
-    FileConfigEnum, UnrecognizedValues,
+    CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
+    ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues,
 };
 
 pub type SpriteConfig = FileConfigEnum<InnerSpriteConfig>;
@@ -39,6 +39,12 @@ impl SpriteConfig {
             results.add_source(name.to_string_lossy().to_string(), path);
         }
 
+        for (alias, sprites) in &cfg.custom.aliases {
+            results
+                .add_alias(alias.clone(), sprites.clone())
+                .map_err(ConfigFileError::SpriteAliasResolutionFailed)?;
+        }
+
         *self = Self::new_extended(directories, configs, cfg.custom);
 
         Ok(results)
@@ -66,6 +72,14 @@ pub struct InnerSpriteConfig {
         schemars(with = "crate::config::file::CacheSizeConfigShape")
     )]
     pub cache: CacheSizeConfig,
+
+    /// Named combinations of sprite sources.
+    ///
+    /// Each alias can be requested like a sprite source and serves the listed sources combined.
+    /// Aliases may only reference configured sprite sources, not other aliases.
+    /// An alias sharing the name of a sprite source takes precedence over it.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aliases: BTreeMap<String, Vec<String>>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]

--- a/martin/src/srv/sprites.rs
+++ b/martin/src/srv/sprites.rs
@@ -62,9 +62,15 @@ pub async fn get_sprite_png(
 ) -> ActixResult<HttpResponse> {
     let is_sdf = false;
     let png = if let Some(cache) = cache.as_ref() {
+        // Key the cache by the sources the request resolves to, not by the alias,
+        // so invalidating a source also evicts entries reached through an alias.
         cache
             .get_or_insert(
-                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, false),
+                SpriteCacheKey::new(
+                    normalize_sprite_ids(&sprites.expand_sprite_ids(&path.source_ids)),
+                    is_sdf,
+                    false,
+                ),
                 async || get_sprite(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -132,7 +138,11 @@ pub async fn get_sprite_sdf_png(
     let png = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, false),
+                SpriteCacheKey::new(
+                    normalize_sprite_ids(&sprites.expand_sprite_ids(&path.source_ids)),
+                    is_sdf,
+                    false,
+                ),
                 async || get_sprite(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -201,7 +211,11 @@ pub async fn get_sprite_json(
     let json = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, true),
+                SpriteCacheKey::new(
+                    normalize_sprite_ids(&sprites.expand_sprite_ids(&path.source_ids)),
+                    is_sdf,
+                    true,
+                ),
                 async || get_index(&path.source_ids, &sprites, is_sdf).await,
             )
             .await
@@ -270,7 +284,11 @@ pub async fn get_sprite_sdf_json(
     let json = if let Some(cache) = cache.as_ref() {
         cache
             .get_or_insert(
-                SpriteCacheKey::new(normalize_sprite_ids(&path.source_ids), is_sdf, true),
+                SpriteCacheKey::new(
+                    normalize_sprite_ids(&sprites.expand_sprite_ids(&path.source_ids)),
+                    is_sdf,
+                    true,
+                ),
                 async || get_index(&path.source_ids, &sprites, is_sdf).await,
             )
             .await

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -463,6 +463,16 @@
     },
     "FileConfig4": {
       "properties": {
+        "aliases": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Named combinations of sprite sources.\n\nEach alias can be requested like a sprite source and serves the listed sources combined.\nAliases may only reference configured sprite sources, not other aliases.\nAn alias sharing the name of a sprite source takes precedence over it.",
+          "type": "object"
+        },
         "cache": {
           "$ref": "#/$defs/CacheSizeConfigShape",
           "description": "Cache configuration for sprites.\nUse `cache: disable` to disable sprite caching."


### PR DESCRIPTION
Sprites slice of #1076, same shape as the fonts one in #3210.

Adds `sprites.aliases` to the config: a named combination of sprite sources that a style requests like a single source, and Martin serves like `/sprite/a,b`. One server-side name replaces listing every source in every style, and a source can gain icons without changing the name styles use, since an alias may shadow a source it references. Aliases are listed in the catalog with the images of every source they combine, and cache keys store the expanded sources, so `DELETE /cache/{sprite}` also evicts entries reached through an alias. Same flat map and the same rules as fonts: only configured sources, no alias inside an alias, and an alias name cannot end in `@2x` since that suffix belongs to the request