### PR TITLE
ci(docs): stop link-checking digitalocean.com

### DIFF
--- a/.github/files/markdown.links.config.json
+++ b/.github/files/markdown.links.config.json
@@ -27,6 +27,10 @@
     {
       "__comment__": "Geofabrik drops the checker's connection (socket hang up), which fails every docs build that links a download page",
       "pattern": "^https://download.geofabrik.de"
+    },
+    {
+      "__comment__": "DigitalOcean drops the checker's connection (socket hang up) on its product pages, which fails every docs build that links the managed Postgres recipe",
+      "pattern": "^https://[a-z]+.digitalocean.com"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Every docs build that links the DigitalOcean managed Postgres recipe page fails with `socket hang up`, regardless of the change under review; #3235 hit it today on `recipes.md`.

DigitalOcean drops the link checker's connection on its product pages. This adds the host to the checker's ignore list next to Geofabrik, which #3227 added for the same failure.