### PR TITLE
feat(config): publish each subdirectory of a collection as its own source

### DIFF
--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -523,6 +523,8 @@ sprites:
     # Size of the cache in MB (0 to disable).
     # default: inherits from `cache.size_mb` (with a per-source split)
     size_mb: 64
+  # Directories whose subdirectories are each published as a sprite source named after them.
+  collections: []
   # A list of file paths
   paths: []
   # A map of source IDs to file paths or config objects
@@ -530,6 +532,9 @@ sprites:
 # Publish `MapLibre` style files
 # You can also configure us to render the styles on the server side.
 styles:
+  # Directories whose subdirectories each hold the styles of one project.
+  # A style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`.
+  collections: []
   # A list of file paths
   paths: []
   # Allows static, server side, style rendering

--- a/docs/content/files/generated_config.md
+++ b/docs/content/files/generated_config.md
@@ -139,6 +139,8 @@ fonts:
     # Size of the cache in MB (0 to disable).
     # default: inherits from `cache.size_mb` (with a per-source split)
     size_mb: 64
+  # A list of directories whose subdirectories are each published under the subdirectory's name
+  collections: []
   # A list of file paths
   paths: []
   # A map of source IDs to file paths or config objects
@@ -161,6 +163,8 @@ geojson:
     # Can be overridden with `cache.minzoom` on an individual source.
     # default: null (no lower bound, all zoom levels cached)
     minzoom: 0
+  # A list of directories whose subdirectories are each published under the subdirectory's name
+  collections: []
   # Side length of the MVT tile coordinate grid each tile is encoded into, defaulting to 4096.
   extent: 4096
   # A list of file paths
@@ -188,6 +192,8 @@ mbtiles:
     # Can be overridden with `cache.minzoom` on an individual source.
     # default: null (no lower bound, all zoom levels cached)
     minzoom: 0
+  # A list of directories whose subdirectories are each published under the subdirectory's name
+  collections: []
   # MVT->MLT encoder settings for all `MBTiles` sources.
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
@@ -300,6 +306,8 @@ pmtiles:
     # Can be overridden with `cache.minzoom` on an individual source.
     # default: null (no lower bound, all zoom levels cached)
     minzoom: 0
+  # A list of directories whose subdirectories are each published under the subdirectory's name
+  collections: []
   # MVT->MLT encoder settings for all `PMTiles` sources.
   # Overrides global; overridden by per-source `convert_to_mlt`.
   convert_to_mlt:
@@ -523,7 +531,7 @@ sprites:
     # Size of the cache in MB (0 to disable).
     # default: inherits from `cache.size_mb` (with a per-source split)
     size_mb: 64
-  # Directories whose subdirectories are each published as a sprite source named after them.
+  # A list of directories whose subdirectories are each published under the subdirectory's name
   collections: []
   # A list of file paths
   paths: []
@@ -532,8 +540,7 @@ sprites:
 # Publish `MapLibre` style files
 # You can also configure us to render the styles on the server side.
 styles:
-  # Directories whose subdirectories each hold the styles of one project.
-  # A style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`.
+  # A list of directories whose subdirectories are each published under the subdirectory's name
   collections: []
   # A list of file paths
   paths: []

--- a/docs/content/sources-cog-files.md
+++ b/docs/content/sources-cog-files.md
@@ -89,6 +89,9 @@ cog:
     Set `recursive: true` next to `paths` to scan subdirectories too.
     A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.tif` becomes `2024.roads`.
 
+!!! tip "Per-project directories"
+    List a directory of project directories under `collections` to publish every file inside a project as `<project>.<file>`, so `/projects/tiles/project1/elevation.tif` becomes `project1.elevation`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-fonts.md
+++ b/docs/content/sources-fonts.md
@@ -86,6 +86,15 @@ fonts:
   - /path/to/font_dir
 ```
 
+A directory of per-project font directories is loaded in one line with `collections`.
+Every directory directly inside it is loaded like a `paths` entry, since a font is named by the family inside the file.
+
+```yaml
+fonts:
+  collections:
+    - /projects/fonts
+```
+
 ### Font Aliases
 
 !!! tip "Supporting multiple writing systems via `aliases`"

--- a/docs/content/sources-geojson.md
+++ b/docs/content/sources-geojson.md
@@ -80,6 +80,9 @@ geojson:
     Set `recursive: true` next to `paths` to scan subdirectories too.
     A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.geojson` becomes `2024.roads`.
 
+!!! tip "Per-project directories"
+    List a directory of project directories under `collections` to publish every file inside a project as `<project>.<file>`, so `/projects/tiles/project1/roads.geojson` becomes `project1.roads`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-mbtiles.md
+++ b/docs/content/sources-mbtiles.md
@@ -45,6 +45,9 @@ mbtiles:
     Set `recursive: true` next to `paths` to scan subdirectories too.
     A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.mbtiles` becomes `2024.roads`.
 
+!!! tip "Per-project directories"
+    List a directory of project directories under `collections` to publish every file inside a project as `<project>.<file>`, so `/projects/tiles/project1/roads.mbtiles` becomes `project1.roads`.
+
 The following events are handled automatically:
 
 - **File added** - the new source appears in the catalog.

--- a/docs/content/sources-pmtiles.md
+++ b/docs/content/sources-pmtiles.md
@@ -40,6 +40,10 @@ pmtiles:
     Set `recursive: true` next to `paths` to scan subdirectories too.
     A nested file is named by its path relative to the scanned directory with `/` replaced by `.`, so `2024/roads.pmtiles` becomes `2024.roads`.
 
+!!! tip "Per-project directories"
+    List a directory of project directories under `collections` to publish every file inside a project as `<project>.<file>`, so `/projects/tiles/project1/roads.pmtiles` becomes `project1.roads`.
+    A collection is a local directory.
+
 For remote object-storage prefixes (`s3://bucket/prefix/`, `gs://bucket/prefix/`, `https://host/prefix/`, etc.) Martin periodically re-lists the prefix and diffs against the previous snapshot, taking into account
 object `ETag` or `Last-Modified` headers to detect updates to an existing source.
 There is no event channel from blob storage to subscribe to.

