### PR TITLE
perf(postgres): skip the catalog queries for source kinds nothing publishes

### DIFF
--- a/martin/src/config/file/tiles/postgres/builder.rs
+++ b/martin/src/config/file/tiles/postgres/builder.rs
@@ -164,6 +164,10 @@ impl PostgresAutoDiscoveryBuilder {
         specs: &mut BTreeMap<String, SourceSpec>,
         warnings: &mut Vec<TileSourceWarning>,
     ) -> PostgresResult<()> {
+        if self.tables.is_empty() && self.auto_tables.is_none() {
+            // No table source can come out of this, so the catalog query is skipped.
+            return Ok(());
+        }
         let restrict_to_tables = self.auto_tables.is_none().then(|| self.configured_tables());
         let mut db_tables_info = query_available_tables(&self.pool, restrict_to_tables).await?;
 
@@ -243,6 +247,10 @@ impl PostgresAutoDiscoveryBuilder {
         specs: &mut BTreeMap<String, SourceSpec>,
         warnings: &mut Vec<TileSourceWarning>,
     ) -> PostgresResult<()> {
+        if self.functions.is_empty() && self.auto_functions.is_none() {
+            // No function source can come out of this, so the catalog query is skipped.
+            return Ok(());
+        }
         let mut db_funcs_info = query_available_function(&self.pool).await?;
 
         // Match configured function sources against the discovered catalog.


### PR DESCRIPTION
Discovery runs both catalog queries on every connection, even when a source kind is neither configured nor auto-published, and then drops every row. The function query walks `information_schema.routines` and is the slowest of the three, so the recommended config for a plain PostGIS schema, tables only, paid for it on every start and every reload poll. Each kind now returns before querying when it has nothing to publish. The published sources do not change, since the dropped rows could never become one.

Measured server-side with `log_min_duration_statement` on PostGIS 18 / 3.6.1, four tables, `auto_publish.tables` only.

| Per start | main | this branch |
|---|---:|---:|
| Function catalog queries | 2 | 0 |
| Catalog time, all discovery queries | 31 to 42 ms | 12 to 15 ms |

The two runs per start are `init` and the reload poll's first tick, which the sibling PR on the poll trigger removes