### PR TITLE
feat: add tile source aliases

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -11,6 +11,13 @@
 ```yaml title="config.yaml"
 # yaml-language-server: $schema=https://raw.githubusercontent.com/maplibre/martin/main/schemas/config.json
 
+# Named combinations of tile sources.
+#
+# Each alias can be requested like a tile source and serves the listed sources combined,
+# exactly like the composite request `/{source1},{source2}`.
+# Aliases may only reference tile sources, not other aliases.
+# An alias sharing the name of a tile source takes precedence over it.
+aliases: {}
 # Set `TileJSON` URL path prefix.
 # This overrides the default path prefix for URLs in `TileJSON` responses.
 # If both `route_prefix` and `base_path` are set, `base_path` takes priority for `TileJSON` URLs.

--- a/docs/content/sources-composite.md
+++ b/docs/content/sources-composite.md
@@ -25,3 +25,30 @@ curl localhost:3000/points,lines
 # Whole world as a single tile
 curl localhost:3000/points,lines/0/0/0
 ```
+
+## Source Aliases
+
+An alias is a named combination of tile sources that a client requests like a single source.
+Each alias serves the listed sources exactly like the composite request `/{source1},...,{sourceN}`.
+
+```yaml
+mbtiles:
+  paths:
+    - /path/to/roads.mbtiles
+    - /path/to/buildings.mbtiles
+# Each alias can be requested like a tile source and serves the listed sources combined.
+aliases:
+  basemap: [roads, buildings]
+```
+
+Aliases may only reference tile sources, not other aliases.
+An alias may share the name of a source it references; requests for that name then serve the alias.
+This extends an existing source without changing the name a style uses:
+
+```yaml
+aliases:
+  # Requests for "roads" also get the buildings.
+  roads: [roads, buildings]
+```
+
+Aliases are listed in the catalog under their own name with the format of the sources they combine.

--- a/e2e-tests/tests/tile_routes.rs
+++ b/e2e-tests/tests/tile_routes.rs
@@ -1,6 +1,6 @@
 //! Routing behaviour shared by every tile source: redirects from a format suffix and from the `/tiles/` prefix, `Accept` header negotiation, and the zoom range a source covers.
 
-use martin_e2e_tests::Martin;
+use martin_e2e_tests::{Martin, StartError, mbtiles_fixture};
 use rstest::rstest;
 
 async fn martin_with_a_pmtiles_source() -> Martin {
@@ -274,4 +274,88 @@ async fn a_zoom_the_source_does_not_cover_is_a_404_naming_the_range(#[case] zoom
         r#"ERROR error="Zoom {zoom} is outside the supported range: png supports zoom 0-1""#
     ));
     martin.assert_startup_warnings();