--- a/docs/content/sources-sprites.md
+++ b/docs/content/sources-sprites.md
@@ -97,6 +97,15 @@ sprites:
 
 The sprites are now available at `/sprite/my_images,some_dir.png`/ ...
 
+A directory of per-project sprite directories is published in one line with `collections`.
+Every directory directly inside it becomes a sprite source named after that directory, so `/projects/sprites/project1/*.svg` is served as `/sprite/project1.png`.
+
+```yaml
+sprites:
+  collections:
+    - /projects/sprites
+```
+
 ### Sprite Aliases
 
 An alias is a named combination of sprite sources that a style requests like a single source.

--- a/docs/content/sources-styles/index.md
+++ b/docs/content/sources-styles/index.md
@@ -26,6 +26,24 @@ Use the `/style/<style_id>` API to get a `<style_id>`'s JSON content.
 Changes or removals of styles are reflected immediately, but additions are not.
 A restart of Martin is required to see new styles.
 
+### Configuring with Config File
+
+Styles are configured with the `styles` key.
+`paths` lists files or directories, and every `.json` file found is published under its file name.
+`sources` maps a `<style_id>` to one file.
+`collections` lists directories of per-project directories, and a style at `/projects/styles/project1/basic.json` is published as `project1.basic`.
+
+```yaml
+styles:
+  paths:
+    - /path/to/style.json
+    - /path/to/style_dir
+  sources:
+    my_style: /path/to/another_style.json
+  collections:
+    - /projects/styles
+```
+
 ### Server-side raster tile rendering
 
 On Linux, Martin can also render a style server-side into raster images -

--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -429,6 +429,62 @@ async fn reload_removes_a_source_when_its_file_is_deleted() {
     martin.assert_startup_warnings();
 }
 
+#[cfg(not(windows))]
+#[tokio::test]
+async fn reload_publishes_and_removes_a_project_of_a_collection() {
+    let watched = WatchedDir::new();
+    let original = watched.outside("original.mbtiles");
+    mbtiles_from_sql(fixture("mbtiles/world_cities.sql"), &original).await;
+
+    let mut martin = Martin::builder()
+        .config(&format!(
+            "mbtiles:\n  collections: {}\n",
+            watched.dir().display()
+        ))
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    assert_eq!(
+        martin.get("/catalog").await.json()["tiles"],
+        serde_json::json!({})
+    );
+
+    // The staged file already sits next to the watched directory, so the rename is atomic.
+    let project = watched.dir().join("project1");
+    std::fs::create_dir_all(&project).expect("failed to create the project directory");
+    std::fs::rename(&original, project.join("world_cities.mbtiles"))
+        .expect("failed to move the file into the project");
+    martin.wait_for_source("project1.world_cities").await;
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["tiles"], @r#"
+    {
+      "project1.world_cities": {
+        "content_encoding": "gzip",
+        "content_type": "application/x-protobuf",
+        "description": "Major cities from Natural Earth data",
+        "name": "Major cities from Natural Earth data"
+      }
+    }
+    "#);
+    assert_eq!(
+        martin.get("/project1.world_cities/0/0/0").await.status(),
+        200
+    );
+
+    std::fs::remove_dir_all(&project).expect("failed to remove the project directory");
+    martin
+        .wait_for_source_removed("project1.world_cities")
+        .await;
+    assert_eq!(
+        martin.get("/catalog").await.json()["tiles"],
+        serde_json::json!({})
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains("Added source source.id=project1.world_cities");
+    martin.assert_log_contains("Removed source source.id=project1.world_cities");
+}
+
 #[tokio::test]
 async fn a_file_discovered_in_a_directory_takes_the_global_cache_bounds() {
     fn tile_cache_lines(scrape: &str) -> String {

--- a/e2e-tests/tests/sprites.rs
+++ b/e2e-tests/tests/sprites.rs
@@ -326,3 +326,32 @@ async fn an_alias_naming_an_unknown_source_fails_startup() {
         "log must name the alias and the missing source; log:\n{log}"
     );
 }
+
+#[tokio::test]
+async fn a_collection_publishes_each_subdirectory_as_a_sprite() {
+    let mut martin = Martin::builder()
+        .config("sprites:\n  collections: tests/fixtures/sprites\n")
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    insta::assert_json_snapshot!(martin.get("/catalog").await.json()["sprites"], @r#"
+    {
+      "src1": {
+        "images": [
+          "another_bicycle",
+          "bear",
+          "sub/circle"
+        ]
+      },
+      "src2": {
+        "images": [
+          "bicycle"
+        ]
+      }
+    }
+    "#);
+    assert_eq!(martin.get("/sprite/src1,src2.json").await.status(), 200);
+
+    martin.stop().await;
+}

--- a/e2e-tests/tests/styles.rs
+++ b/e2e-tests/tests/styles.rs
@@ -470,3 +470,28 @@ async fn the_plural_styles_path_redirects() {
 
     martin.stop().await;
 }
+
+#[tokio::test]
+async fn a_collection_publishes_each_subdirectory_as_a_project() {
+    let mut martin = Martin::builder()
+        .config("styles:\n  collections: tests/fixtures/styles\n")
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let mut styles = martin.get("/catalog").await.json()["styles"].clone();
+    normalize_paths(&mut styles);
+    insta::assert_json_snapshot!(styles, @r#"
+    {
+      "src2.maptiler_basic": {
+        "path": "tests/fixtures/styles/src2/maptiler_basic.json"
+      },
+      "src2.osm-liberty-lite": {
+        "path": "tests/fixtures/styles/src2/osm-liberty-lite.json"
+      }
+    }
+    "#);
+    assert_eq!(martin.get("/style/src2.maptiler_basic").await.status(), 200);
+
+    martin.stop().await;
+}

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -4,7 +4,12 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::mem;
-#[cfg(feature = "_tiles")]
+#[cfg(any(
+    feature = "_tiles",
+    feature = "sprites",
+    feature = "styles",
+    feature = "fonts"
+))]
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -56,11 +61,6 @@ pub trait ConfigurationLivecycleHooks:
     /// In practice, this method is only implemented on a path of the config if a value or a value in the path below it needs to be finalized
     fn finalize(&mut self) -> impl Future<Output = ConfigFileResult<()>> + Send {
         async { Ok(()) }
-    }
-
-    /// Whether the section configures sources through keys other than `paths` and `sources`.
-    fn has_content(&self) -> bool {
-        false
     }
 }
 
