### PR TITLE
ci(docs): stop link-checking download.geofabrik.de

### DIFF
--- a/.github/files/markdown.links.config.json
+++ b/.github/files/markdown.links.config.json
@@ -23,6 +23,10 @@
     },
     {
       "pattern": "^http://opensource.org"
+    },
+    {
+      "__comment__": "Geofabrik drops the checker's connection (socket hang up), which fails every docs build that links a download page",
+      "pattern": "^https://download.geofabrik.de"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Every docs build that links a Geofabrik download page fails with `socket hang up`, regardless of the change under review; the three PRs of #3213 hit it today on `recipe-basemap-selfhosted.md`.

Geofabrik drops the link checker's connection. This adds the host to the checker's ignore list next to the other unreachable hosts.