### PR TITLE
feat(mbtiles): copy several source files into one destination

### DIFF
--- a/docs/content/mbtiles-copy.md
+++ b/docs/content/mbtiles-copy.md
@@ -23,6 +23,16 @@ mbtiles copy normalized.mbtiles dst.mbtiles \
          --dst-type flat-with-hash
 ```
 
+### Merging several files
+
+`copy` takes any number of source files before the destination and copies them into it one after another.
+Two sources can hold the same tile, so `--on-duplicate` is required to say which one wins.
+`--diff-with-file` and `--apply-patch` take exactly one source.
+
+```bash
+mbtiles copy north.mbtiles south.mbtiles merged.mbtiles --on-duplicate override
+```
+
 ## `mbtiles copy --diff-with-file`
 
 This option is identical to using [`mbtiles diff ...`](mbtiles-diff.md). The following commands two are equivalent:

--- a/e2e-tests/tests/mbtiles_cli.rs
+++ b/e2e-tests/tests/mbtiles_cli.rs
@@ -382,10 +382,7 @@ async fn copying_several_sources_needs_on_duplicate() {
         .run_failing()
         .await;
 
-    assert!(
-        output.contains("needs --on-duplicate"),
-        "unexpected output:\n{output}"
-    );
+    insta::assert_snapshot!(output, @"ERROR copying 2 sources into one file needs --on-duplicate to say what happens when two of them hold the same tile");
     assert!(!merged.exists(), "nothing is copied before the check");
 }
 
@@ -406,8 +403,5 @@ async fn copy_with_a_diff_file_takes_one_source() {
         .run_failing()
         .await;
 
-    assert!(
-        output.contains("take exactly one source file"),
-        "unexpected output:\n{output}"
-    );
+    insta::assert_snapshot!(output, @"ERROR --diff-with-file and --apply-patch take exactly one source file, got 2");
 }

--- a/e2e-tests/tests/mbtiles_cli.rs
+++ b/e2e-tests/tests/mbtiles_cli.rs
@@ -5,7 +5,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use martin_e2e_tests::{GZIP_MAGIC, MbtilesCli, mbtiles_fixture, temp_dir, tiles};
+use martin_e2e_tests::{GZIP_MAGIC, MbtilesCli, Tile, mbtiles_fixture, temp_dir, tiles};
 use rstest::rstest;
 
 fn tile_tree(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
@@ -317,6 +317,97 @@ async fn pack_rejects_inconsistent_tile_formats() {
 
     assert!(
         output.contains("Inconsistent tile formats"),
+        "unexpected output:\n{output}"
+    );
+}
+
+#[tokio::test]
+async fn copy_merges_several_sources_in_order() {
+    let dir = temp_dir();
+    let first = mbtiles_fixture(dir.path(), "world_cities").await;
+    let second = mbtiles_fixture(dir.path(), "world_cities_modified").await;
+    let first_tiles = tiles(&first).await;
+    let second_tiles = tiles(&second).await;
+    assert_ne!(
+        first_tiles, second_tiles,
+        "the fixtures must differ for the order to show"
+    );
+
+    let merged = dir.path().join("merged.mbtiles");
+    MbtilesCli::new("copy")
+        .arg(&first)
+        .arg(&second)
+        .arg(&merged)
+        .arg("--on-duplicate")
+        .arg("override")
+        .run()
+        .await;
+
+    // Every tile of both files, the later one in `order` winning where they share a coordinate.
+    let union = |order: [&Vec<Tile>; 2]| {
+        let mut expected = BTreeMap::new();
+        for (z, x, y, data) in order.into_iter().flatten() {
+            expected.insert((*z, *x, *y), data.clone());
+        }
+        expected
+            .into_iter()
+            .map(|((z, x, y), data)| (z, x, y, data))
+            .collect::<Vec<Tile>>()
+    };
+    assert_eq!(tiles(&merged).await, union([&first_tiles, &second_tiles]));
+
+    let kept = dir.path().join("kept.mbtiles");
+    MbtilesCli::new("copy")
+        .arg(&first)
+        .arg(&second)
+        .arg(&kept)
+        .arg("--on-duplicate")
+        .arg("ignore")
+        .run()
+        .await;
+    assert_eq!(tiles(&kept).await, union([&second_tiles, &first_tiles]));
+}
+
+#[tokio::test]
+async fn copying_several_sources_needs_on_duplicate() {
+    let dir = temp_dir();
+    let first = mbtiles_fixture(dir.path(), "world_cities").await;
+    let second = mbtiles_fixture(dir.path(), "world_cities_modified").await;
+    let merged = dir.path().join("merged.mbtiles");
+
+    let output = MbtilesCli::new("copy")
+        .arg(&first)
+        .arg(&second)
+        .arg(&merged)
+        .run_failing()
+        .await;
+
+    assert!(
+        output.contains("needs --on-duplicate"),
+        "unexpected output:\n{output}"
+    );
+    assert!(!merged.exists(), "nothing is copied before the check");
+}
+
+#[tokio::test]
+async fn copy_with_a_diff_file_takes_one_source() {
+    let dir = temp_dir();
+    let first = mbtiles_fixture(dir.path(), "world_cities").await;
+    let second = mbtiles_fixture(dir.path(), "world_cities_modified").await;
+
+    let output = MbtilesCli::new("copy")
+        .arg(&first)
+        .arg(&second)
+        .arg(dir.path().join("merged.mbtiles"))
+        .arg("--diff-with-file")
+        .arg(&second)
+        .arg("--on-duplicate")
+        .arg("override")
+        .run_failing()
+        .await;
+
+    assert!(
+        output.contains("take exactly one source file"),
         "unexpected output:\n{output}"
     );
 }

--- a/e2e-tests/tests/mbtiles_diff.rs
+++ b/e2e-tests/tests/mbtiles_diff.rs
@@ -61,9 +61,9 @@ async fn patch_fixtures(dir: &Path, extra_args: &[&str]) -> (PathBuf, PathBuf, P
 
     let mut command = MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&patch)
         .arg("--diff-with-file")
-        .arg(&modified)
-        .arg(&patch);
+        .arg(&modified);
     for arg in extra_args {
         command = command.arg(*arg);
     }
@@ -131,9 +131,9 @@ async fn a_cache_round_trip_leaves_the_differ_nothing_to_report() {
         .await;
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&patch)
         .arg("--diff-with-file")
         .arg(&back)
-        .arg(&patch)
         .run()
         .await;
 
@@ -212,9 +212,9 @@ async fn diff_and_copy_with_diff_with_file_write_the_same_patch() {
 
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&from_copy)
         .arg("--diff-with-file")
         .arg(&modified)
-        .arg(&from_copy)
         .run()
         .await;
     MbtilesCli::new("diff")
@@ -248,9 +248,9 @@ async fn a_patch_applied_as_plain_sql_reproduces_the_modified_tileset() {
 
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&patch)
         .arg("--diff-with-file")
         .arg(&modified)
-        .arg(&patch)
         .run()
         .await;
 
@@ -296,18 +296,18 @@ async fn a_bin_diff_patch_reproduces_the_modified_tileset() {
 
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&patch)
         .arg("--diff-with-file")
         .arg(&modified)
-        .arg(&patch)
         .arg("--patch-type")
         .arg("bin-diff-gz")
         .run()
         .await;
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&applied)
         .arg("--apply-patch")
         .arg(&patch)
-        .arg(&applied)
         .run()
         .await;
 
@@ -329,9 +329,9 @@ async fn the_checked_in_bin_diff_fixture_still_applies() {
 
     MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&applied)
         .arg("--apply-patch")
         .arg(&patch)
-        .arg(&applied)
         .run()
         .await;
 
@@ -357,9 +357,9 @@ async fn applying_a_patch_announces_the_hashes_it_expects() {
 
     let output = MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&applied)
         .arg("--apply-patch")
         .arg(&patch)
-        .arg(&applied)
         .run()
         .await;
 
@@ -386,9 +386,9 @@ async fn bin_diff_reports_how_many_workers_it_used() {
     // Both cutting and applying a bin-diff run the parallel bindiff pass and say so.
     let cutting = MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&patch)
         .arg("--diff-with-file")
         .arg(&modified)
-        .arg(&patch)
         .arg("--patch-type")
         .arg("bin-diff-gz")
         .run()
@@ -397,9 +397,9 @@ async fn bin_diff_reports_how_many_workers_it_used() {
 
     let applying = MbtilesCli::new("copy")
         .arg(&source)
+        .arg(&applied)
         .arg("--apply-patch")
         .arg(&patch)
-        .arg(&applied)
         .run()
         .await;
     insta::assert_snapshot!("applying_a_bin_diff", redact(&dir, &applying));

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -176,8 +176,9 @@ enum Commands {
 pub struct CopyArgs {
     /// `MBTiles` file to read from
     src_file: PathBuf,
-    /// `MBTiles` file to write to
-    dst_file: PathBuf,
+    /// Further `MBTiles` files to read from, followed by the file to write to
+    #[arg(required = true, num_args = 1.., value_name = "FILE")]
+    files: Vec<PathBuf>,
     #[command(flatten)]
     pub options: SharedCopyOpts,
     /// Compare source file with this file, and only copy non-identical tiles to destination.
@@ -312,7 +313,6 @@ async fn main() {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 async fn main_int() -> anyhow::Result<()> {
     let args = Args::parse();
     match args.command {
@@ -325,16 +325,7 @@ async fn main_int() -> anyhow::Result<()> {
         Commands::MetaSetValue { file, key, value } => {
             meta_set_value(file.as_path(), &key, value.as_deref()).await?;
         }
-        Commands::Copy(args) => {
-            let copier = args.options.into_copier(
-                args.src_file,
-                args.dst_file,
-                args.diff_with_file,
-                args.apply_patch,
-                args.patch_type,
-            );
-            copier.run().instrument(info_span!("copy")).await?;
-        }
+        Commands::Copy(args) => copy(args).await?,
         Commands::Diff(args) => {
             let copier = args.options.into_copier(
                 args.file1,
@@ -456,6 +447,40 @@ async fn meta_print_all(file: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Copies every source file in `args` into the last one, in order.
+async fn copy(args: CopyArgs) -> anyhow::Result<()> {
+    let (dst_file, more) = args
+        .files
+        .split_last()
+        .expect("clap requires the destination");
+    let src_files: Vec<&PathBuf> = std::iter::once(&args.src_file).chain(more).collect();
+    if src_files.len() > 1 {
+        if args.diff_with_file.is_some() || args.apply_patch.is_some() {
+            anyhow::bail!(
+                "--diff-with-file and --apply-patch take exactly one source file, got {}",
+                src_files.len()
+            );
+        }
+        if args.options.on_duplicate.is_none() {
+            anyhow::bail!(
+                "copying {} sources into one file needs --on-duplicate to say what happens when two of them hold the same tile",
+                src_files.len()
+            );
+        }
+    }
+    for src_file in src_files {
+        let copier = args.options.clone().into_copier(
+            src_file.clone(),
+            dst_file.clone(),
+            args.diff_with_file.clone(),
+            args.apply_patch.clone(),
+            args.patch_type,
+        );
+        copier.run().instrument(info_span!("copy")).await?;
+    }
+    Ok(())
+}
+
 async fn meta_get_value(file: &Path, key: &str) -> MbtResult<()> {
     let mbt = Mbtiles::new(file)?;
     let mut conn = mbt.open_readonly().await?;
@@ -536,7 +561,26 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
+                    ..Default::default()
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn copy_several_sources() {
+        assert_eq!(
+            Args::parse_from(["mbtiles", "copy", "a", "b", "c", "dst_file"]),
+            Args {
+                verbose: false,
+                command: Copy(CopyArgs {
+                    src_file: PathBuf::from("a"),
+                    files: vec![
+                        PathBuf::from("b"),
+                        PathBuf::from("c"),
+                        PathBuf::from("dst_file"),
+                    ],
                     ..Default::default()
                 })
             }
@@ -561,7 +605,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     options: SharedCopyOpts {
                         min_zoom: Some(1),
                         max_zoom: Some(100),
@@ -581,7 +625,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     options: SharedCopyOpts {
                         strict: true,
                         ..Default::default()
@@ -645,7 +689,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     options: SharedCopyOpts {
                         zoom_levels: vec![3, 7, 1],
                         ..Default::default()
@@ -671,7 +715,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     diff_with_file: Some(PathBuf::from("no_file")),
                     ..Default::default()
                 })
@@ -694,7 +738,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     options: SharedCopyOpts {
                         on_duplicate: Some(CopyDuplicateMode::Override),
                         ..Default::default()
@@ -715,7 +759,7 @@ mod tests {
                 verbose: false,
                 command: Copy(CopyArgs {
                     src_file: PathBuf::from("src_file"),
-                    dst_file: PathBuf::from("dst_file"),
+                    files: vec![PathBuf::from("dst_file")],
                     options: SharedCopyOpts {
                         copy: CopyType::Metadata,
                         ..Default::default()

--- a/mbtiles/src/bin/mbtiles.rs
+++ b/mbtiles/src/bin/mbtiles.rs
@@ -174,11 +174,12 @@ enum Commands {
 
 #[derive(Clone, Default, PartialEq, Debug, clap::Args)]
 pub struct CopyArgs {
-    /// `MBTiles` file to read from
-    src_file: PathBuf,
-    /// Further `MBTiles` files to read from, followed by the file to write to
-    #[arg(required = true, num_args = 1.., value_name = "FILE")]
-    files: Vec<PathBuf>,
+    /// `MBTiles` files to read from
+    #[arg(required = true, num_args = 1..)]
+    src_files: Vec<PathBuf>,
+    /// `MBTiles` file to write to
+    #[arg(required = true)]
+    dst_file: PathBuf,
     #[command(flatten)]
     pub options: SharedCopyOpts,
     /// Compare source file with this file, and only copy non-identical tiles to destination.
@@ -449,11 +450,8 @@ async fn meta_print_all(file: &Path) -> anyhow::Result<()> {
 
 /// Copies every source file in `args` into the last one, in order.
 async fn copy(args: CopyArgs) -> anyhow::Result<()> {
-    let (dst_file, more) = args
-        .files
-        .split_last()
-        .expect("clap requires the destination");
-    let src_files: Vec<&PathBuf> = std::iter::once(&args.src_file).chain(more).collect();
+    let src_files = &args.src_files;
+    let dst_file = &args.dst_file;
     if src_files.len() > 1 {
         if args.diff_with_file.is_some() || args.apply_patch.is_some() {
             anyhow::bail!(
@@ -560,8 +558,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     ..Default::default()
                 })
             }
@@ -575,12 +573,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("a"),
-                    files: vec![
-                        PathBuf::from("b"),
-                        PathBuf::from("c"),
-                        PathBuf::from("dst_file"),
-                    ],
+                    src_files: vec![PathBuf::from("a"), PathBuf::from("b"), PathBuf::from("c")],
+                    dst_file: PathBuf::from("dst_file"),
                     ..Default::default()
                 })
             }
@@ -604,8 +598,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     options: SharedCopyOpts {
                         min_zoom: Some(1),
                         max_zoom: Some(100),
@@ -624,8 +618,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     options: SharedCopyOpts {
                         strict: true,
                         ..Default::default()
@@ -688,8 +682,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     options: SharedCopyOpts {
                         zoom_levels: vec![3, 7, 1],
                         ..Default::default()
@@ -714,8 +708,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     diff_with_file: Some(PathBuf::from("no_file")),
                     ..Default::default()
                 })
@@ -737,8 +731,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     options: SharedCopyOpts {
                         on_duplicate: Some(CopyDuplicateMode::Override),
                         ..Default::default()
@@ -758,8 +752,8 @@ mod tests {
             Args {
                 verbose: false,
                 command: Copy(CopyArgs {
-                    src_file: PathBuf::from("src_file"),
-                    files: vec![PathBuf::from("dst_file")],
+                    src_files: vec![PathBuf::from("src_file")],
+                    dst_file: PathBuf::from("dst_file"),
                     options: SharedCopyOpts {
                         copy: CopyType::Metadata,
                         ..Default::default()


### PR DESCRIPTION
Closes #965

`mbtiles copy` takes one source, so merging tiles from several files means a chain of copies into the same destination by hand. It now takes any number of source files before the destination and copies them into it in order, using the existing `--on-duplicate` mode to decide which file wins where two hold the same tile, which is why that flag is required for more than one source. `--diff-with-file` and `--apply-patch` keep exactly one source, as the issue settled. The `mbtiles` library API is unchanged.