### PR TITLE
fix(reload): flake fix: skip a collection project removed mid-rescan

### DIFF
--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -261,9 +261,22 @@ impl Discovery for FsDiscovery {
         for collection in &self.collections {
             let root = collection.canonicalize().map_err(SourceBuildError::Io)?;
             for (project, dir) in subdirectories(&root).map_err(SourceBuildError::Io)? {
-                let dir = dir.canonicalize().map_err(SourceBuildError::Io)?;
-                self.scan(&dir, &format!("{project}."), &mut discovered)
-                    .await?;
+                // A project listed a moment ago can be gone by the time it is read, and the
+                // event for its removal brings the next scan.
+                let dir = match dir.canonicalize() {
+                    Ok(dir) => dir,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(SourceBuildError::Io(error)),
+                };
+                match self
+                    .scan(&dir, &format!("{project}."), &mut discovered)
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(SourceBuildError::Io(error)) if error.kind() == io::ErrorKind::NotFound => {
+                    }
+                    Err(error) => return Err(error),
+                }
             }
         }
 


### PR DESCRIPTION
Same family as #3240 and #3258. `reload_publishes_and_removes_a_project_of_a_collection` removes a project directory while the scan its creation queued can still be running. The collection walk lists the projects and then canonicalizes and reads each one, so a project gone in between fails the whole discovery with `NotFound`, the reload keeps its baseline and logs a warning, and the harness fails the test on that warning (seen on the arm64 docker leg of #3261, where everything runs slower). A project that is gone by the time it is read is now skipped and the event for its removal brings the next scan, exactly what #3258 does for a directory queued inside one scan. A missing collection root still fails as before.