### PR TITLE
feat(postgres): add a connection-level cache zoom default

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -356,6 +356,19 @@ postgres:
       # Optionally set how source ID should be generated based on the table's name,
       # schema, and geometry column
       source_id_format: table.{schema}.{table}.{column}
+  # Zoom-level bounds for caching the tiles of this connection.
+  # Every table and function without its own `cache` takes them, over the top-level `cache` bounds.
+  cache:
+    # Default maximum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed in than this will bypass the cache entirely.
+    # Can be overridden per-source.
+    # default: null (no upper bound, all zoom levels cached)
+    maxzoom: 14
+    # Default minimum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed out than this will bypass the cache entirely.
+    # Can be overridden with `cache.minzoom` on an individual source.
+    # default: null (no lower bound, all zoom levels cached)
+    minzoom: 0
   # Database connection string.
   #
   # You can use environment variables too, for example:

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -703,3 +703,57 @@ async fn the_saved_config_carries_the_auto_publish_settings_into_every_table_it_
     martin.stop().await;
     assert_unindexed_table_warnings(&mut martin);
 }
+
+/// The `martin_tile_cache_requests_total` lines of a metrics scrape, so a test can say what the
+/// tile cache saw without pinning the rest of the scrape.
+fn tile_cache_lines(scrape: &str) -> String {
+    scrape
+        .lines()
+        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A server that auto-publishes everything, like [`martin_with_postgres`], from a config that
+/// carries the given connection-level keys.
+async fn martin_auto_publishing_with(connection_keys: &str) -> Martin {
+    Martin::builder()
+        .with_postgres()
+        .config(&format!(
+            "
+postgres:
+  connection_string: ${{DATABASE_URL}}
+  default_srid: 900913
+  auto_bounds: calc
+  pool_size: 1
+{connection_keys}"
+        ))
+        .start()
+        .await
+        .expect("failed to start martin")
+}
+
+#[tokio::test]
+async fn an_auto_discovered_table_takes_the_connection_level_cache_bounds() {
+    let mut bounded = martin_auto_publishing_with("  cache:\n    minzoom: 1\n").await;
+    for _ in 0..2 {
+        assert_eq!(bounded.get("/table_source/0/0/0").await.status(), 200);
+    }
+    let scrape = bounded.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
+    bounded.stop().await;
+    assert_discovery_warnings(&mut bounded);
+
+    // The same connection without bounds shows what the cache would have counted.
+    let mut unbounded = martin_auto_publishing_with("").await;
+    for _ in 0..2 {
+        assert_eq!(unbounded.get("/table_source/0/0/0").await.status(), 200);
+    }
+    let scrape = unbounded.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @r#"
+    martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
+    martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1
+    "#);
+    unbounded.stop().await;
+    assert_discovery_warnings(&mut unbounded);
+}

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -708,23 +708,23 @@ async fn the_saved_config_carries_the_auto_publish_settings_into_every_table_it_
 async fn an_auto_discovered_table_takes_the_connection_level_cache_bounds() {
     let mut bounded = Martin::builder()
         .with_postgres()
-        .config(&format!(
+        .config(
             "
 postgres:
-  connection_string: ${{DATABASE_URL}}
+  connection_string: ${DATABASE_URL}
   default_srid: 900913
   auto_bounds: calc
   pool_size: 1
   cache:
-    minzoom: 1"
-        ))
+    minzoom: 1",
+        )
         .start()
         .await
         .expect("failed to start martin");
     for _ in 0..2 {
         assert_eq!(bounded.get("/table_source/0/0/0").await.status(), 200);
     }
-    let metrics = unbounded.get("/_/metrics").await;
+    let metrics = bounded.get("/_/metrics").await;
     assert_eq!(metrics.status(), 200);
     let tile_cache_lines = metrics
         .text()
@@ -732,23 +732,23 @@ postgres:
         .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
         .collect::<Vec<_>>()
         .join("\n");
-    insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
+    insta::assert_snapshot!(tile_cache_lines, @"");
     bounded.stop().await;
     assert_discovery_warnings(&mut bounded);
 }
 
 #[tokio::test]
 async fn an_auto_discovered_table_takes_the_default_cache_bounds() {
-    let mut bounded = Martin::builder()
+    let mut unbounded = Martin::builder()
         .with_postgres()
-        .config(&format!(
+        .config(
             "
 postgres:
-  connection_string: ${{DATABASE_URL}}
+  connection_string: ${DATABASE_URL}
   default_srid: 900913
   auto_bounds: calc
-  pool_size: 1"
-        ))
+  pool_size: 1",
+        )
         .start()
         .await
         .expect("failed to start martin");

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -704,20 +704,9 @@ async fn the_saved_config_carries_the_auto_publish_settings_into_every_table_it_
     assert_unindexed_table_warnings(&mut martin);
 }
 
-/// The `martin_tile_cache_requests_total` lines of a metrics scrape, so a test can say what the
-/// tile cache saw without pinning the rest of the scrape.
-fn tile_cache_lines(scrape: &str) -> String {
-    scrape
-        .lines()
-        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// A server that auto-publishes everything, like [`martin_with_postgres`], from a config that
-/// carries the given connection-level keys.
-async fn martin_auto_publishing_with(connection_keys: &str) -> Martin {
-    Martin::builder()
+#[tokio::test]
+async fn an_auto_discovered_table_takes_the_connection_level_cache_bounds() {
+    let mut bounded = Martin::builder()
         .with_postgres()
         .config(&format!(
             "
@@ -726,31 +715,55 @@ postgres:
   default_srid: 900913
   auto_bounds: calc
   pool_size: 1
-{connection_keys}"
+  cache:
+    minzoom: 1"
         ))
         .start()
         .await
-        .expect("failed to start martin")
-}
-
-#[tokio::test]
-async fn an_auto_discovered_table_takes_the_connection_level_cache_bounds() {
-    let mut bounded = martin_auto_publishing_with("  cache:\n    minzoom: 1\n").await;
+        .expect("failed to start martin");
     for _ in 0..2 {
         assert_eq!(bounded.get("/table_source/0/0/0").await.status(), 200);
     }
-    let scrape = bounded.get("/_/metrics").await.text();
+    let metrics = unbounded.get("/_/metrics").await;
+    assert_eq!(metrics.status(), 200);
+    let tile_cache_lines = metrics
+            .text()
+            .lines()
+            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+            .collect::<Vec<_>>()
+            .join("\n");
     insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
     bounded.stop().await;
     assert_discovery_warnings(&mut bounded);
+}
 
-    // The same connection without bounds shows what the cache would have counted.
-    let mut unbounded = martin_auto_publishing_with("").await;
+#[tokio::test]
+async fn an_auto_discovered_table_takes_the_default_cache_bounds() {
+    let mut bounded = Martin::builder()
+        .with_postgres()
+        .config(&format!(
+            "
+postgres:
+  connection_string: ${{DATABASE_URL}}
+  default_srid: 900913
+  auto_bounds: calc
+  pool_size: 1"
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
     for _ in 0..2 {
         assert_eq!(unbounded.get("/table_source/0/0/0").await.status(), 200);
     }
-    let scrape = unbounded.get("/_/metrics").await.text();
-    insta::assert_snapshot!(tile_cache_lines(&scrape), @r#"
+    let metrics = unbounded.get("/_/metrics").await;
+    assert_eq!(metrics.status(), 200);
+    let tile_cache_lines = metrics
+            .text()
+            .lines()
+            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+            .collect::<Vec<_>>()
+            .join("\n");
+    insta::assert_snapshot!(tile_cache_lines, @r#"
     martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
     martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1
     "#);

--- a/e2e-tests/tests/postgres.rs
+++ b/e2e-tests/tests/postgres.rs
@@ -727,11 +727,11 @@ postgres:
     let metrics = unbounded.get("/_/metrics").await;
     assert_eq!(metrics.status(), 200);
     let tile_cache_lines = metrics
-            .text()
-            .lines()
-            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        .text()
+        .lines()
+        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+        .collect::<Vec<_>>()
+        .join("\n");
     insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
     bounded.stop().await;
     assert_discovery_warnings(&mut bounded);
@@ -758,11 +758,11 @@ postgres:
     let metrics = unbounded.get("/_/metrics").await;
     assert_eq!(metrics.status(), 200);
     let tile_cache_lines = metrics
-            .text()
-            .lines()
-            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        .text()
+        .lines()
+        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+        .collect::<Vec<_>>()
+        .join("\n");
     insta::assert_snapshot!(tile_cache_lines, @r#"
     martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
     martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1

--- a/martin/src/config/args/postgres.rs
+++ b/martin/src/config/args/postgres.rs
@@ -5,6 +5,7 @@ use tracing::{info, warn};
 use super::bounds::BoundsCalcType;
 use super::connections::Arguments;
 use super::connections::State::{Ignore, Take};
+use crate::config::file::CachePolicy;
 use crate::config::file::UnrecognizedValues;
 use crate::config::file::postgres::{
     DEFAULT_POOL_SIZE, DEFAULT_RELOAD_INTERVAL, PostgresConfig, PostgresSslCerts,
@@ -62,6 +63,7 @@ impl PostgresArgs {
                 auto_bounds: self.auto_bounds,
                 max_feature_count: self.max_feature_count,
                 pool_size: self.pool_size,
+                cache: CachePolicy::default(),
                 reload_interval: DEFAULT_RELOAD_INTERVAL,
                 auto_publish: OptBoolObj::NoValue,
                 tables: None,

--- a/martin/src/config/file/tiles/postgres/config.rs
+++ b/martin/src/config/file/tiles/postgres/config.rs
@@ -8,8 +8,8 @@ use tilejson::TileJSON;
 use super::{FuncInfoSources, TableInfoSources};
 use crate::config::args::BoundsCalcType;
 use crate::config::file::{
-    CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks,
-    UnrecognizedValues,
+    CachePolicy, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
+    ConfigurationLivecycleHooks, UnrecognizedValues,
 };
 #[cfg(all(feature = "mlt", feature = "_tiles"))]
 use crate::config::file::{MltProcessConfig, MvtProcessConfig};
@@ -94,6 +94,14 @@ pub struct PostgresConfig {
     /// Maximum Postgres connections pool size \[default: 20\]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &20usize))]
     pub pool_size: Option<NonZeroUsize>,
+    /// Zoom-level bounds for caching the tiles of this connection.
+    /// Every table and function without its own `cache` takes them, over the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
     /// How often the `PostgresReloader` re-runs catalog discovery to publish new tables and
     /// functions, update changed ones, and drop removed ones at runtime, without a restart.
     ///
@@ -166,6 +174,7 @@ impl Default for PostgresConfig {
             auto_bounds: None,
             max_feature_count: None,
             pool_size: None,
+            cache: CachePolicy::default(),
             reload_interval: DEFAULT_RELOAD_INTERVAL,
             auto_publish: OptBoolObj::default(),
             tables: None,
@@ -383,6 +392,29 @@ mod tests {
             &Config {
                 postgres: One(PostgresConfig {
                     connection_string: Some("postgresql://postgres@localhost/db".to_owned()),
+                    auto_publish: OptBoolObj::Bool(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn parse_pg_cache() {
+        assert_config(
+            indoc! {"
+            postgres:
+              connection_string: 'postgresql://postgres@localhost/db'
+              cache:
+                minzoom: 1
+                maxzoom: 10
+        "},
+            &Config {
+                postgres: One(PostgresConfig {
+                    connection_string: Some("postgresql://postgres@localhost/db".to_owned()),
+                    cache: CachePolicy::new(martin_core::CacheZoomRange::new(Some(1), Some(10))),
                     auto_publish: OptBoolObj::Bool(true),
                     ..Default::default()
                 }),

--- a/martin/src/config/file/tiles/reload/postgres.rs
+++ b/martin/src/config/file/tiles/reload/postgres.rs
@@ -54,6 +54,7 @@ impl PostgresReloader {
             ProcessConfig::default()
         };
 
+        let default_cache = config.cache.or(default_cache);
         let discovery = PostgresDiscovery::new(config, id_resolver, default_cache, process);
         Self {
             driver: ReloadDriver::new(discovery, tsm),

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -1413,6 +1413,10 @@
           "$ref": "#/$defs/OptBoolObj",
           "description": "Enable automatic discovery of tables and functions. \\[default: null\\]\n\nOptions:\n- `true`: run automatic discovery (`true` may be omitted if further configuration is provided)\n- `false`: disable automatic discovery\n- null: run automatic discovery if `postgres.tables` is null and `postgres.functions` is null"
         },
+        "cache": {
+          "$ref": "#/$defs/CachePolicyShape",
+          "description": "Zoom-level bounds for caching the tiles of this connection.\nEvery table and function without its own `cache` takes them, over the top-level `cache` bounds."
+        },
         "connection_string": {
           "description": "Database connection string.\n\nYou can use environment variables too, for example:\n`connection_string: $DATABASE_URL`\n`connection_string: ${DATABASE_URL:-postgres://postgres@localhost/db}`",
           "examples": ["postgres://postgres@localhost:5432/db"],


### PR DESCRIPTION
Step 3 of #1137, and the postgres half of step 2. Prior art: #2673 (per-source `cache`), #3193 (per-source > source type > global for the process settings).

Adds `postgres.cache`: the cache zoom bounds every table and function on that connection takes unless it sets its own, layered over the top-level `cache` bounds the way `default_srid` sits on the connection. Until now an auto-discovered table or function could only take the global bounds, so keeping a whole discovered schema out of the cache meant declaring every table. The file kinds get the same per-kind default in a follow-up, which is the rest of step 2 and closes the issue