### PR TITLE
feat(config): add a per-kind cache zoom default for file and passthrough sources

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -148,6 +148,19 @@ geojson:
   # Clip margin kept around each tile edge, in tile units, defaulting to 64.
   # Increase it if you see seam artifacts on line caps/joins or polygon outlines near tile edges.
   buffer: 64
+  # Zoom-level bounds for caching the tiles of every `GeoJSON` source without its own `cache`.
+  # Overrides the top-level `cache` bounds.
+  cache:
+    # Default maximum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed in than this will bypass the cache entirely.
+    # Can be overridden per-source.
+    # default: null (no upper bound, all zoom levels cached)
+    maxzoom: 14
+    # Default minimum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed out than this will bypass the cache entirely.
+    # Can be overridden with `cache.minzoom` on an individual source.
+    # default: null (no lower bound, all zoom levels cached)
+    minzoom: 0
   # Side length of the MVT tile coordinate grid each tile is encoded into, defaulting to 4096.
   extent: 4096
   # A list of file paths
@@ -162,6 +175,19 @@ keep_alive: 75
 listen_addresses: 0.0.0.0:3000
 # Publish `MBTiles` files
 mbtiles:
+  # Zoom-level bounds for caching the tiles of every `MBTiles` source without its own `cache`.
+  # Overrides the top-level `cache` bounds.
+  cache:
+    # Default maximum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed in than this will bypass the cache entirely.
+    # Can be overridden per-source.
+    # default: null (no upper bound, all zoom levels cached)
+    maxzoom: 14
+    # Default minimum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed out than this will bypass the cache entirely.
+    # Can be overridden with `cache.minzoom` on an individual source.
+    # default: null (no lower bound, all zoom levels cached)
+    minzoom: 0
   # MVT->MLT encoder settings for all `MBTiles` sources.
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
@@ -208,6 +234,19 @@ on_invalid: abort
 # Re-serve tiles from upstream HTTP tile servers, with optional caching/MVT<->MLT re-encoding.
 # Each upstream is configured under `sources`.
 passthrough:
+  # Zoom-level bounds for caching the tiles of every passthrough source without its own `cache`.
+  # Overrides the top-level `cache` bounds.
+  cache:
+    # Default maximum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed in than this will bypass the cache entirely.
+    # Can be overridden per-source.
+    # default: null (no upper bound, all zoom levels cached)
+    maxzoom: 14
+    # Default minimum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed out than this will bypass the cache entirely.
+    # Can be overridden with `cache.minzoom` on an individual source.
+    # default: null (no lower bound, all zoom levels cached)
+    minzoom: 0
   # MVT->MLT encoder settings for all passthrough sources.
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
@@ -248,6 +287,19 @@ passthrough:
       url: https://api.example.com/{z}/{x}/{y}
 # Publish `PMTiles` files from local disk or proxy to a web server
 pmtiles:
+  # Zoom-level bounds for caching the tiles of every `PMTiles` source without its own `cache`.
+  # Overrides the top-level `cache` bounds.
+  cache:
+    # Default maximum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed in than this will bypass the cache entirely.
+    # Can be overridden per-source.
+    # default: null (no upper bound, all zoom levels cached)
+    maxzoom: 14
+    # Default minimum zoom level (inclusive) for tile caching.
+    # Tiles further zoomed out than this will bypass the cache entirely.
+    # Can be overridden with `cache.minzoom` on an individual source.
+    # default: null (no lower bound, all zoom levels cached)
+    minzoom: 0
   # MVT->MLT encoder settings for all `PMTiles` sources.
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:

--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -473,3 +473,51 @@ async fn a_file_discovered_in_a_directory_takes_the_global_cache_bounds() {
     "#);
     unbounded.stop().await;
 }