+}
+
+async fn martin_with_tile_alias(alias: &str) -> (tempfile::TempDir, Result<Martin, StartError>) {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let cities = mbtiles_fixture(dir.path(), "world_cities").await;
+    let cities = cities.to_str().expect("fixture path is valid utf-8");
+    let martin = Martin::builder()
+        .config(&format!(
+            "
+mbtiles:
+  sources:
+    cities: {cities}
+    more_cities: {cities}
+aliases:
+  {alias}
+"
+        ))
+        .start()
+        .await;
+    (dir, martin)
+}
+
+#[tokio::test]
+async fn an_alias_serves_the_sources_it_combines() {
+    let (_dir, martin) = martin_with_tile_alias("basemap: [cities, more_cities]").await;
+    let mut martin = martin.expect("failed to start martin");
+
+    let catalog = martin.get("/catalog").await.json();
+    assert!(catalog["tiles"]["cities"].is_object());
+    insta::assert_json_snapshot!(catalog["tiles"]["basemap"], @r#"
+    {
+      "content_encoding": "gzip",
+      "content_type": "application/x-protobuf"
+    }
+    "#);
+
+    let tilejson = martin.get("/basemap").await;
+    assert_eq!(tilejson.status(), 200);
+    let tiles_url = tilejson.json()["tiles"][0]
+        .as_str()
+        .expect("tilejson lists a tiles url")
+        .to_owned();
+    assert!(
+        tiles_url.ends_with("/basemap/{z}/{x}/{y}"),
+        "tiles url must use the alias: {tiles_url}"
+    );
+
+    let aliased = martin.get("/basemap/0/0/0").await;
+    assert_eq!(aliased.status(), 200);
+    let explicit = martin.get("/cities,more_cities/0/0/0").await;
+    assert_eq!(aliased.body(), explicit.body());
+
+    martin.stop().await;
+    martin.assert_log_contains("Configured tile source alias");
+}
+
+#[tokio::test]
+async fn an_alias_may_shadow_the_source_it_extends() {
+    let (_dir, martin) = martin_with_tile_alias("cities: [cities, more_cities]").await;
+    let mut martin = martin.expect("failed to start martin");
+
+    let shadowed = martin.get("/cities/0/0/0").await;
+    assert_eq!(shadowed.status(), 200);
+    let explicit = martin.get("/cities,more_cities/0/0/0").await;
+    assert_eq!(shadowed.body(), explicit.body());
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        "Tile source alias shadows a tile source of the same name; requests for it will serve the alias",
+    );
+}
+
+#[tokio::test]
+async fn an_alias_naming_an_unknown_source_fails_startup() {
+    let (_dir, martin) = martin_with_tile_alias("basemap: [cities, nonexistent]").await;
+    let error = martin.expect_err("martin must reject an alias naming an unknown tile source");
+    let StartError::EarlyExit { status, log } = error else {
+        panic!("expected an early exit, got: {error}");
+    };
+    assert!(!status.success(), "exit status must be a failure: {status}");
+    assert!(
+        log.contains(r#"Tile source alias "basemap" references unknown tile source "nonexistent""#),
+        "log must name the alias and the missing source; log:\n{log}"
+    );
 }

--- a/martin/src/config/file/error.rs
+++ b/martin/src/config/file/error.rs
@@ -103,6 +103,10 @@ pub enum ConfigFileError {
     #[error("Failed to configure sprite alias: {0}")]
     SpriteAliasResolutionFailed(#[source] SpriteError),
 
+    #[cfg(feature = "_tiles")]
+    #[error("Failed to configure tile source alias: {0}")]
+    TileAliasResolutionFailed(#[source] crate::source::TileAliasError),
+
     #[cfg(feature = "pmtiles")]
     #[error("Failed to parse object store URL of {1}: {0}")]
     ObjectStoreUrlParsing(object_store::Error, String),
@@ -294,6 +298,8 @@ impl Diagnostic for ConfigFileError {
             Self::FontAliasResolutionFailed(_) => "martin::config::fonts::alias",
             #[cfg(feature = "sprites")]
             Self::SpriteAliasResolutionFailed(_) => "martin::config::sprites::alias",
+            #[cfg(feature = "_tiles")]
+            Self::TileAliasResolutionFailed(_) => "martin::config::aliases",
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) => "martin::config::pmtiles::object_store_url",
             #[cfg(feature = "pmtiles")]
@@ -349,6 +355,10 @@ impl Diagnostic for ConfigFileError {
             #[cfg(feature = "sprites")]
             Self::SpriteAliasResolutionFailed(_) => {
                 "Check the `sprites.aliases` block: every alias must list at least one configured sprite source by its id, and aliases cannot reference other aliases."
+            }
+            #[cfg(feature = "_tiles")]
+            Self::TileAliasResolutionFailed(_) => {
+                "Check the `aliases` block: every alias must list at least one configured tile source by its id, and aliases cannot reference other aliases."
             }
             #[cfg(feature = "pmtiles")]
             Self::ObjectStoreUrlParsing(..) | Self::ObjectStoreList(..) => return None,

--- a/martin/src/config/file/main/config.rs
+++ b/martin/src/config/file/main/config.rs
@@ -155,6 +155,16 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "FileConfigEnum::is_none")]
     pub geojson: FileConfigEnum<GeoJsonConfig>,
 
+    /// Named combinations of tile sources.
+    ///
+    /// Each alias can be requested like a tile source and serves the listed sources combined,
+    /// exactly like the composite request `/{source1},{source2}`.
+    /// Aliases may only reference tile sources, not other aliases.
+    /// An alias sharing the name of a tile source takes precedence over it.
+    #[cfg(feature = "_tiles")]
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub aliases: std::collections::BTreeMap<String, Vec<String>>,
+
     /// Sprite configuration
     #[cfg(feature = "sprites")]
     #[serde(default, skip_serializing_if = "FileConfigEnum::is_none")]

--- a/martin/src/config/file/main/lifecycle.rs
+++ b/martin/src/config/file/main/lifecycle.rs
@@ -234,13 +234,23 @@ impl Config {
                 .collect::<Vec<_>>()
         };
 
+        #[cfg(feature = "_tiles")]
+        let tile_manager = TileSourceManager::from_sources(
+            cache_config.create_tile_cache(),
+            self.on_invalid.unwrap_or_default(),
+            tile_sources_with_process,
+        );
+        #[cfg(feature = "_tiles")]
+        for (alias, sources) in &self.aliases {
+            tile_manager
+                .tile_sources()
+                .add_alias(alias.clone(), sources.clone())
+                .map_err(ConfigFileError::TileAliasResolutionFailed)?;
+        }
+
         Ok(ServerState {
             #[cfg(feature = "_tiles")]
-            tile_manager: TileSourceManager::from_sources(
-                cache_config.create_tile_cache(),
-                self.on_invalid.unwrap_or_default(),
-                tile_sources_with_process,
-            ),
+            tile_manager,
 
             #[cfg(feature = "sprites")]
             sprites: self.sprites.resolve()?,

--- a/martin/src/source.rs
+++ b/martin/src/source.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use actix_web::error::{ErrorBadRequest, ErrorNotFound};
 use dashmap::DashMap;
-use martin_core::tiles::catalog::TileCatalog;
+use martin_core::tiles::catalog::{CatalogSourceEntry, TileCatalog};
 use martin_core::tiles::{BoxedSource, Source};
 use martin_tile_utils::TileInfo;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::config::file::ResolvedProcess;
 
@@ -20,12 +20,63 @@ pub struct ResolvedSources {
     pub info: TileInfo,
 }
 
+/// Errors from registering a tile source alias.
+#[derive(Debug, thiserror::Error)]
+pub enum TileAliasError {
+    /// The alias name cannot be requested.
+    #[error(
+        "Tile source alias {0:?} is invalid: alias names must be non-empty and must not contain commas"
+    )]
+    InvalidAliasName(String),
+
+    /// The alias lists no sources.
+    #[error("Tile source alias {0:?} does not reference any tile sources")]
+    EmptyAlias(String),
+
+    /// The alias references more sources than a single request may use.
+    #[error(
+        "Tile source alias {alias:?} references {requested} tile sources, but at most {max} are allowed"
+    )]
+    TooManySourcesInAlias {
+        /// Alias name.
+        alias: String,
+        /// Referenced source count.
+        requested: usize,
+        /// Allowed maximum.
+        max: usize,
+    },
+
+    /// The alias references another alias instead of a tile source.
+    #[error(
+        "Tile source alias {alias:?} references {source_id:?}, which is itself an alias; aliases may only reference tile sources"
+    )]
+    AliasWithinAlias {
+        /// Alias name.
+        alias: String,
+        /// The referenced alias.
+        source_id: String,
+    },
+
+    /// The alias references a tile source that is not registered.
+    #[error("Tile source alias {alias:?} references unknown tile source {source_id:?}")]
+    AliasSourceNotFound {
+        /// Alias name.
+        alias: String,
+        /// The referenced tile source.
+        source_id: String,
+    },
+}
+
 /// Thread-safe registry of tile sources indexed by ID.
 ///
 /// Uses a [`DashMap`] for concurrent access without explicit locking.
 /// Each source is paired with its resolved [`ResolvedProcess`].
 #[derive(Default, Clone)]