@@ -170,21 +170,22 @@ where
 impl<T: ConfigurationLivecycleHooks> FileConfigEnum<T> {
     #[must_use]
     pub fn new(paths: Vec<PathBuf>) -> Self {
-        Self::new_extended(paths, BTreeMap::new(), T::default())
+        Self::new_extended(paths, vec![], BTreeMap::new(), T::default())
     }
 
     #[must_use]
     pub fn new_extended(
         paths: Vec<PathBuf>,
+        collections: Vec<PathBuf>,
         configs: BTreeMap<String, FileConfigSrc>,
         custom: T,
     ) -> Self {
-        // Collapse to the simpler `Path` / `Paths` / `None` variants only when both `configs`
-        // and `custom` carry no information; otherwise preserve `custom` by emitting `Config`.
+        // Collapse to the simpler `Path` / `Paths` / `None` variants only when `collections`,
+        // `configs` and `custom` carry no information; otherwise preserve them by emitting `Config`.
         // Without this, custom settings (e.g. `pmtiles.reload_interval` or s3 options
         // needed by the reloader) would silently disappear after `resolve_files` rebuilds
         // the enum for an empty source set.
-        if configs.is_empty() && custom == T::default() {
+        if collections.is_empty() && configs.is_empty() && custom == T::default() {
             match paths.len() {
                 0 => Self::None,
                 1 => Self::Path(paths.into_iter().next().expect("one path exists")),
@@ -193,6 +194,7 @@ impl<T: ConfigurationLivecycleHooks> FileConfigEnum<T> {
         } else {
             Self::Config(FileConfig {
                 paths: OptOneMany::new(paths),
+                collections: OptOneMany::new(collections),
                 sources: if configs.is_empty() {
                     None
                 } else {
@@ -215,7 +217,7 @@ impl<T: ConfigurationLivecycleHooks> FileConfigEnum<T> {
             Self::Paths(paths) => paths,
             Self::Config(_) => unreachable!("handled above"),
         };
-        *self = Self::new_extended(paths, BTreeMap::from([(id, src)]), T::default());
+        *self = Self::new_extended(paths, vec![], BTreeMap::from([(id, src)]), T::default());
     }
 
     #[must_use]
@@ -254,11 +256,13 @@ impl<T: ConfigurationLivecycleHooks> FileConfigEnum<T> {
         match self {
             Self::Path(path) => Self::Config(FileConfig {
                 paths: OptOneMany::One(path),
+                collections: OptOneMany::NoVals,
                 sources: None,
                 custom: T::default(),
             }),
             Self::Paths(paths) => Self::Config(FileConfig {
                 paths: OptOneMany::Many(paths),
+                collections: OptOneMany::NoVals,
                 sources: None,
                 custom: T::default(),
             }),
@@ -284,6 +288,9 @@ pub struct FileConfig<T> {
     /// A list of file paths
     #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
     pub paths: OptOneMany<PathBuf>,
+    /// A list of directories whose subdirectories are each published under the subdirectory's name
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub collections: OptOneMany<PathBuf>,
     /// A map of source IDs to file paths or config objects
     pub sources: Option<BTreeMap<String, FileConfigSrc>>,
     /// Any customizations related to the specifics of the configuration section
@@ -295,10 +302,33 @@ impl<T: ConfigurationLivecycleHooks> FileConfig<T> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.paths.is_none()
+            && self.collections.is_none()
             && self.sources.is_none()
-            && !self.custom.has_content()
             && self.get_unrecognized_keys().is_empty()
     }
+}
+
+/// The directories directly inside a collection, sorted by name, as `(name, path)` pairs.
+///
+/// Files and hidden directories are skipped.
+#[cfg(any(
+    feature = "_file_kinds",
+    feature = "sprites",
+    feature = "styles",
+    feature = "fonts"
+))]
+pub(crate) fn subdirectories(collection: &Path) -> std::io::Result<Vec<(String, PathBuf)>> {
+    let mut found = Vec::new();
+    for entry in std::fs::read_dir(collection)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir() && !name.starts_with('.') {
+            found.push((name, path));
+        }
+    }
+    found.sort();
+    Ok(found)
 }
 
 #[cfg(feature = "_tiles")]
@@ -550,7 +580,8 @@ async fn resolve_int<T: TileSourceConfiguration>(
         }
     }
 
-    *config = FileConfigEnum::new_extended(directories, configs, cfg.custom);
+    let collections = cfg.collections.into_iter().collect();
+    *config = FileConfigEnum::new_extended(directories, collections, configs, cfg.custom);
 
     Ok((results, warnings))
 }
@@ -1637,6 +1668,7 @@ mod mbtiles_tests {
         );
         let mut config = FileConfigEnum::<MbtConfig>::Config(FileConfig {
             paths: OptOneMany::One(invalid_path.clone()),
+            collections: OptOneMany::NoVals,
             sources: Some(file_sources),
             custom: MbtConfig::default(),
         });
@@ -1668,6 +1700,7 @@ mod pmtiles_tests {
         );
         let mut config = FileConfigEnum::<PmtConfig>::Config(FileConfig {
             paths: OptOneMany::One(invalid_path.clone()),
+            collections: OptOneMany::NoVals,
             sources: Some(file_sources),
             custom: PmtConfig::default(),
         });

--- a/martin/src/config/file/file_config.rs
+++ b/martin/src/config/file/file_config.rs
@@ -57,6 +57,11 @@ pub trait ConfigurationLivecycleHooks:
     fn finalize(&mut self) -> impl Future<Output = ConfigFileResult<()>> + Send {
         async { Ok(()) }
     }
+
+    /// Whether the section configures sources through keys other than `paths` and `sources`.
+    fn has_content(&self) -> bool {
+        false
+    }
 }
 
 /// Configuration which all of our tile sources implement to make configuring them easier
@@ -289,7 +294,10 @@ pub struct FileConfig<T> {
 impl<T: ConfigurationLivecycleHooks> FileConfig<T> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.paths.is_none() && self.sources.is_none() && self.get_unrecognized_keys().is_empty()
+        self.paths.is_none()
+            && self.sources.is_none()
+            && !self.custom.has_content()
+            && self.get_unrecognized_keys().is_empty()
     }
 }
 

--- a/martin/src/config/file/resources/fonts.rs
+++ b/martin/src/config/file/resources/fonts.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::file::{
     CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
-    ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues,
+    ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues, subdirectories,
 };
 
 #[serde_with::skip_serializing_none]
@@ -71,13 +71,24 @@ impl FontConfig {
                 .map_err(|e| ConfigFileError::FontResolutionFailed(e, base_path.clone()))?;
         }
 
+        let collections: Vec<_> = cfg.collections.into_iter().collect();
+        for collection in &collections {
+            for (_name, path) in subdirectories(collection)
+                .map_err(|e| ConfigFileError::IoError(e, collection.clone()))?
+            {
+                results
+                    .recursively_add_directory(path.clone())
+                    .map_err(|e| ConfigFileError::FontResolutionFailed(e, path))?;
+            }
+        }
+
         for (alias, fonts) in &cfg.custom.aliases {
             results
                 .add_alias(alias.clone(), fonts.clone())
                 .map_err(ConfigFileError::FontAliasResolutionFailed)?;
         }
 
-        *self = Self::new_extended(directories, configs, cfg.custom);
+        *self = Self::new_extended(directories, collections, configs, cfg.custom);
 
         Ok(results)
     }

