### PR TITLE
ci(hotpath): install the hotpath-utils CLI at the version Cargo.lock pins

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -41,7 +41,11 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Install hotpath-utils CLI
-        run: cargo install hotpath --features=utils --bin hotpath-utils --locked
+        # The version Cargo.lock pins, so the CLI reads the metrics the profile wrote
+        run: |
+          set -euo pipefail
+          version=$(grep -A1 '^name = "hotpath"$' Cargo.lock | tail -1 | sed 's/version = "\(.*\)"/\1/')
+          cargo install "hotpath@$version" --features=utils --bin hotpath-utils --locked
 
       - name: Post PR comment
         env:


### PR DESCRIPTION
Every Hotpath comment run since 2026-09-03 22:12Z fails on "Failed to parse /tmp/metrics/base_timing.json: missing field `location`", the last green one being 21:23Z that day. The comment job installs the newest hotpath-utils from crates.io while the profile job writes its metrics with the hotpath 0.24.0 martin depends on, and hotpath 0.25.0, published at 22:12Z, changed the metrics format. The install now reads the version from Cargo.lock, so the reader stays in step with the writer whenever the dependency moves.
