### PR TITLE
feat(mbtiles): warn when a served file has no tile index

### DIFF
--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -577,3 +577,31 @@ async fn a_kind_level_cache_bound_covers_a_directory_and_a_source_can_override_i
     "#);
     overridden.stop().await;
 }
+
+#[tokio::test]
+async fn a_source_without_a_tile_index_is_served_with_a_warning() {
+    use sqlx::Connection as _;
+
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let path = mbtiles_fixture(dir.path(), "world_cities").await;
+    let mut conn = sqlx::SqliteConnection::connect(&format!("sqlite://{}", path.display()))
+        .await
+        .expect("failed to open the fixture");
+    sqlx::query("DROP INDEX tile_index")
+        .execute(&mut conn)
+        .await
+        .expect("failed to drop the tile index");
+    conn.close().await.expect("failed to close the fixture");
+
+    let mut martin = Martin::builder()
+        .arg(&path)
+        .start()
+        .await
+        .expect("failed to start martin");
+
+    let tile = martin.get("/world_cities/0/0/0").await;
+    assert_eq!(tile.status(), 200);
+
+    martin.stop().await;
+    martin.assert_log_contains("Table tiles has no index on (zoom_level, tile_column, tile_row)");
+}

--- a/martin-core/src/tiles/mbtiles/source.rs
+++ b/martin-core/src/tiles/mbtiles/source.rs
@@ -12,7 +12,7 @@ use martin_tile_utils::{TileCoord, TileData, TileInfo};
 use mbtiles::sqlx::error::DatabaseError;
 use mbtiles::{MbtError, MbtilesPool};
 use tilejson::TileJSON;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::CacheZoomRange;
 use crate::tiles::mbtiles::MbtilesError;
@@ -78,6 +78,17 @@ impl MbtSource {
             })
             .await
             .map_err(|e| MbtilesError::InvalidMetadata(e.to_string(), path.clone()))?;
+
+        match mbt.missing_tile_index().await {
+            Ok(Some(table)) => warn!(
+                source.id = %id,
+                mbtiles.file = %path.display(),
+                "Table {table} has no index on (zoom_level, tile_column, tile_row), so every tile lookup scans it. \
+                 Create one with: CREATE UNIQUE INDEX {table}_index ON {table} (zoom_level, tile_column, tile_row)"
+            ),
+            Ok(None) => {}
+            Err(e) => debug!(source.id = %id, error = %e, "Could not check the tile index"),
+        }
 
         let tile_info = mbt
             .detect_format(&meta.tilejson)

--- a/mbtiles/src/pool.rs
+++ b/mbtiles/src/pool.rs
@@ -233,6 +233,12 @@ impl MbtilesPool {
         self.mbtiles.detect_format(tilejson, &mut *conn).await
     }
 
+    /// See [`Mbtiles::missing_tile_index`].
+    pub async fn missing_tile_index(&self) -> MbtResult<Option<&'static str>> {
+        let mut conn = self.pool.acquire().await?;
+        self.mbtiles.missing_tile_index(&mut *conn).await
+    }
+
     /// Retrieves a tile from the pool by its coordinates.
     ///
     /// Automatically acquires a connection from the pool, fetches the tile data,

