### PR TITLE
fix(reload): apply the global cache zoom bounds to discovered files

### DIFF
--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -429,18 +429,15 @@ async fn reload_removes_a_source_when_its_file_is_deleted() {
     martin.assert_startup_warnings();
 }
 
-/// The `martin_tile_cache_requests_total` lines of a metrics scrape, so a test can say what the
-/// tile cache saw without pinning the rest of the scrape.
-fn tile_cache_lines(scrape: &str) -> String {
-    scrape
-        .lines()
-        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 #[tokio::test]
 async fn a_file_discovered_in_a_directory_takes_the_global_cache_bounds() {
+    fn tile_cache_lines(scrape: &str) -> String {
+        scrape
+            .lines()
+            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
     let watched = WatchedDir::new();
     mbtiles_fixture(watched.dir(), "world_cities").await;
     let dir = watched.dir();

--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -428,3 +428,51 @@ async fn reload_removes_a_source_when_its_file_is_deleted() {
     martin.assert_log_contains(r#"ERROR error="Source world_cities does not exist""#);
     martin.assert_startup_warnings();
 }
+
+/// The `martin_tile_cache_requests_total` lines of a metrics scrape, so a test can say what the
+/// tile cache saw without pinning the rest of the scrape.
+fn tile_cache_lines(scrape: &str) -> String {
+    scrape
+        .lines()
+        .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn a_file_discovered_in_a_directory_takes_the_global_cache_bounds() {
+    let watched = WatchedDir::new();
+    mbtiles_fixture(watched.dir(), "world_cities").await;
+    let dir = watched.dir();
+
+    let mut bounded = Martin::builder()
+        .config(&format!(
+            "cache:\n  minzoom: 1\nmbtiles:\n  paths: {}\n",
+            dir.display()
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
+    for _ in 0..2 {
+        assert_eq!(bounded.get("/world_cities/0/0/0").await.status(), 200);
+    }
+    let scrape = bounded.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
+    bounded.stop().await;
+
+    // The same directory without a lower bound shows what the cache would have counted.
+    let mut unbounded = Martin::builder()
+        .config(&format!("mbtiles:\n  paths: {}\n", dir.display()))
+        .start()
+        .await
+        .expect("failed to start martin");
+    for _ in 0..2 {
+        assert_eq!(unbounded.get("/world_cities/0/0/0").await.status(), 200);
+    }
+    let scrape = unbounded.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @r#"
+    martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
+    martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1
+    "#);
+    unbounded.stop().await;
+}

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -55,6 +55,8 @@ pub struct FsDiscovery {
     /// Canonical path -> configured entry for explicitly-configured sources.
     configured: BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: IdResolver,
+    /// The kind level cache bounds, for every source without its own.
+    default_cache: CachePolicy,
     /// The kind level, resolved once for every source without its own override.
     process: ResolvedProcess,
     build: FsSourceBuilder,
@@ -65,12 +67,17 @@ pub struct FsDiscovery {
 impl FsDiscovery {
     /// Collects the local watch directories and per-path config entries.
     /// Remote URLs are skipped.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one call per file kind, and every argument is a distinct kind-level input"
+    )]
     pub fn from_config<C>(
         kind: FileKind,
         config: &FileConfigEnum<C>,
         recursive: bool,
         extensions: &'static [&'static str],
         id_resolver: IdResolver,
+        default_cache: CachePolicy,
         process: &ProcessConfig,
         build: FsSourceBuilder,
     ) -> Self {
@@ -93,7 +100,7 @@ impl FsDiscovery {
                 configured.insert(
                     canonical,
                     ConfiguredSource {
-                        policy: src.cache_zoom(),
+                        policy: src.cache_zoom().or(default_cache),
                         process: per_source_process(process, src),
                         src: src.clone(),
                     },
@@ -143,6 +150,7 @@ impl FsDiscovery {
             extensions,
             configured,
             id_resolver,
+            default_cache,
             process: process
                 .resolve()
                 .expect("the kind level carries no range-checked settings"),
@@ -222,6 +230,7 @@ impl Discovery for FsDiscovery {
             self.extensions,
             &self.configured,
             &self.id_resolver,
+            self.default_cache,
         )
         .await?;
 
@@ -330,6 +339,7 @@ async fn discover_sources_by_ext(
     extensions: &[&str],
     configured: &BTreeMap<PathBuf, ConfiguredSource>,
     id_resolver: &IdResolver,
+    default_cache: CachePolicy,
 ) -> SourceBuildResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
     let mut out = BTreeMap::new();
     for directory in directories {
@@ -362,8 +372,7 @@ async fn discover_sources_by_ext(
                 };
                 let policy = configured
                     .get(&e.path)
-                    .map(|cfg| cfg.policy)
-                    .unwrap_or_default();
+                    .map_or(default_cache, |cfg| cfg.policy);
                 let id = id_resolver.resolve(&name, e.path_str.clone());
                 out.insert(id, (e.path, e.modified_ms, policy));
             }
@@ -466,6 +475,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             unreachable_builder(),
         );
@@ -498,6 +508,7 @@ mod tests {
             true,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             unreachable_builder(),
         );
@@ -517,6 +528,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             unreachable_builder(),
         );
@@ -547,6 +559,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             fake_builder(),
         );
@@ -574,6 +587,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             fake_builder(),
         );
@@ -593,6 +607,56 @@ mod tests {
     }
 
     #[cfg(all(feature = "mlt", feature = "hillshade", feature = "_tiles"))]
+    #[tokio::test]
+    async fn discovered_files_take_the_kind_level_cache_bounds() {
+        use crate::config::file::{FileConfig, FileConfigSource};
+        use crate::config::primitives::OptOneMany;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let scanned = dir.path().join("scanned.mbtiles");
+        let configured = dir.path().join("configured.mbtiles");
+        File::create(&scanned).expect("create scanned");
+        File::create(&configured).expect("create configured");
+
+        let config = FileConfigEnum::Config(FileConfig {
+            paths: OptOneMany::One(dir.path().to_path_buf()),
+            sources: Some(BTreeMap::from([(
+                "configured".to_owned(),
+                FileConfigSrc::Obj(Box::new(FileConfigSource {
+                    path: configured.clone(),
+                    convert_to_mlt: None,
+                    convert_to_mvt: None,
+                    cache_control: None,
+                    convert_to_hillshade: None,
+                    #[cfg(all(feature = "contour", feature = "_tiles"))]
+                    convert_to_contour: None,
+                    cache: CachePolicy::new(CacheZoomRange::new(Some(3), None)),
+                })),
+            )])),
+            ..FileConfig::<()>::default()
+        });
+        let discovery = FsDiscovery::from_config(
+            FileKind::Mbtiles,
+            &config,
+            false,
+            &["mbtiles"],
+            IdResolver::new(&[]),
+            CachePolicy::new(CacheZoomRange::new(Some(1), Some(10))),
+            &ProcessConfig::default(),
+            unreachable_builder(),
+        );
+
+        let snapshot = discovery.discover().await.expect("discover").sources;
+        let (_, (_, scanned)) = &snapshot["scanned"];
+        assert_eq!(scanned.zoom(), CacheZoomRange::new(Some(1), Some(10)));
+        let (_, (_, configured)) = &snapshot["configured"];
+        assert_eq!(
+            configured.zoom(),
+            CacheZoomRange::new(Some(3), Some(10)),
+            "a configured bound wins and the other is filled from the kind level"
+        );
+    }
+
     #[test]
     fn configured_sources_keep_their_convert_override() {
         use crate::config::file::{FileConfig, FileConfigSource};
@@ -637,6 +701,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &kind_level,
             unreachable_builder(),
         );
@@ -693,6 +758,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             unreachable_builder(),
         );
@@ -728,6 +794,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             fake_builder(),
         );
@@ -766,6 +833,7 @@ mod tests {
             false,
             &["mbtiles"],
             IdResolver::new(&[]),
+            CachePolicy::default(),
             &ProcessConfig::default(),
             unreachable_builder(),
         );

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -606,7 +606,6 @@ mod tests {
         assert_yaml_snapshot!(error.to_string().replace(&prefix, "<DIR>"), @r#""Source path is not a file: <DIR>/bad_0.mbtiles""#);
     }
 
-    #[cfg(all(feature = "mlt", feature = "hillshade", feature = "_tiles"))]
     #[tokio::test]
     async fn discovered_files_take_the_kind_level_cache_bounds() {
         use crate::config::file::{FileConfig, FileConfigSource};
@@ -624,9 +623,12 @@ mod tests {
                 "configured".to_owned(),
                 FileConfigSrc::Obj(Box::new(FileConfigSource {
                     path: configured.clone(),
+                    #[cfg(all(feature = "mlt", feature = "_tiles"))]
                     convert_to_mlt: None,
+                    #[cfg(all(feature = "mlt", feature = "_tiles"))]
                     convert_to_mvt: None,
                     cache_control: None,
+                    #[cfg(all(feature = "hillshade", feature = "_tiles"))]
                     convert_to_hillshade: None,
                     #[cfg(all(feature = "contour", feature = "_tiles"))]
                     convert_to_contour: None,
@@ -657,6 +659,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "mlt", feature = "hillshade", feature = "_tiles"))]
     #[test]
     fn configured_sources_keep_their_convert_override() {
         use crate::config::file::{FileConfig, FileConfigSource};

--- a/martin/src/config/file/tiles/discovery/object_store.rs
+++ b/martin/src/config/file/tiles/discovery/object_store.rs
@@ -24,6 +24,8 @@ pub struct ObjectStoreDiscovery {
     remote_prefixes: Vec<Url>,
     id_resolver: IdResolver,
     config: PmtConfig,
+    /// The kind level cache bounds, for every remote source.
+    default_cache: CachePolicy,
     /// The kind level, which every remote prefix serves with.
     process: ResolvedProcess,
 }
@@ -34,6 +36,7 @@ impl ObjectStoreDiscovery {
     pub fn from_config(
         config: &FileConfigEnum<PmtConfig>,
         id_resolver: IdResolver,
+        default_cache: CachePolicy,
         process: &ProcessConfig,
     ) -> Self {
         let mut remote_prefixes: Vec<Url> = vec![];
@@ -72,6 +75,7 @@ impl ObjectStoreDiscovery {
             remote_prefixes,
             id_resolver,
             config: pmt_config,
+            default_cache,
             process: process
                 .resolve()
                 .expect("the kind level carries no range-checked settings"),
@@ -116,7 +120,7 @@ impl Discovery for ObjectStoreDiscovery {
 
     async fn build(&self, id: &str, args: &Self::Args) -> SourceBuildResult<BuiltSource> {
         self.config
-            .new_sources_url(id.to_owned(), args.clone(), CachePolicy::default())
+            .new_sources_url(id.to_owned(), args.clone(), self.default_cache)
             .await
             .map(Into::into)
     }

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -6,7 +6,7 @@ use crate::config::file::cog::CogConfig;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
-use crate::config::file::{FileConfigEnum, SourceBuildResult, TileSourceWarning};
+use crate::config::file::{CachePolicy, FileConfigEnum, SourceBuildResult, TileSourceWarning};
 use crate::config::primitives::IdResolver;
 use crate::reload::FileKind;
 
@@ -21,6 +21,7 @@ impl CogReloader {
         tsm: TileSourceManager,
         id_resolver: IdResolver,
         config: &FileConfigEnum<CogConfig>,
+        default_cache: CachePolicy,
     ) -> Self {
         // See `MbtilesReloader::new`: both boxes erase per-kind types to a shared shape.
         // This builder captures nothing, but is `Box::new`d to share the boxed `FsSourceBuilder` type.
@@ -37,6 +38,7 @@ impl CogReloader {
             recursive,
             &["tif", "tiff"],
             id_resolver,
+            default_cache,
             &ProcessConfig::default(),
             build,
         );

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -4,7 +4,7 @@ use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
 use crate::config::file::{
-    FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _, TileSourceWarning,
+    CachePolicy, FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _, TileSourceWarning,
 };
 use crate::config::primitives::IdResolver;
 use crate::reload::FileKind;
@@ -20,6 +20,7 @@ impl GeoJsonReloader {
         tsm: TileSourceManager,
         id_resolver: IdResolver,
         config: &FileConfigEnum<GeoJsonConfig>,
+        default_cache: CachePolicy,
     ) -> Self {
         // Discovered files inherit the configured extent and buffer, so the builder closes over the
         // custom config and delegates to its `new_sources` (see `PmtilesReloader::new`).
@@ -40,6 +41,7 @@ impl GeoJsonReloader {
             recursive,
             &["json", "geojson"],
             id_resolver,
+            default_cache,
             &ProcessConfig::default(),
             build,
         );

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -6,7 +6,7 @@ use crate::config::file::mbtiles::MbtConfig;
 use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, ReloadDriver};
-use crate::config::file::{FileConfigEnum, SourceBuildResult, TileSourceWarning};
+use crate::config::file::{CachePolicy, FileConfigEnum, SourceBuildResult, TileSourceWarning};
 use crate::config::primitives::IdResolver;
 use crate::reload::FileKind;
 
@@ -22,6 +22,7 @@ impl MbtilesReloader {
         tsm: TileSourceManager,
         id_resolver: IdResolver,
         config: &FileConfigEnum<MbtConfig>,
+        default_cache: CachePolicy,
         global_process: &ProcessConfig,
     ) -> Self {
         #[cfg(feature = "_process")]
@@ -64,6 +65,7 @@ impl MbtilesReloader {
             recursive,
             &["mbtiles"],
             id_resolver,
+            default_cache,
             &process,
             build,
         );

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -4,7 +4,7 @@ use crate::config::file::process::ProcessConfig;
 use crate::config::file::tiles::discovery::{FsDiscovery, FsSourceBuilder, ObjectStoreDiscovery};
 use crate::config::file::tiles::driver::{Baseline, NotifyTrigger, PollTrigger, ReloadDriver};
 use crate::config::file::{
-    FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _, TileSourceWarning,
+    CachePolicy, FileConfigEnum, SourceBuildResult, TileSourceConfiguration as _, TileSourceWarning,
 };
 use crate::config::primitives::IdResolver;
 use crate::reload::FileKind;
@@ -27,6 +27,7 @@ impl PmtilesReloader {
         tsm: TileSourceManager,
         id_resolver: IdResolver,
         config: &FileConfigEnum<PmtConfig>,
+        default_cache: CachePolicy,
         global_process: &ProcessConfig,
     ) -> Self {
         #[cfg(feature = "_process")]
@@ -72,10 +73,12 @@ impl PmtilesReloader {
             pmt_config.recursive.unwrap_or_default(),
             &[PMTILES_EXT],
             id_resolver.clone(),
+            default_cache,
             &process,
             build,
         );
-        let remote = ObjectStoreDiscovery::from_config(config, id_resolver, &process);
+        let remote =
+            ObjectStoreDiscovery::from_config(config, id_resolver, default_cache, &process);
 
         Self {
             local: ReloadDriver::new(local, tsm.clone()),
@@ -140,7 +143,13 @@ mod tests {
     fn make_reloader(config: &FileConfigEnum<PmtConfig>) -> PmtilesReloader {
         let tsm = TileSourceManager::new(None, OnInvalid::Warn);
         let resolver = IdResolver::new(&[]);
-        PmtilesReloader::new(tsm, resolver, config, &ProcessConfig::default())
+        PmtilesReloader::new(
+            tsm,
+            resolver,
+            config,
+            CachePolicy::default(),
+            &ProcessConfig::default(),
+        )
     }
 
     #[derive(serde::Serialize)]

--- a/martin/src/config/file/tiles/reload/reloaders.rs
+++ b/martin/src/config/file/tiles/reload/reloaders.rs
@@ -29,6 +29,7 @@ impl TileReloaders {
         not(feature = "postgres"),
         expect(clippy::unused_async, clippy::unused_async_trait_impl)
     )]
+    #[expect(clippy::too_many_lines, reason = "one block per file kind")]
     pub async fn init(
         config: &Config,
         catalog: &TileSourceManager,
@@ -52,21 +53,29 @@ impl TileReloaders {
             catalog.clone(),
             resolver.clone(),
             &config.mbtiles,
+            config.cache.policy(),
             &global_process,
         );
         #[cfg(feature = "unstable-cog")]
-        let mut cog = super::cog::CogReloader::new(catalog.clone(), resolver.clone(), &config.cog);
+        let mut cog = super::cog::CogReloader::new(
+            catalog.clone(),
+            resolver.clone(),
+            &config.cog,
+            config.cache.policy(),
+        );
         #[cfg(feature = "geojson")]
         let mut geojson = super::geojson::GeoJsonReloader::new(
             catalog.clone(),
             resolver.clone(),
             &config.geojson,
+            config.cache.policy(),
         );
         #[cfg(feature = "pmtiles")]
         let mut pmtiles = super::pmtiles::PmtilesReloader::new(
             catalog.clone(),
             resolver.clone(),
             &config.pmtiles,
+            config.cache.policy(),
             &global_process,
         );
         #[cfg(feature = "mbtiles")]

--- a/martin/tests/pmt_minio_test.rs
+++ b/martin/tests/pmt_minio_test.rs
@@ -8,6 +8,7 @@ use actix_web::test::{TestRequest, call_service, init_service, read_body, read_b
 use actix_web::web::Data;
 use indoc::formatdoc;
 use insta::assert_yaml_snapshot;
+use martin::config::file::CachePolicy;
 use martin::config::file::ProcessConfig;
 use martin::config::file::reload::pmtiles::PmtilesReloader;
 use martin::config::file::srv::SrvConfig;
@@ -157,6 +158,7 @@ async fn pmt_minio_polls_catalog_via_public_api() {
         state.tile_manager.clone(),
         resolver,
         &config.pmtiles,
+        CachePolicy::default(),
         &ProcessConfig::default(),
     );
     reloader.start().expect("reloader start");
@@ -271,6 +273,7 @@ async fn pmt_minio_in_place_blob_overwrite_updates_existing_source() {
         state.tile_manager.clone(),
         resolver,
         &config.pmtiles,
+        CachePolicy::default(),
         &ProcessConfig::default(),
     );
     reloader.start().expect("reloader start");


### PR DESCRIPTION
Since 1.15.0, the top-level `cache.minzoom` and `cache.maxzoom` do nothing for a file that Martin finds by scanning a `paths:` directory, at startup or when the file shows up later, nor for any PMTiles file under a remote prefix. A file given by its own path, or listed under `sources:`, still gets them. #3190 moved directory scanning into the reload discovery, which only knew a file's own `cache` entry and never saw the top-level bounds. The discovery now starts from the top-level bounds and lets a file's own `cache` override them, which is what the directly named files always did.

Checked on the release binaries with `cache: {minzoom: 1}`, one mbtiles file in a `paths:` directory, and its z0 tile requested three times. A z0 tile should never touch the cache with that bound in place.

| Martin | Tile cache requests at z0 |
|---|---|
| 1.14.0 | none |
| 1.15.0 | 1 miss, 2 hits |
| this branch | none |

The per-kind `cache` default for #1137 builds on the same seam, in a follow-up