### PR TITLE
ci: bless the COG, DuckDB and rendering snapshots too

### DIFF
--- a/justfile
+++ b/justfile
@@ -209,7 +209,11 @@ bless:
     done
 
     echo "Blessing end-to-end tests"
-    {{just}} bless-e2e
+    for target in bless-e2e bless-cog bless-duckdb {{ if os() == "linux" { "bless-rendering" } else { "" } }}; do
+      echo "::group::just $target"
+      {{just}} $target
+      echo "::endgroup::"
+    done
 
 # Run insta snapshot tests and save their output as the new expected output.
 bless-insta *args:  fetch (cargo-install 'cargo-insta')
@@ -224,6 +228,25 @@ bless-pg: fetch start  (cargo-install 'cargo-insta')
     cargo insta test --accept --force-update-snapshots --features test-pg --no-default-features --test pg_function_source_test --test pg_reload_test --test pg_server_test --test pg_table_source_test
     cargo insta test --accept --force-update-snapshots --features test-pg --no-default-features --package martin --lib
     cargo insta test --accept --force-update-snapshots --features test-pg --package martin-core --no-default-features --lib
+
+# Bless the COG/GeoTIFF tests, including the end-to-end ones
+bless-cog: fetch (cargo-install 'cargo-insta')
+    cargo insta test --accept --force-update-snapshots -p martin --features unstable-cog --no-default-features --lib
+    cargo insta test --accept --force-update-snapshots -p martin-core --features unstable-cog --no-default-features --lib
+    cargo build --package martin --no-default-features --features unstable-cog
+    cargo insta test --accept --force-update-snapshots --package martin-e2e-tests --features test-cog --test cog
+
+# Bless the DuckDB/GeoParquet tests, including the end-to-end ones
+bless-duckdb: fetch (cargo-install 'cargo-insta')
+    cargo insta test --accept --force-update-snapshots -p martin -p martin-core --no-default-features --features martin/test-duckdb,martin-core/unstable-duckdb --lib --test duckdb_test
+    cargo build -p martin -p martin-core --no-default-features --features martin/test-duckdb,martin-core/unstable-duckdb --bin martin --test duckdb_test
+    cargo insta test --accept --force-update-snapshots --package martin-e2e-tests --features test-duckdb --test duckdb
+
+# Bless the style rendering tests end-to-end
+[linux]
+bless-rendering: fetch (cargo-install 'cargo-insta')
+    cargo build --package martin --no-default-features --features rendering
+    cargo insta test --accept --force-update-snapshots --package martin-e2e-tests --features test-rendering --test rendering -- --test-threads=2
 
 # Build binaries for a target. In release mode (default), strips debug info.
 # Set RELEASE_MODE='' to build in debug mode (used for PRs in CI to reduce build time).


### PR DESCRIPTION
The `bless` label on #3223 ran green and committed nothing: `just bless` never builds the DuckDB feature, so the two DuckDbConfig snapshots had to be blessed by hand (https://github.com/maplibre/martin/pull/3223#issuecomment-5517921990).

`bless-e2e` only enables `test-pg` and the unit pass runs with default features, so everything behind `unstable-cog`, `unstable-duckdb` and `test-rendering` is skipped. This adds `bless-cog`, `bless-duckdb` and `bless-rendering` as the `cargo insta` twins of the `test-*` recipes and runs them after `bless-e2e`, rendering on Linux only like its test.

The minio suite has no snapshots and stays out. The label job gets three more martin builds, the DuckDB one being the slow one. The first run will also normalize the inline snapshots in four files that have never been through `bless` (raw-string markers, indentation, a leading blank line in the SQL ones); I ran it locally and every suite stayed green.