--- a/mbtiles/src/validation.rs
+++ b/mbtiles/src/validation.rs
@@ -489,30 +489,74 @@ impl Mbtiles {
         for<'e> &'e mut T: SqliteExecutor<'e>,
     {
         debug!("Detecting MBTiles type for {self}");
-        let typ = if is_normalized_tables_type(&mut *conn).await? {
-            MbtType::Normalized {
-                hash_view: has_tiles_with_hash(&mut *conn).await?,
-                schema: NormalizedSchema::Hash,
-            }
-        } else if is_dedup_id_normalized_tables_type(&mut *conn).await? {
-            MbtType::Normalized {
-                hash_view: false,
-                schema: NormalizedSchema::DedupId,
-            }
-        } else if is_flat_with_hash_tables_type(&mut *conn).await? {
-            MbtType::FlatWithHash
-        } else if is_flat_tables_type(&mut *conn).await? {
-            MbtType::Flat
-        } else if is_cache_tables_type(&mut *conn).await? {
-            MbtType::Cache
-        } else {
-            return Err(MbtError::InvalidDataFormat(self.filepath().to_owned()));
-        };
+        let typ = self.detect_layout(&mut *conn).await?;
 
         self.check_for_uniqueness_constraint(&mut *conn, typ)
             .await?;
 
         Ok(typ)
+    }
+
+    /// Detects the table layout without checking the tile index.
+    async fn detect_layout<T>(&self, conn: &mut T) -> MbtResult<MbtType>
+    where
+        for<'e> &'e mut T: SqliteExecutor<'e>,
+    {
+        if is_normalized_tables_type(&mut *conn).await? {
+            Ok(MbtType::Normalized {
+                hash_view: has_tiles_with_hash(&mut *conn).await?,
+                schema: NormalizedSchema::Hash,
+            })
+        } else if is_dedup_id_normalized_tables_type(&mut *conn).await? {
+            Ok(MbtType::Normalized {
+                hash_view: false,
+                schema: NormalizedSchema::DedupId,
+            })
+        } else if is_flat_with_hash_tables_type(&mut *conn).await? {
+            Ok(MbtType::FlatWithHash)
+        } else if is_flat_tables_type(&mut *conn).await? {
+            Ok(MbtType::Flat)
+        } else if is_cache_tables_type(&mut *conn).await? {
+            Ok(MbtType::Cache)
+        } else {
+            Err(MbtError::InvalidDataFormat(self.filepath().to_owned()))
+        }
+    }
+
+    /// The table that lookups by tile coordinate read from.
+    fn tile_table(mbt_type: MbtType) -> &'static str {
+        match mbt_type {
+            MbtType::Flat => "tiles",
+            MbtType::FlatWithHash => "tiles_with_hash",
+            MbtType::Normalized { schema, .. } => schema.map_table(),
+            MbtType::Cache => "tile_cache",
+        }
+    }
+
+    /// The tile table when no index, unique or not, covers `(zoom_level, tile_column, tile_row)`.
+    pub async fn missing_tile_index<T>(&self, conn: &mut T) -> MbtResult<Option<&'static str>>
+    where
+        for<'e> &'e mut T: SqliteExecutor<'e>,
+    {
+        let table_name = Self::tile_table(self.detect_layout(&mut *conn).await?);
+        let indexes = query("SELECT name FROM pragma_index_list(?)")
+            .bind(table_name)
+            .fetch_all(&mut *conn)
+            .await?;
+        for index in indexes {
+            let rows = query("SELECT DISTINCT name FROM pragma_index_info(?)")
+                .bind(index.get::<String, _>("name"))
+                .fetch_all(&mut *conn)
+                .await?;
+            let columns: HashSet<String> = rows.iter().map(|row| row.get("name")).collect();
+            if ["zoom_level", "tile_column", "tile_row"]
+                .iter()
+                .all(|column| columns.contains(*column))
+            {
+                return Ok(None);
+            }
+        }
+        Ok(Some(table_name))
     }
 
     async fn check_for_uniqueness_constraint<T>(
@@ -523,12 +567,7 @@ impl Mbtiles {
     where
         for<'e> &'e mut T: SqliteExecutor<'e>,
     {
-        let table_name = match mbt_type {
-            MbtType::Flat => "tiles",
-            MbtType::FlatWithHash => "tiles_with_hash",
-            MbtType::Normalized { schema, .. } => schema.map_table(),
-            MbtType::Cache => "tile_cache",
-        };
+        let table_name = Self::tile_table(mbt_type);
 
         let indexes = query("SELECT name FROM pragma_index_list(?) WHERE [unique] = 1")
             .bind(table_name)


### PR DESCRIPTION
Closes #741

Martin serves an MBTiles file whose tile table has no index on `(zoom_level, tile_column, tile_row)` without a word, and every tile request then scans the table. The report on the issue saw request times past a second on such a file. `mbtiles validate` already refuses these files, but the server never runs that check. On startup Martin now looks for any index covering the three coordinate columns on the table it reads from and logs a warning naming the table and the `CREATE UNIQUE INDEX` that fixes it. The file is still served, `validate` is unchanged, and the validation levels sketched on the issue are not part of this.