### PR TITLE
fix(reload): flake fix: recover when a project directory is removed mid-rescan

### DIFF
--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -2,6 +2,7 @@
 //! Each kind differs only by its extension list and a build closure.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -378,7 +379,13 @@ impl FsDiscovery {
             if !visited.insert(dir.clone()) {
                 continue;
             }
-            let mut entries = fs::read_dir(&dir).await.map_err(SourceBuildError::Io)?;
+            let mut entries = match fs::read_dir(&dir).await {
+                Ok(entries) => entries,
+                // A directory queued by this walk can be gone by the time it is read, and the
+                // event for its removal brings the next scan.
+                Err(error) if error.kind() == io::ErrorKind::NotFound && dir != root => continue,
+                Err(error) => return Err(SourceBuildError::Io(error)),
+            };
             while let Some(entry) = entries.next_entry().await.map_err(SourceBuildError::Io)? {
                 let Some(e) = resolve_dir_entry(&entry) else {
                     continue;


### PR DESCRIPTION
`Test on ubuntu-latest` flakes on `reload_publishes_and_removes_a_project_of_a_collection`, most recently on #3244, with `WARN reload discovery failed; retaining baseline error=Io(Os { code: 2, kind: NotFound ... })`. The test removes a project directory while a rescan is walking its collection, the walk had already queued that directory, and reading it fails. The removal's own event brings the next scan, so the walk now skips a queued directory it can no longer read instead of failing the whole discovery. The root directory still fails as before. Same family as #3240.