--- a/martin/src/config/file/resources/mod.rs
+++ b/martin/src/config/file/resources/mod.rs
@@ -1,6 +1,38 @@
+#[cfg(any(feature = "sprites", feature = "styles"))]
+use std::path::{Path, PathBuf};
+
+#[cfg(any(feature = "sprites", feature = "styles"))]
+use crate::config::file::{ConfigFileError, ConfigFileResult};
+
 #[cfg(feature = "fonts")]
 pub mod fonts;
 #[cfg(feature = "sprites")]
 pub mod sprites;
 #[cfg(feature = "styles")]
 pub mod styles;
+
+/// The directories directly inside `root`, sorted by name, as `(name, path)` pairs.
+///
+/// Files and hidden directories are skipped, and a root without any directory warns.
+#[cfg(any(feature = "sprites", feature = "styles"))]
+pub(crate) fn subdirectories(root: &Path) -> ConfigFileResult<Vec<(String, PathBuf)>> {
+    let mut found = Vec::new();
+    let entries =
+        std::fs::read_dir(root).map_err(|e| ConfigFileError::IoError(e, root.to_path_buf()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| ConfigFileError::IoError(e, root.to_path_buf()))?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir() && !name.starts_with('.') {
+            found.push((name, path));
+        }
+    }
+    if found.is_empty() {
+        tracing::warn!(
+            "No directories found in collection {}, so it publishes nothing",
+            root.display()
+        );
+    }
+    found.sort();
+    Ok(found)
+}

--- a/martin/src/config/file/resources/mod.rs
+++ b/martin/src/config/file/resources/mod.rs
@@ -1,38 +1,6 @@
-#[cfg(any(feature = "sprites", feature = "styles"))]
-use std::path::{Path, PathBuf};
-
-#[cfg(any(feature = "sprites", feature = "styles"))]
-use crate::config::file::{ConfigFileError, ConfigFileResult};
-
 #[cfg(feature = "fonts")]
 pub mod fonts;
 #[cfg(feature = "sprites")]
 pub mod sprites;
 #[cfg(feature = "styles")]
 pub mod styles;
-
-/// The directories directly inside `root`, sorted by name, as `(name, path)` pairs.
-///
-/// Files and hidden directories are skipped, and a root without any directory warns.
-#[cfg(any(feature = "sprites", feature = "styles"))]
-pub(crate) fn subdirectories(root: &Path) -> ConfigFileResult<Vec<(String, PathBuf)>> {
-    let mut found = Vec::new();
-    let entries =
-        std::fs::read_dir(root).map_err(|e| ConfigFileError::IoError(e, root.to_path_buf()))?;
-    for entry in entries {
-        let entry = entry.map_err(|e| ConfigFileError::IoError(e, root.to_path_buf()))?;
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy().to_string();
-        if path.is_dir() && !name.starts_with('.') {
-            found.push((name, path));
-        }
-    }
-    if found.is_empty() {
-        tracing::warn!(
-            "No directories found in collection {}, so it publishes nothing",
-            root.display()
-        );
-    }
-    found.sort();
-    Ok(found)
-}

--- a/martin/src/config/file/resources/sprites.rs
+++ b/martin/src/config/file/resources/sprites.rs
@@ -1,13 +1,16 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use martin_core::sprites::SpriteSources;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+use crate::config::file::resources::subdirectories;
 use crate::config::file::{
     CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
     ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues,
 };
