### PR TITLE
docs(install): list the AUR and Nix packages

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -64,6 +64,7 @@ multipolygon
 multisurface
 mydb
 mypass
+nixpkgs
 notnull
 noto
 onthegomap

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -74,6 +74,8 @@ brew install martin
 martin --help
 ```
 
+Martin is also in Homebrew core, so `brew install martin` works without the tap.
+
 #### Debian packages (x86_64) manually
 
 ```bash
@@ -81,6 +83,24 @@ curl -O https://github.com/maplibre/martin/releases/latest/download/debian-x86_6
 sudo dpkg -i ./debian-x86_64.deb
 martin --help
 rm ./debian-x86_64.deb
+```
+
+#### Arch Linux
+
+The [AUR](https://aur.archlinux.org/packages/martin) carries `martin` and `martin-cp`, maintained by the community.
+With an AUR helper such as `yay`:
+
+```bash
+yay -S martin
+martin --help
+```
+
+#### Nix
+
+[nixpkgs](https://search.nixos.org/packages?query=martin) carries `martin`, usually a release or two behind.
+
+```bash
+nix-shell -p martin --run 'martin --help'
 ```
 
 ### Building from source

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -66,15 +66,14 @@ to [improve packaging for various platforms](https://github.com/maplibre/martin/
 
 #### Homebrew
 
-If you are using macOS and [Homebrew](https://brew.sh/) you can install martin using Homebrew tap.
+If you are using [Homebrew](https://brew.sh/) you can install martin using
 
 ```bash
 brew tap maplibre/martin
 brew install martin
+brew install martin
 martin --help
 ```
-
-Martin is also in Homebrew core, so `brew install martin` works without the tap.
 
 #### Debian packages (x86_64) manually
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -69,8 +69,6 @@ to [improve packaging for various platforms](https://github.com/maplibre/martin/
 If you are using [Homebrew](https://brew.sh/) you can install martin using
 
 ```bash
-brew tap maplibre/martin
-brew install martin
 brew install martin
 martin --help
 ```


### PR DESCRIPTION
Works towards #578

The installation page knew the Homebrew tap and the .deb, while Martin has also been in Homebrew core since Homebrew/homebrew-core#206380, on the AUR as `martin` and `martin-cp`, and in nixpkgs. This adds those three, each with the one command that installs it.
