### PR TITLE
perf(reload): start the PostgreSQL poll one interval after init

### DIFF
--- a/martin/src/config/file/tiles/driver/trigger.rs
+++ b/martin/src/config/file/tiles/driver/trigger.rs
@@ -65,16 +65,27 @@ impl Trigger for NotifyTrigger {
     }
 }
 
-/// Fires on a fixed interval, first tick immediate. Never ends the loop.
+/// Fires on a fixed interval. Never ends the loop.
 pub struct PollTrigger {
     ticker: tokio::time::Interval,
 }
 
 impl PollTrigger {
+    /// Fires immediately, then once per interval.
     /// `interval` must be non-zero; the wiring skips spawning when it is zero.
     #[must_use]
     pub fn new(interval: Duration) -> Self {
-        let mut ticker = tokio::time::interval_at(Instant::now(), interval);
+        Self::starting_at(Instant::now(), interval)
+    }
+
+    /// Fires one interval from now, then once per interval, for a catalog that `init` has already loaded.
+    #[must_use]
+    pub fn after_interval(interval: Duration) -> Self {
+        Self::starting_at(Instant::now() + interval, interval)
+    }
+
+    fn starting_at(start: Instant, interval: Duration) -> Self {
+        let mut ticker = tokio::time::interval_at(start, interval);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self { ticker }
     }
@@ -104,6 +115,19 @@ mod tests {
         // auto-advances virtual time to the next deadline, so the timing is exact.
         assert_eq!(trigger.next().await, Some(()));
         assert_eq!(started.elapsed(), interval);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_trigger_after_interval_skips_the_immediate_tick() {
+        let interval = Duration::from_secs(30);
+        let started = Instant::now();
+        let mut trigger = PollTrigger::after_interval(interval);
+
+        assert_eq!(trigger.next().await, Some(()));
+        assert_eq!(started.elapsed(), interval);
+
+        assert_eq!(trigger.next().await, Some(()));
+        assert_eq!(started.elapsed(), interval * 2);
     }
 
     #[tokio::test]

--- a/martin/src/config/file/tiles/reload/postgres.rs
+++ b/martin/src/config/file/tiles/reload/postgres.rs
@@ -93,7 +93,7 @@ impl PostgresReloader {
         }
         Some(
             self.driver
-                .spawn(PollTrigger::new(interval), Baseline::Initialized),
+                .spawn(PollTrigger::after_interval(interval), Baseline::Initialized),
         )
     }
 }


### PR DESCRIPTION
Follows #3130. `PostgresReloader::init` publishes everything the catalog discovers before the server starts, and `start` then spawns a `PollTrigger` whose first tick is immediate, a leftover from when that first pass was the seed. The same discovery therefore ran a second time a few milliseconds later, while the first tile requests were arriving and sharing the pool with it. The remote PMTiles path still needs the immediate tick, since nothing else loads remote prefixes, so `PollTrigger::new` keeps it and the PostgreSQL poll uses `PollTrigger::after_interval`, which waits one interval first.

Measured server-side with `log_min_duration_statement`, four tables, `auto_publish.tables` only, default 10 minute interval.

| Per start | main | this branch |
|---|---:|---:|
| Discovery passes | 2 | 1 |
| Catalog time, all discovery queries | 31 to 42 ms | 18 to 26 ms |

With the sibling catalog-skip PR on top, the one remaining pass is 6 to 8 ms for this config