### PR TITLE
fix(mbtiles): CI flake: keep the embedded SQL schemas LF on every checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 martin/martin-ui/src/lib/types.gen.ts linguist-generated=true
 schemas/config.json linguist-generated=true
 schemas/openapi.json linguist-generated=true
+*.sql text eol=lf


### PR DESCRIPTION
`Unit test the server (windows-latest)` fails on main since #3255, 155 of the mbtiles `copy` tests, every one a dump snapshot whose `CREATE TABLE` text now carries `\r\n`. The schema files under `mbtiles/sql/` are embedded with `include_str!`, so a CRLF checkout puts the carriage returns into the SQLite schema itself. The job never ran on main before #3255 corrected the matrix expression (the old one always evaluated to the ubuntu and macOS list), which is why the first Windows run is the first red one. One `.gitattributes` line keeps `.sql` files LF on every checkout; verified on a Windows 11 box with `core.autocrlf=true`, rustc 1.98.1: `cargo test -p mbtiles --test copy` on main fails 155 of 156 exactly as the CI job does, with 7 carriage returns in `init-flat.sql`; on this branch, after renormalizing the checkout, all 156 pass and the file has none.