+
+#[tokio::test]
+async fn a_kind_level_cache_bound_covers_a_directory_and_a_source_can_override_it() {
+    fn tile_cache_lines(scrape: &str) -> String {
+        scrape
+            .lines()
+            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+    let watched = WatchedDir::new();
+    let file = mbtiles_fixture(watched.dir(), "world_cities").await;
+    let dir = watched.dir();
+
+    let mut kind_level = Martin::builder()
+        .config(&format!(
+            "mbtiles:\n  paths: {}\n  cache:\n    minzoom: 1\n",
+            dir.display()
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
+    for _ in 0..2 {
+        assert_eq!(kind_level.get("/world_cities/0/0/0").await.status(), 200);
+    }
+    let scrape = kind_level.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
+    kind_level.stop().await;
+
+    let mut overridden = Martin::builder()
+        .config(&format!(
+            "mbtiles:\n  paths: {}\n  cache:\n    minzoom: 1\n  sources:\n    world_cities:\n      path: {}\n      cache:\n        minzoom: 0\n",
+            dir.display(),
+            file.display()
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
+    for _ in 0..2 {
+        assert_eq!(overridden.get("/world_cities/0/0/0").await.status(), 200);
+    }
+    let scrape = overridden.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @r#"
+    martin_tile_cache_requests_total{cache="tile",result="hit",zoom="0"} 1
+    martin_tile_cache_requests_total{cache="tile",result="miss",zoom="0"} 1
+    "#);
+    overridden.stop().await;
+}

--- a/e2e-tests/tests/pmtiles.rs
+++ b/e2e-tests/tests/pmtiles.rs
@@ -651,3 +651,26 @@ async fn reload_removes_a_source_present_at_startup() {
     martin.assert_log_contains("Removed source source.id=png");
     martin.assert_startup_warnings();
 }
+
+#[tokio::test]
+async fn a_kind_level_cache_bound_covers_a_configured_file() {
+    fn tile_cache_lines(scrape: &str) -> String {
+        scrape
+            .lines()
+            .filter(|line| line.starts_with("martin_tile_cache_requests_total"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+    let mut martin = Martin::builder()
+        .config("pmtiles:\n  paths: tests/fixtures/pmtiles/png.pmtiles\n  cache:\n    minzoom: 1\n")
+        .start()
+        .await
+        .expect("failed to start martin");
+    for _ in 0..2 {
+        assert_eq!(martin.get("/png/0/0/0").await.status(), 200);
+    }
+    let scrape = martin.get("/_/metrics").await.text();
+    insta::assert_snapshot!(tile_cache_lines(&scrape), @"");
+    martin.stop().await;
+    martin.assert_startup_warnings();
+}

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -69,6 +69,10 @@ pub trait TileSourceConfiguration: ConfigurationLivecycleHooks {
     #[must_use]
     fn parse_urls() -> bool;
 
+    /// The kind level cache bounds, for every source of this kind without its own.
+    #[must_use]
+    fn cache(&self) -> CachePolicy;
+
     /// Asynchronously creates a new `BoxedSource` from a **local** file `path` using the given `id`.
     ///
     /// This function is called for each discovered file path that is not a URL.
@@ -289,6 +293,18 @@ impl<T: ConfigurationLivecycleHooks> FileConfig<T> {
     }
 }
 
+#[cfg(feature = "_tiles")]
+impl<T: TileSourceConfiguration> FileConfigEnum<T> {
+    /// The kind level cache bounds over the top level ones.
+    #[must_use]
+    pub fn cache_or(&self, global: CachePolicy) -> CachePolicy {
+        match self {
+            Self::Config(cfg) => cfg.custom.cache().or(global),
+            Self::None | Self::Path(_) | Self::Paths(_) => global,
+        }
+    }
+}
+
 impl<T: ConfigurationLivecycleHooks> ConfigurationLivecycleHooks for FileConfig<T> {
     async fn finalize(&mut self) -> ConfigFileResult<()> {
         self.custom.finalize().await
@@ -450,6 +466,7 @@ async fn resolve_int<T: TileSourceConfiguration>(
     extension: &[&str],
     default_cache: CachePolicy,
 ) -> ResolutionResult {
+    let default_cache = config.cache_or(default_cache);
     let Some(cfg) = config.extract_file_config() else {
         return Ok((vec![], vec![]));
     };
@@ -1555,6 +1572,29 @@ mod deserialize_tests {
     // not addressable via a top-level YAML path. We exercise the deserializer directly here
     // and rely on the `cache:` and per-source `cache:` block tests above to cover the
     // user-visible diagnostic surface.
+
+    #[cfg(feature = "mbtiles")]
+    #[test]
+    fn cache_or_layers_the_kind_level_over_the_global_one() {
+        use crate::config::file::mbtiles::MbtConfig;
+
+        let global = CachePolicy::new(CacheZoomRange::new(Some(1), Some(10)));
+        let kind = FileConfigEnum::Config(FileConfig {
+            custom: MbtConfig {
+                cache: CachePolicy::new(CacheZoomRange::new(None, Some(5))),
+                ..MbtConfig::default()
+            },
+            ..FileConfig::default()
+        });
+        assert_eq!(
+            kind.cache_or(global).zoom(),
+            CacheZoomRange::new(Some(1), Some(5))
+        );
+        assert_eq!(
+            FileConfigEnum::<MbtConfig>::None.cache_or(global).zoom(),
+            global.zoom()
+        );
+    }
 
     #[test]
     fn cache_policy_disable_string() {

--- a/martin/src/config/file/tiles/cog.rs
+++ b/martin/src/config/file/tiles/cog.rs
@@ -27,6 +27,14 @@ pub struct CogConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
     pub recursive: Option<bool>,
+    /// Zoom-level bounds for caching the tiles of every COG source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -36,6 +44,10 @@ pub struct CogConfig {
 impl TileSourceConfiguration for CogConfig {
     fn parse_urls() -> bool {
         false
+    }
+
+    fn cache(&self) -> CachePolicy {
+        self.cache
     }
 
     async fn new_sources(

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -7,7 +7,8 @@ use crate::config::file::tiles::duckdb::sources::{
     DuckDbDatabaseEntry, DuckDbSourceDefaults, GeoParquetEntry,
 };
 use crate::config::file::{
-    CollectUnrecognizedKeys, ConfigFileResult, ConfigurationLivecycleHooks, UnrecognizedValues,
+    CachePolicy, CollectUnrecognizedKeys, ConfigFileResult, ConfigurationLivecycleHooks,
+    UnrecognizedValues,
 };
 
 const DEFAULT_POOL_SIZE: usize = 4;
@@ -52,6 +53,14 @@ pub struct DuckDbConfig {
     /// Ordered source definitions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<DuckDbSourceEntry>,
+    /// Zoom-level bounds for caching the tiles of every `DuckDB` source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
@@ -65,6 +74,7 @@ impl Default for DuckDbConfig {
             memory_limit_mb: None,
             auto_bounds: BoundsCalcType::default(),
             sources: Vec::new(),
+            cache: CachePolicy::default(),
             unrecognized: UnrecognizedValues::default(),
         }
     }

--- a/martin/src/config/file/tiles/duckdb/config.rs
+++ b/martin/src/config/file/tiles/duckdb/config.rs
@@ -250,6 +250,12 @@ sources:
                     },
                 ),
             ],
+            cache: CachePolicy {
+                zoom: CacheZoomRange {
+                    minzoom: None,
+                    maxzoom: None,
+                },
+            },
             unrecognized: UnrecognizedValues(
                 {},
             ),
@@ -336,6 +342,12 @@ sources:
                     },
                 ),
             ],
+            cache: CachePolicy {
+                zoom: CacheZoomRange {
+                    minzoom: None,
+                    maxzoom: None,
+                },
+            },
             unrecognized: UnrecognizedValues(
                 {},
             ),

--- a/martin/src/config/file/tiles/duckdb/resolver/resolve.rs
+++ b/martin/src/config/file/tiles/duckdb/resolver/resolve.rs
@@ -107,6 +107,7 @@ impl DuckDbConfig {
         id_resolver: IdResolver,
         default_cache: CachePolicy,
     ) -> ResolutionResult {
+        let default_cache = self.cache.or(default_cache);
         let pending = self
             .sources
             .iter()

--- a/martin/src/config/file/tiles/geojson.rs
+++ b/martin/src/config/file/tiles/geojson.rs
@@ -63,6 +63,14 @@ pub struct GeoJsonConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
     pub recursive: Option<bool>,
+    /// Zoom-level bounds for caching the tiles of every `GeoJSON` source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -75,6 +83,7 @@ impl Default for GeoJsonConfig {
             extent: default_extent(),
             buffer: default_buffer(),
             recursive: None,
+            cache: CachePolicy::default(),
             unrecognized: UnrecognizedValues::default(),
         }
     }
@@ -83,6 +92,10 @@ impl Default for GeoJsonConfig {
 impl TileSourceConfiguration for GeoJsonConfig {
     fn parse_urls() -> bool {
         false
+    }
+
+    fn cache(&self) -> CachePolicy {
+        self.cache
     }
 
     async fn new_sources(

--- a/martin/src/config/file/tiles/mbtiles.rs
+++ b/martin/src/config/file/tiles/mbtiles.rs
@@ -42,6 +42,14 @@ pub struct MbtConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
     pub recursive: Option<bool>,
+    /// Zoom-level bounds for caching the tiles of every `MBTiles` source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -51,6 +59,10 @@ pub struct MbtConfig {
 impl TileSourceConfiguration for MbtConfig {
     fn parse_urls() -> bool {
         false
+    }
+
+    fn cache(&self) -> CachePolicy {
+        self.cache
     }
     async fn new_sources(
         &self,

--- a/martin/src/config/file/tiles/passthrough.rs
+++ b/martin/src/config/file/tiles/passthrough.rs
@@ -70,6 +70,15 @@ pub struct PassthroughConfig {
     #[serde(default)]
     pub convert_to_mvt: Option<MvtProcessConfig>,
 
+    /// Zoom-level bounds for caching the tiles of every passthrough source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
+
     /// Upstream tile servers to proxy, keyed by the source ID Martin serves them under.
     ///
     /// Each value is one of:
@@ -108,6 +117,7 @@ impl PassthroughConfig {
         idr: &IdResolver,
         default_cache: CachePolicy,
     ) -> ResolutionResult {
+        let default_cache = self.cache.or(default_cache);
         let mut results = Vec::new();
         let mut warnings = Vec::new();
 

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -123,6 +123,14 @@ pub struct PmtConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "unstable-schemas", schemars(example = &false))]
     pub recursive: Option<bool>,
+    /// Zoom-level bounds for caching the tiles of every `PMTiles` source without its own `cache`.
+    /// Overrides the top-level `cache` bounds.
+    #[serde(default, skip_serializing_if = "CachePolicy::is_empty")]
+    #[cfg_attr(
+        feature = "unstable-schemas",
+        schemars(with = "crate::config::file::CachePolicyShape")
+    )]
+    pub cache: CachePolicy,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -160,6 +168,7 @@ impl Default for PmtConfig {
             #[cfg(all(feature = "mlt", feature = "_tiles"))]
             convert_to_mvt: None,
             recursive: None,
+            cache: CachePolicy::default(),
             unrecognized: UnrecognizedValues::default(),
             pmtiles_directory_cache: PmtCache::default(),
             aws_credentials: None,
@@ -177,6 +186,7 @@ impl PartialEq for PmtConfig {
             && self.profile == other.profile
             && self.options == other.options
             && self.recursive == other.recursive
+            && self.cache == other.cache
             && self.unrecognized == other.unrecognized;
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
         let base = base
@@ -537,6 +547,10 @@ impl PmtConfig {
 impl TileSourceConfiguration for PmtConfig {
     fn parse_urls() -> bool {
         true
+    }
+
+    fn cache(&self) -> CachePolicy {
+        self.cache
     }
 
     async fn new_sources(

--- a/martin/src/config/file/tiles/reload/cog.rs
+++ b/martin/src/config/file/tiles/reload/cog.rs
@@ -23,6 +23,7 @@ impl CogReloader {
         config: &FileConfigEnum<CogConfig>,
         default_cache: CachePolicy,
     ) -> Self {
+        let default_cache = config.cache_or(default_cache);
         // See `MbtilesReloader::new`: both boxes erase per-kind types to a shared shape.
         // This builder captures nothing, but is `Box::new`d to share the boxed `FsSourceBuilder` type.
         let build: FsSourceBuilder = Box::new(|id, path, policy| {

--- a/martin/src/config/file/tiles/reload/geojson.rs
+++ b/martin/src/config/file/tiles/reload/geojson.rs
@@ -22,6 +22,7 @@ impl GeoJsonReloader {
         config: &FileConfigEnum<GeoJsonConfig>,
         default_cache: CachePolicy,
     ) -> Self {
+        let default_cache = config.cache_or(default_cache);
         // Discovered files inherit the configured extent and buffer, so the builder closes over the
         // custom config and delegates to its `new_sources` (see `PmtilesReloader::new`).
         let geojson_config = match config {

--- a/martin/src/config/file/tiles/reload/mbtiles.rs
+++ b/martin/src/config/file/tiles/reload/mbtiles.rs
@@ -25,6 +25,7 @@ impl MbtilesReloader {
         default_cache: CachePolicy,
         global_process: &ProcessConfig,
     ) -> Self {
+        let default_cache = config.cache_or(default_cache);
         #[cfg(feature = "_process")]
         let process = {
             let source_type = match config {

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -30,6 +30,7 @@ impl PmtilesReloader {
         default_cache: CachePolicy,
         global_process: &ProcessConfig,
     ) -> Self {
+        let default_cache = config.cache_or(default_cache);
         #[cfg(feature = "_process")]
         let process = {
             let source_type = match config {

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -333,6 +333,10 @@
     },
     "FileConfig": {
       "properties": {
+        "cache": {
+          "$ref": "#/$defs/CachePolicyShape",
+          "description": "Zoom-level bounds for caching the tiles of every `PMTiles` source without its own `cache`.\nOverrides the top-level `cache` bounds."
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -385,6 +389,10 @@
     },
     "FileConfig2": {
       "properties": {
+        "cache": {
+          "$ref": "#/$defs/CachePolicyShape",
+          "description": "Zoom-level bounds for caching the tiles of every `MBTiles` source without its own `cache`.\nOverrides the top-level `cache` bounds."
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -434,6 +442,10 @@
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
+        },
+        "cache": {
+          "$ref": "#/$defs/CachePolicyShape",
+          "description": "Zoom-level bounds for caching the tiles of every `GeoJSON` source without its own `cache`.\nOverrides the top-level `cache` bounds."
         },
         "extent": {
           "description": "Side length of the MVT tile coordinate grid each tile is encoded into, defaulting to 4096.",
@@ -1162,6 +1174,10 @@
     "PassthroughConfig": {
       "description": "Configuration for the `passthrough` source type: a sources map plus type-level\nMVT<->MLT conversion defaults. Unlike file sources there are no `paths:` to glob.",
       "properties": {
+        "cache": {
+          "$ref": "#/$defs/CachePolicyShape",
+          "description": "Zoom-level bounds for caching the tiles of every passthrough source without its own `cache`.\nOverrides the top-level `cache` bounds."
+        },
         "convert_to_mlt": {
           "anyOf": [
             {


### PR DESCRIPTION
Closes #1137

Adds `cache` to the `mbtiles`, `pmtiles`, `cog`, `geojson`, `duckdb` and `passthrough` blocks: the cache zoom bounds every source of that kind takes unless it sets its own, layered over the top-level `cache` bounds the same way `convert_to_mlt` layers since #3193. A source's own `cache` still wins, and a kind without the key behaves as before. With `postgres.cache` (#3221) every source type now has the per-type default Yuri's checklist asked for, and the `enable`/`auto` literals from step 1 have no behaviour left to carry, since omitting the key already means enabled.

| Precedence | Example |
|---|---|
| source | `mbtiles.sources.<id>.cache` |
| kind | `mbtiles.cache` |
| global | `cache.minzoom` / `cache.maxzoom` |