-pub struct TileSources(Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>);
+pub struct TileSources {
+    sources: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>,
+    /// Map of alias name to the tile source ids it combines.
+    aliases: Arc<DashMap<String, Vec<String>>>,
+}
 
 impl TileSources {
     /// Creates a new registry from flattened source collections.
@@ -49,25 +100,34 @@ impl TileSources {
     /// Creates a new registry from sources paired with their resolved process configs.
     #[must_use]
     pub fn new_with_process(sources: Vec<Vec<(BoxedSource, ResolvedProcess)>>) -> Self {
-        Self(Arc::new(
-            sources
-                .into_iter()
-                .flatten()
-                .map(|(src, pc)| (src.get_id().to_owned(), (src, pc)))
-                .collect(),
-        ))
+        Self {
+            sources: Arc::new(
+                sources
+                    .into_iter()
+                    .flatten()
+                    .map(|(src, pc)| (src.get_id().to_owned(), (src, pc)))
+                    .collect(),
+            ),
+            aliases: Arc::default(),
+        }
     }
 
-    /// Creates a registry backed by an existing shared `DashMap`.
+    /// Creates a registry backed by existing shared maps.
     #[must_use]
-    pub(crate) fn from_dashmap(map: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>) -> Self {
-        Self(map)
+    pub(crate) fn from_maps(
+        sources: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>,
+        aliases: Arc<DashMap<String, Vec<String>>>,
+    ) -> Self {
+        Self { sources, aliases }
     }
 
-    /// Returns a catalog of all sources with their metadata.
+    /// Returns a catalog of all sources and aliases with their metadata.
+    ///
+    /// An alias is listed under its own name with the format its member sources serve.
     #[must_use]
     pub fn get_catalog(&self) -> TileCatalog {
-        self.0
+        let mut catalog: TileCatalog = self
+            .sources
             .iter()
             .map(|v| {
                 let (src, pc) = v.value();
@@ -79,19 +139,95 @@ impl TileSources {
                 entry.content_encoding = info.encoding.compression().map(str::to_owned);
                 (v.key().clone(), entry)
             })
-            .collect()
+            .collect();
+        for alias in self.aliases.iter() {
+            let Some(member) = alias.value().iter().find_map(|id| self.sources.get(id)) else {
+                continue;
+            };
+            let (src, pc) = member.value();
+            let info = pc.advertised_tile_info(src.get_tile_info());
+            let entry = CatalogSourceEntry {
+                content_type: info.format.content_type().to_owned(),
+                content_encoding: info.encoding.compression().map(str::to_owned),
+                ..CatalogSourceEntry::default()
+            };
+            catalog.insert(alias.key().clone(), entry);
+        }
+        catalog
     }
 
     /// Returns all source IDs.
     #[must_use]
     pub fn source_names(&self) -> Vec<String> {
-        self.0.iter().map(|v| v.key().clone()).collect()
+        self.sources.iter().map(|v| v.key().clone()).collect()
+    }
+
+    /// Registers a named combination of tile sources that serves like a single source.
+    ///
+    /// Every member must name a registered tile source, not another alias.
+    /// An alias may share the name of a source it references.
+    /// Requests for such a name serve the alias.
+    pub fn add_alias(&self, name: String, sources: Vec<String>) -> Result<(), TileAliasError> {
+        if name.is_empty() || name.contains(',') {
+            return Err(TileAliasError::InvalidAliasName(name));
+        }
+        if sources.is_empty() {
+            return Err(TileAliasError::EmptyAlias(name));
+        }
+        if sources.len() > MAX_SOURCE_IDS_PER_REQUEST {
+            return Err(TileAliasError::TooManySourcesInAlias {
+                alias: name,
+                requested: sources.len(),
+                max: MAX_SOURCE_IDS_PER_REQUEST,
+            });
+        }
+        for source in &sources {
+            if self.aliases.contains_key(source) {
+                return Err(TileAliasError::AliasWithinAlias {
+                    alias: name,
+                    source_id: source.clone(),
+                });
+            }
+            if !self.sources.contains_key(source) {
+                return Err(TileAliasError::AliasSourceNotFound {
+                    alias: name,
+                    source_id: source.clone(),
+                });
+            }
+        }
+        if self.sources.contains_key(&name) {
+            info!(
+                source.alias = %name,
+                "Tile source alias shadows a tile source of the same name; requests for it will serve the alias"
+            );
+        }
+        info!(
+            source.alias = %name,
+            source.ids = %sources.join(", "),
+            "Configured tile source alias"
+        );
+        self.aliases.insert(name, sources);
+        Ok(())
+    }
+
+    /// Splits a request id list and replaces every alias with its member sources, in order.
+    #[must_use]
+    pub fn expand_ids(&self, source_ids: &str) -> Vec<String> {
+        let mut expanded = Vec::new();
+        for id in source_ids.split(',') {
+            if let Some(alias) = self.aliases.get(id) {
+                expanded.extend(alias.value().iter().cloned());
+            } else {
+                expanded.push(id.to_owned());
+            }
+        }
+        expanded
     }
 
     /// Gets a source and its process config by ID, returning 404 error if not found.
     pub fn get_source(&self, id: &str) -> actix_web::Result<(BoxedSource, ResolvedProcess)> {
         Ok(self
-            .0
+            .sources
             .get(id)
             .ok_or_else(|| ErrorNotFound(format!("Source {id} does not exist")))?
             .value()
@@ -100,8 +236,9 @@ impl TileSources {
 
     /// Gets multiple sources for composite tiles, ensuring format compatibility.
     ///
-    /// Parses comma-separated source IDs and validates all sources have matching
-    /// format/encoding. Optionally filters by zoom level support.
+    /// Parses comma-separated source IDs, replaces aliases with their member sources,
+    /// and validates all sources have matching format/encoding.
+    /// Optionally filters by zoom level support.
     ///
     #[hotpath::measure]
     pub fn get_sources(
@@ -122,29 +259,12 @@ impl TileSources {
         let mut use_url_query = false;
 
         for id in ids {
-            let (src, pc) = self.get_source(id)?;
-            let src_inf = pc.advertised_tile_info(src.get_tile_info());
-            use_url_query |= src.support_url_query();
-
-            // make sure all sources have the same format and encoding
-            // TODO: support multiple encodings of the same format
-            match info {
-                Some(inf) if inf == src_inf => {}
-                Some(inf) => {
-                    return Err(ErrorNotFound(format!(
-                        "Cannot merge sources with {inf} with {src_inf}"
-                    )));
+            if let Some(alias) = self.aliases.get(id) {
+                for member in alias.value() {
+                    self.collect_source(member, zoom, &mut sources, &mut info, &mut use_url_query)?;
                 }
-                None => info = Some(src_inf),
-            }
-
-            // TODO: Use chained-if-let once available
-            if match zoom {
-                Some(zoom) if Self::check_zoom(&*src, id, zoom) => true,
-                None => true,
-                _ => false,
-            } {
-                sources.push((src, pc));
+            } else {
+                self.collect_source(id, zoom, &mut sources, &mut info, &mut use_url_query)?;
             }
         }
 
@@ -153,6 +273,42 @@ impl TileSources {
             use_url_query,
             info: info.expect("at least one source must be present"),
         })
+    }
+
+    /// Adds one source to a composite resolution, checking its format against the others.
+    fn collect_source(
+        &self,
+        id: &str,
+        zoom: Option<u8>,
+        sources: &mut Vec<(BoxedSource, ResolvedProcess)>,
+        info: &mut Option<TileInfo>,
+        use_url_query: &mut bool,
+    ) -> actix_web::Result<()> {
+        let (src, pc) = self.get_source(id)?;
+        let src_inf = pc.advertised_tile_info(src.get_tile_info());
+        *use_url_query |= src.support_url_query();
+
+        // make sure all sources have the same format and encoding
+        // TODO: support multiple encodings of the same format
+        match *info {
+            Some(inf) if inf == src_inf => {}
+            Some(inf) => {
+                return Err(ErrorNotFound(format!(
+                    "Cannot merge sources with {inf} with {src_inf}"
+                )));
+            }
+            None => *info = Some(src_inf),
+        }
+
+        // TODO: Use chained-if-let once available
+        if match zoom {
+            Some(zoom) if Self::check_zoom(&*src, id, zoom) => true,
+            None => true,
+            _ => false,
+        } {
+            sources.push((src, pc));
+        }
+        Ok(())
     }
 
     /// Validates zoom level support for a source
@@ -175,7 +331,7 @@ impl TileSources {
     /// Returns if any source benefits from concurrent scraping by martin-cp
     #[must_use]
     pub fn benefits_from_concurrent_scraping(&self) -> bool {
-        self.0
+        self.sources
             .iter()
             .any(|s| s.value().0.benefits_from_concurrent_scraping())
     }
@@ -210,5 +366,38 @@ mod tests {
         let ids = vec!["valid"; MAX_SOURCE_IDS_PER_REQUEST].join(",");
         let resolved = sources.get_sources(&ids, None).unwrap();
         assert_eq!(resolved.sources.len(), MAX_SOURCE_IDS_PER_REQUEST);
+    }
+
+    #[test]
+    fn an_alias_expands_to_its_member_sources_in_order() {
+        let sources = sources_with_one_valid();
+        sources
+            .add_alias(
+                "both".to_owned(),
+                vec!["valid".to_owned(), "valid".to_owned()],
+            )
+            .unwrap();
+        assert_eq!(
+            sources.expand_ids("both,valid"),
+            ["valid", "valid", "valid"]
+        );
+        let resolved = sources.get_sources("both,valid", None).unwrap();
+        assert_eq!(resolved.sources.len(), 3);
+    }
+
+    #[test]
+    fn an_alias_must_name_registered_sources_and_never_another_alias() {
+        let sources = sources_with_one_valid();
+        assert!(matches!(
+            sources.add_alias("cities".to_owned(), vec!["missing".to_owned()]),
+            Err(TileAliasError::AliasSourceNotFound { .. })
+        ));
+        sources
+            .add_alias("cities".to_owned(), vec!["valid".to_owned()])
+            .unwrap();
+        assert!(matches!(
+            sources.add_alias("nested".to_owned(), vec!["cities".to_owned()]),
+            Err(TileAliasError::AliasWithinAlias { .. })
+        ));
     }
 }

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -296,8 +296,9 @@ impl<'a> DynTileSource<'a> {
 
         if resolved.sources.is_empty() {
             let z = zoom.expect("sources are only filtered out when a zoom is requested");
-            let supported = source_ids
-                .split(',')
+            let supported = tile_sources
+                .expand_ids(source_ids)
+                .iter()
                 .filter_map(|id| {
                     let (src, _) = tile_sources.get_source(id).ok()?;
                     let tj = src.get_tilejson();

--- a/martin/src/tile_source_manager.rs
+++ b/martin/src/tile_source_manager.rs
@@ -19,6 +19,8 @@ use crate::source::TileSources;
 #[derive(Clone)]
 pub struct TileSourceManager {
     tile_sources: Arc<DashMap<String, (BoxedSource, ResolvedProcess)>>,
+    /// Named combinations of tile sources, served like a single source.
+    aliases: Arc<DashMap<String, Vec<String>>>,
     /// Kept beside the serving map so `--save-config` can serialize what is actually served.
     provenance: Arc<DashMap<String, SourceProvenance>>,
     tile_cache: OptTileCache,
@@ -31,6 +33,7 @@ impl TileSourceManager {
     pub fn new(tile_cache: OptTileCache, on_invalid: OnInvalid) -> Self {
         Self {
             tile_sources: Arc::new(DashMap::new()),
+            aliases: Arc::new(DashMap::new()),
             provenance: Arc::new(DashMap::new()),
             tile_cache,
             on_invalid,
@@ -53,6 +56,7 @@ impl TileSourceManager {
             .collect();
         Self {
             tile_sources: Arc::new(map),
+            aliases: Arc::new(DashMap::new()),
             provenance: Arc::new(DashMap::new()),
             tile_cache,
             on_invalid,
@@ -62,7 +66,7 @@ impl TileSourceManager {
     /// Returns a [`TileSources`] view for read-only tile serving.
     #[must_use]
     pub fn tile_sources(&self) -> TileSources {
-        TileSources::from_dashmap(Arc::clone(&self.tile_sources))
+        TileSources::from_maps(Arc::clone(&self.tile_sources), Arc::clone(&self.aliases))
     }
 
     /// Returns a reference to the optional tile cache.

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -1683,6 +1683,16 @@
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
+    "aliases": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "description": "Named combinations of tile sources.\n\nEach alias can be requested like a tile source and serves the listed sources combined,\nexactly like the composite request `/{source1},{source2}`.\nAliases may only reference tile sources, not other aliases.\nAn alias sharing the name of a tile source takes precedence over it.",
+      "type": "object"
+    },
     "base_path": {
       "description": "Set `TileJSON` URL path prefix.\nThis overrides the default path prefix for URLs in `TileJSON` responses.\nIf both `route_prefix` and `base_path` are set, `base_path` takes priority for `TileJSON` URLs.\nIf neither is set, the `X-Rewrite-URL` header is respected.\nMust begin with a `/`.\nExamples: `/`, `/tiles`",
       "type": ["string", "null"]


### PR DESCRIPTION
Closes #1076

Last slice of #1076 after fonts (#3210) and sprites (#3220). A top-level `aliases` block names a combination of tile sources that clients request like a single source: `/{alias}` and `/{alias}/{z}/{x}/{y}` serve exactly what `/{a},{b}` serves, so a style no longer carries the composite list. Aliases may only reference tile sources, an alias may shadow the source it extends, and every alias is checked at startup. The catalog lists an alias under its own name with its members' format. Tile cache keys stay per member source, so purging a source also drops what its aliases served.

The shape is Yuri's proposal from the issue body, flattened to `name: [members]` like the two merged slices.