+use crate::config::primitives::OptOneMany;
 
 pub type SpriteConfig = FileConfigEnum<InnerSpriteConfig>;
 impl SpriteConfig {
@@ -39,6 +42,12 @@ impl SpriteConfig {
             results.add_source(name.to_string_lossy().to_string(), path);
         }
 
+        for root in cfg.custom.collections.iter() {
+            for (name, path) in subdirectories(root)? {
+                results.add_source(name, path);
+            }
+        }
+
         for (alias, sprites) in &cfg.custom.aliases {
             results
                 .add_alias(alias.clone(), sprites.clone())
@@ -52,16 +61,7 @@ impl SpriteConfig {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    CollectUnrecognizedKeys,
-    ConfigurationLivecycleHooks,
-)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, CollectUnrecognizedKeys)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct InnerSpriteConfig {
     /// Cache configuration for sprites.
@@ -72,6 +72,10 @@ pub struct InnerSpriteConfig {
         schemars(with = "crate::config::file::CacheSizeConfigShape")
     )]
     pub cache: CacheSizeConfig,
+
+    /// Directories whose subdirectories are each published as a sprite source named after them.
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub collections: OptOneMany<PathBuf>,
 
     /// Named combinations of sprite sources.
     ///
@@ -84,4 +88,34 @@ pub struct InnerSpriteConfig {
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
+}
+
+impl ConfigurationLivecycleHooks for InnerSpriteConfig {
+    fn has_content(&self) -> bool {
+        !self.collections.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+
+    #[test]
+    fn sprites_parse_collections() {
+        let yaml = indoc! {"
+            collections:
+              - /projects/sprites
+        "};
+        let cfg: SpriteConfig =
+            serde_saphyr::from_str(yaml).expect("sprites with collections must parse");
+        let SpriteConfig::Config(cfg) = cfg else {
+            panic!("expected Config variant, got {cfg:?}");
+        };
+        assert_eq!(
+            cfg.custom.collections.iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/projects/sprites")]
+        );
+    }
 }

--- a/martin/src/config/file/resources/sprites.rs
+++ b/martin/src/config/file/resources/sprites.rs
@@ -1,16 +1,13 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 
 use martin_core::sprites::SpriteSources;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::config::file::resources::subdirectories;
 use crate::config::file::{
     CacheSizeConfig, CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult,
-    ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues,
+    ConfigurationLivecycleHooks, FileConfigEnum, UnrecognizedValues, subdirectories,
 };
-use crate::config::primitives::OptOneMany;
 
 pub type SpriteConfig = FileConfigEnum<InnerSpriteConfig>;
 impl SpriteConfig {
@@ -42,8 +39,11 @@ impl SpriteConfig {
             results.add_source(name.to_string_lossy().to_string(), path);
         }
 
-        for root in cfg.custom.collections.iter() {
-            for (name, path) in subdirectories(root)? {
+        let collections: Vec<_> = cfg.collections.into_iter().collect();
+        for collection in &collections {
+            for (name, path) in subdirectories(collection)
+                .map_err(|e| ConfigFileError::IoError(e, collection.clone()))?
+            {
                 results.add_source(name, path);
             }
         }
@@ -54,14 +54,23 @@ impl SpriteConfig {
                 .map_err(ConfigFileError::SpriteAliasResolutionFailed)?;
         }
 
-        *self = Self::new_extended(directories, configs, cfg.custom);
+        *self = Self::new_extended(directories, collections, configs, cfg.custom);
 
         Ok(results)
     }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, CollectUnrecognizedKeys)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    CollectUnrecognizedKeys,
+    ConfigurationLivecycleHooks,
+)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct InnerSpriteConfig {
     /// Cache configuration for sprites.
@@ -72,10 +81,6 @@ pub struct InnerSpriteConfig {
         schemars(with = "crate::config::file::CacheSizeConfigShape")
     )]
     pub cache: CacheSizeConfig,
-
-    /// Directories whose subdirectories are each published as a sprite source named after them.
-    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
-    pub collections: OptOneMany<PathBuf>,
 
     /// Named combinations of sprite sources.
     ///
@@ -88,34 +93,4 @@ pub struct InnerSpriteConfig {
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
-}
-
-impl ConfigurationLivecycleHooks for InnerSpriteConfig {
-    fn has_content(&self) -> bool {
-        !self.collections.is_none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use indoc::indoc;
-
-    use super::*;
-
-    #[test]
-    fn sprites_parse_collections() {
-        let yaml = indoc! {"
-            collections:
-              - /projects/sprites
-        "};
-        let cfg: SpriteConfig =
-            serde_saphyr::from_str(yaml).expect("sprites with collections must parse");
-        let SpriteConfig::Config(cfg) = cfg else {
-            panic!("expected Config variant, got {cfg:?}");
-        };
-        assert_eq!(
-            cfg.custom.collections.iter().collect::<Vec<_>>(),
-            vec![&PathBuf::from("/projects/sprites")]
-        );
-    }
 }

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -9,23 +9,16 @@ use martin_core::walk_files;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+use crate::config::file::resources::subdirectories;
 use crate::config::file::{
     CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks,
     FileConfigEnum, UnrecognizedValues,
 };
 #[cfg(all(feature = "rendering", target_os = "linux"))]
 use crate::config::primitives::OptBoolObj;
+use crate::config::primitives::OptOneMany;
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    CollectUnrecognizedKeys,
-    ConfigurationLivecycleHooks,
-)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, CollectUnrecognizedKeys)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct InnerStyleConfig {
     /// Allows static, server side, style rendering
@@ -36,6 +29,11 @@ pub struct InnerStyleConfig {
     #[cfg(all(feature = "rendering", target_os = "linux"))]
     #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
     pub rendering: OptBoolObj<RendererConfig>,
+
+    /// Directories whose subdirectories each hold the styles of one project.
+    /// A style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`.
+    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
+    pub collections: OptOneMany<PathBuf>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -66,6 +64,12 @@ pub struct RendererConfig {
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
 }
+impl ConfigurationLivecycleHooks for InnerStyleConfig {
+    fn has_content(&self) -> bool {
+        !self.collections.is_none()
+    }
+}
+
 pub type StyleConfig = FileConfigEnum<InnerStyleConfig>;
 
 impl StyleConfig {
@@ -146,6 +150,18 @@ impl StyleConfig {
         paths_with_names.sort_unstable();
         paths_with_names.dedup();
 
+        for root in cfg.custom.collections.iter() {
+            for (project, dir) in subdirectories(root)? {
+                for path in list_contained_files(&dir, "json")? {
+                    let Some(stem) = path.file_stem() else {
+                        continue;
+                    };
+                    let style_id = format!("{project}.{}", stem.to_string_lossy().trim());
+                    results.add_style(style_id, path);
+                }
+            }
+        }
+
         *self = Self::new_extended(paths_with_names, configs, cfg.custom);
 
         Ok(results)
@@ -187,6 +203,22 @@ mod tests {
 
     use super::*;
     use crate::config::file::FileConfigSrc;
+
+    #[test]
+    fn styles_parse_collections() {
+        let yaml = indoc! {"
+            collections: /projects/styles
+        "};
+        let cfg: StyleConfig =
+            serde_saphyr::from_str(yaml).expect("styles with collections must parse");
+        let StyleConfig::Config(cfg) = cfg else {
+            panic!("expected Config variant, got {cfg:?}");
+        };
+        assert_eq!(
+            cfg.custom.collections.iter().collect::<Vec<_>>(),
+            vec![&PathBuf::from("/projects/styles")]
+        );
+    }
 
     #[test]
     fn styles_parse_paths_only_without_rendering_field() {

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -9,16 +9,23 @@ use martin_core::walk_files;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::config::file::resources::subdirectories;
 use crate::config::file::{
     CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks,
-    FileConfigEnum, UnrecognizedValues,
+    FileConfigEnum, UnrecognizedValues, subdirectories,
 };
 #[cfg(all(feature = "rendering", target_os = "linux"))]
 use crate::config::primitives::OptBoolObj;
-use crate::config::primitives::OptOneMany;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, CollectUnrecognizedKeys)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    CollectUnrecognizedKeys,
+    ConfigurationLivecycleHooks,
+)]
 #[cfg_attr(feature = "unstable-schemas", derive(schemars::JsonSchema))]
 pub struct InnerStyleConfig {
     /// Allows static, server side, style rendering
@@ -29,11 +36,6 @@ pub struct InnerStyleConfig {
     #[cfg(all(feature = "rendering", target_os = "linux"))]
     #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
     pub rendering: OptBoolObj<RendererConfig>,
-
-    /// Directories whose subdirectories each hold the styles of one project.
-    /// A style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`.
-    #[serde(default, skip_serializing_if = "OptOneMany::is_none")]
-    pub collections: OptOneMany<PathBuf>,
 
     #[serde(flatten, skip_serializing)]
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
@@ -64,12 +66,6 @@ pub struct RendererConfig {
     #[cfg_attr(feature = "unstable-schemas", schemars(skip))]
     pub unrecognized: UnrecognizedValues,
 }
-impl ConfigurationLivecycleHooks for InnerStyleConfig {
-    fn has_content(&self) -> bool {
-        !self.collections.is_none()
-    }
-}
-
 pub type StyleConfig = FileConfigEnum<InnerStyleConfig>;
 
 impl StyleConfig {
@@ -150,8 +146,11 @@ impl StyleConfig {
         paths_with_names.sort_unstable();
         paths_with_names.dedup();
 
-        for root in cfg.custom.collections.iter() {
-            for (project, dir) in subdirectories(root)? {
+        let collections: Vec<_> = cfg.collections.into_iter().collect();
+        for collection in &collections {
+            for (project, dir) in subdirectories(collection)
+                .map_err(|e| ConfigFileError::IoError(e, collection.clone()))?
+            {
                 for path in list_contained_files(&dir, "json")? {
                     let Some(stem) = path.file_stem() else {
                         continue;
@@ -162,7 +161,7 @@ impl StyleConfig {
             }
         }
 
-        *self = Self::new_extended(paths_with_names, configs, cfg.custom);
+        *self = Self::new_extended(paths_with_names, collections, configs, cfg.custom);
 
         Ok(results)
     }
@@ -203,22 +202,6 @@ mod tests {
 
     use super::*;
     use crate::config::file::FileConfigSrc;
-
-    #[test]
-    fn styles_parse_collections() {
-        let yaml = indoc! {"
-            collections: /projects/styles
-        "};
-        let cfg: StyleConfig =
-            serde_saphyr::from_str(yaml).expect("styles with collections must parse");
-        let StyleConfig::Config(cfg) = cfg else {
-            panic!("expected Config variant, got {cfg:?}");
-        };
-        assert_eq!(
-            cfg.custom.collections.iter().collect::<Vec<_>>(),
-            vec![&PathBuf::from("/projects/styles")]
-        );
-    }
 
     #[test]
     fn styles_parse_paths_only_without_rendering_field() {
@@ -307,7 +290,8 @@ mod tests {
             .into_iter()
             .map(|(k, v)| (k.to_owned(), FileConfigSrc::Path(v)))
             .collect();
-        let mut cfg = StyleConfig::new_extended(vec![], configs, InnerStyleConfig::default());
+        let mut cfg =
+            StyleConfig::new_extended(vec![], vec![], configs, InnerStyleConfig::default());
 
         let styles = cfg.resolve().unwrap();
         assert_eq!(styles.len(), 2);

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -13,7 +13,7 @@ use crate::config::file::source_location::SourceLocation;
 use crate::config::file::tiles::discovery::{BuiltSource, Discovered, Discovery, Version};
 use crate::config::file::{
     CachePolicy, FileConfigEnum, FileConfigSrc, ProcessConfig, ResolvedProcess, SourceBuildError,
-    SourceBuildResult, TileSourceWarning,
+    SourceBuildResult, TileSourceWarning, subdirectories,
 };
 use crate::config::primitives::{IdResolver, OptOneMany};
 use crate::reload::{FileKind, SourceProvenance};
@@ -49,6 +49,8 @@ pub struct FsDiscovery {
     kind: FileKind,
     /// The watched directories as configured.
     directories: Vec<PathBuf>,
+    /// The collections as configured, each subdirectory of which is scanned as a project.
+    collections: Vec<PathBuf>,
     /// Whether the watched directories are scanned recursively.
     recursive: bool,
     extensions: &'static [&'static str],
@@ -109,26 +111,30 @@ impl FsDiscovery {
         }
 
         let mut warnings: Vec<TileSourceWarning> = vec![];
-        let mut push_local = |path: &PathBuf| {
+        let mut readable = |path: &PathBuf| -> Option<PathBuf> {
             let Ok(SourceLocation::Local(_)) = SourceLocation::classify_path(path) else {
-                return;
+                return None;
             };
             let probed = path
                 .canonicalize()
                 .and_then(|p| std::fs::read_dir(&p).map(|_| p));
             match probed {
-                Ok(canonical) => {
-                    if seen.insert(canonical) {
-                        directories.push(path.clone());
-                    }
-                }
+                Ok(canonical) => Some(canonical),
                 Err(e) => {
                     tracing::warn!(directory = ?path, error = %e, "cannot read watch directory");
                     warnings.push(TileSourceWarning::PathError {
                         path: path.clone(),
                         error: e.to_string(),
                     });
+                    None
                 }
+            }
+        };
+        let mut push_local = |path: &PathBuf| {
+            if let Some(canonical) = readable(path)
+                && seen.insert(canonical)
+            {
+                directories.push(path.clone());
             }
         };
 
@@ -143,9 +149,29 @@ impl FsDiscovery {
             FileConfigEnum::None => {}
         }
 
+        let mut collections: Vec<PathBuf> = vec![];
+        if let FileConfigEnum::Config(cfg) = config {
+            let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
+            for collection in cfg.collections.iter() {
+                if !matches!(
+                    SourceLocation::classify_path(collection),
+                    Ok(SourceLocation::Local(_))
+                ) {
+                    tracing::warn!(collection = ?collection, "a collection must be a local directory");
+                    continue;
+                }
+                if let Some(canonical) = readable(collection)
+                    && seen.insert(canonical)
+                {
+                    collections.push(collection.clone());
+                }
+            }
+        }
+
         Self {
             kind,
             directories,
+            collections,
             recursive,
             extensions,
             configured,
@@ -159,19 +185,20 @@ impl FsDiscovery {
         }
     }
 
-    /// The canonical watched directories, for wiring a `NotifyTrigger`.
+    /// The canonical watched directories and collections, for wiring a `NotifyTrigger`.
     #[must_use]
     pub fn directories(&self) -> Vec<PathBuf> {
         self.directories
             .iter()
+            .chain(&self.collections)
             .filter_map(|dir| dir.canonicalize().ok())
             .collect()
     }
 
-    /// Whether the watched directories are scanned recursively, for wiring a `NotifyTrigger`.
+    /// Whether the directories are watched recursively, which a collection needs as its projects sit one level below it.
     #[must_use]
     pub fn recursive(&self) -> bool {
-        self.recursive
+        self.recursive || !self.collections.is_empty()
     }
 
     /// The config-file entry for a discovered file.
@@ -183,6 +210,7 @@ impl FsDiscovery {
         let as_configured = self
             .directories
             .iter()
+            .chain(&self.collections)
             .filter_map(|dir| {
                 let canonical_dir = dir.canonicalize().ok()?;
                 let relative = canonical.strip_prefix(&canonical_dir).ok()?;
@@ -224,15 +252,19 @@ impl Discovery for FsDiscovery {
     type Args = (PathBuf, CachePolicy);
 
     async fn discover(&self) -> SourceBuildResult<Discovered<Self::Args>> {
-        let discovered = discover_sources_by_ext(
-            &self.directories,
-            self.recursive,
-            self.extensions,
-            &self.configured,
-            &self.id_resolver,
-            self.default_cache,
-        )
-        .await?;
+        let mut discovered = BTreeMap::new();
+        for directory in &self.directories {
+            let root = directory.canonicalize().map_err(SourceBuildError::Io)?;
+            self.scan(&root, "", &mut discovered).await?;
+        }
+        for collection in &self.collections {
+            let root = collection.canonicalize().map_err(SourceBuildError::Io)?;
+            for (project, dir) in subdirectories(&root).map_err(SourceBuildError::Io)? {
+                let dir = dir.canonicalize().map_err(SourceBuildError::Io)?;
+                self.scan(&dir, &format!("{project}."), &mut discovered)
+                    .await?;
+            }
+        }
 
         Ok(Discovered::new(
             discovered
@@ -332,20 +364,16 @@ fn resolve_dir_entry(entry: &DirEntry) -> Option<ResolvedEntry> {
     })
 }
 
-/// Scans `directories` for files matching `extensions`, resolving ids and cache policies.
-async fn discover_sources_by_ext(
-    directories: &[PathBuf],
-    recursive: bool,
-    extensions: &[&str],
-    configured: &BTreeMap<PathBuf, ConfiguredSource>,
-    id_resolver: &IdResolver,
-    default_cache: CachePolicy,
-) -> SourceBuildResult<BTreeMap<String, (PathBuf, u128, CachePolicy)>> {
-    let mut out = BTreeMap::new();
-    for directory in directories {
-        let root = directory.canonicalize().map_err(SourceBuildError::Io)?;
+impl FsDiscovery {
+    /// Scans `root` for files matching the extensions, naming each one `prefix` plus its name under `root`.
+    async fn scan(
+        &self,
+        root: &Path,
+        prefix: &str,
+        out: &mut BTreeMap<String, (PathBuf, u128, CachePolicy)>,
+    ) -> SourceBuildResult<()> {
         let mut visited: BTreeSet<PathBuf> = BTreeSet::new();
-        let mut pending = vec![root.clone()];
+        let mut pending = vec![root.to_path_buf()];
         while let Some(dir) = pending.pop() {
             if !visited.insert(dir.clone()) {
                 continue;
@@ -355,30 +383,33 @@ async fn discover_sources_by_ext(
                 let Some(e) = resolve_dir_entry(&entry) else {
                     continue;
                 };
-                if recursive && e.path.is_dir() {
+                if self.recursive && e.path.is_dir() {
                     pending.push(e.path);
                     continue;
                 }
                 if !e.path.is_file()
                     || e.path
                         .extension()
-                        .is_none_or(|ext| !extensions.iter().any(|ex| *ex == ext))
+                        .is_none_or(|ext| !self.extensions.iter().any(|ex| *ex == ext))
                 {
                     continue;
                 }
-                let Some(name) = source_name(&root, &e.path) else {
+                let Some(name) = source_name(root, &e.path) else {
                     tracing::warn!(path = ?e.path, "failed to resolve source name");
                     continue;
                 };
-                let policy = configured
+                let policy = self
+                    .configured
                     .get(&e.path)
-                    .map_or(default_cache, |cfg| cfg.policy);
-                let id = id_resolver.resolve(&name, e.path_str.clone());
+                    .map_or(self.default_cache, |cfg| cfg.policy);
+                let id = self
+                    .id_resolver
+                    .resolve(&format!("{prefix}{name}"), e.path_str.clone());
                 out.insert(id, (e.path, e.modified_ms, policy));
             }
         }
+        Ok(())
     }
-    Ok(out)
 }
 
 #[cfg(test)]

--- a/martin/src/config/file/tiles/reload/pmtiles.rs
+++ b/martin/src/config/file/tiles/reload/pmtiles.rs
@@ -192,6 +192,7 @@ mod tests {
     #[test]
     fn new_partitions_local_and_remote_paths() {
         let cfg = FileConfigEnum::Config(FileConfig {
+            collections: OptOneMany::NoVals,
             paths: OptOneMany::Many(vec![
                 PathBuf::from("s3://bucket-a/"),
                 PathBuf::from("s3://bucket-b/folder/"),
@@ -217,6 +218,7 @@ mod tests {
     #[test]
     fn new_dedups_remote_prefixes() {
         let cfg = FileConfigEnum::Config(FileConfig {
+            collections: OptOneMany::NoVals,
             paths: OptOneMany::Many(vec![
                 PathBuf::from("s3://bucket/"),
                 PathBuf::from("s3://bucket/"),
@@ -248,6 +250,7 @@ mod tests {
             })),
         );
         let cfg = FileConfigEnum::Config(FileConfig {
+            collections: OptOneMany::NoVals,
             paths: OptOneMany::NoVals,
             sources: Some(sources),
             custom: PmtConfig::default(),

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -489,6 +489,10 @@
           "$ref": "#/$defs/CacheSizeConfigShape",
           "description": "Cache configuration for sprites.\nUse `cache: disable` to disable sprite caching."
         },
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "Directories whose subdirectories are each published as a sprite source named after them."
+        },
         "paths": {
           "$ref": "#/$defs/OptOneMany2",
           "description": "A list of file paths"
@@ -505,6 +509,10 @@
     },
     "FileConfig5": {
       "properties": {
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "Directories whose subdirectories each hold the styles of one project.\nA style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`."
+        },
         "paths": {
           "$ref": "#/$defs/OptOneMany2",
           "description": "A list of file paths"

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -337,6 +337,10 @@
           "$ref": "#/$defs/CachePolicyShape",
           "description": "Zoom-level bounds for caching the tiles of every `PMTiles` source without its own `cache`.\nOverrides the top-level `cache` bounds."
         },
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -393,6 +397,10 @@
           "$ref": "#/$defs/CachePolicyShape",
           "description": "Zoom-level bounds for caching the tiles of every `MBTiles` source without its own `cache`.\nOverrides the top-level `cache` bounds."
         },
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
+        },
         "convert_to_mlt": {
           "anyOf": [
             {
@@ -447,6 +455,10 @@
           "$ref": "#/$defs/CachePolicyShape",
           "description": "Zoom-level bounds for caching the tiles of every `GeoJSON` source without its own `cache`.\nOverrides the top-level `cache` bounds."
         },
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
+        },
         "extent": {
           "description": "Side length of the MVT tile coordinate grid each tile is encoded into, defaulting to 4096.",
           "examples": [4096],
@@ -491,7 +503,7 @@
         },
         "collections": {
           "$ref": "#/$defs/OptOneMany2",
-          "description": "Directories whose subdirectories are each published as a sprite source named after them."
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
         },
         "paths": {
           "$ref": "#/$defs/OptOneMany2",
@@ -511,7 +523,7 @@
       "properties": {
         "collections": {
           "$ref": "#/$defs/OptOneMany2",
-          "description": "Directories whose subdirectories each hold the styles of one project.\nA style found in `<root>/<project>/<file>.json` is published as `<project>.<file>`."
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
         },
         "paths": {
           "$ref": "#/$defs/OptOneMany2",
@@ -546,6 +558,10 @@
         "cache": {
           "$ref": "#/$defs/CacheSizeConfigShape",
           "description": "Cache configuration for fonts.\nUse `cache: disable` to disable font caching."
+        },
+        "collections": {
+          "$ref": "#/$defs/OptOneMany2",
+          "description": "A list of directories whose subdirectories are each published under the subdirectory's name"
         },
         "paths": {
           "$ref": "#/$defs/OptOneMany2",


### PR DESCRIPTION
Closes #1829

Adds `collections` to every file-backed section, next to `paths` and `sources`. A collection is a directory of project directories, and what a project holds is published under the project's name. Sprites publish each project directory as a source, styles and the tile kinds publish `<project>.<file>`, and fonts load the fonts inside. The tile reloaders watch a collection, so a project that appears later is published without a restart. `paths` and `sources` keep their meaning.

```yaml
sprites:
  collections: /projects/sprites   # /projects/sprites/project1/*.svg -> /sprite/project1.png
styles:
  collections: /projects/styles    # /projects/styles/project1/basic.json -> /style/project1.basic
mbtiles:
  collections: /projects/tiles     # /projects/tiles/project1/roads.mbtiles -> /project1.roads
```
