### PR TITLE
test: make the Windows-only unit test job pass again

### DIFF
--- a/e2e-tests/tests/mbtiles.rs
+++ b/e2e-tests/tests/mbtiles.rs
@@ -1,6 +1,8 @@
 //! `MBTiles` sources, both configured up front and served from a watched directory.
 
-use martin_e2e_tests::{Martin, WatchedDir, fixture, mbtiles_fixture, mbtiles_from_sql};
+use martin_e2e_tests::{Martin, WatchedDir, mbtiles_fixture};
+#[cfg(not(windows))]
+use martin_e2e_tests::{fixture, mbtiles_from_sql};
 use rstest::rstest;
 use tempfile::TempDir;
 

--- a/martin-core/src/resources/styles/mod.rs
+++ b/martin-core/src/resources/styles/mod.rs
@@ -250,7 +250,15 @@ mod tests {
         );
         assert_eq!(styles.sources.len(), 3);
 
-        let catalog = styles.get_catalog();
+        let mut catalog = styles.get_catalog();
+        // The catalog keeps the paths as joined, so on Windows they hold backslashes.
+        for entry in catalog.values_mut() {
+            entry.path = entry
+                .path
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/")
+                .into();
+        }
 
         insta::with_settings!({sort_maps => true}, {
         insta::assert_json_snapshot!(catalog, @r#"

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -200,8 +200,23 @@ fn list_contained_files(
 mod tests {
     use indoc::indoc;
 
+    use martin_core::styles::StyleCatalog;
+
     use super::*;
     use crate::config::file::FileConfigSrc;
+
+    /// The catalog keeps the paths as joined, so on Windows they hold backslashes.
+    fn catalog_with_forward_slashes(styles: &StyleSources) -> StyleCatalog {
+        let mut catalog = styles.get_catalog();
+        for entry in catalog.values_mut() {
+            entry.path = entry
+                .path
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/")
+                .into();
+        }
+        catalog
+    }
 
     #[test]
     fn styles_parse_paths_only_without_rendering_field() {
@@ -265,7 +280,7 @@ mod tests {
         let styles = cfg.resolve().unwrap();
         assert_eq!(styles.len(), 3);
         insta::with_settings!({sort_maps => true}, {
-        insta::assert_yaml_snapshot!(styles.get_catalog(), @r#"
+        insta::assert_yaml_snapshot!(catalog_with_forward_slashes(&styles), @r#"
         maplibre_demo:
           path: "../tests/fixtures/styles/maplibre_demo.json"
         maptiler_basic:
@@ -296,7 +311,7 @@ mod tests {
         let styles = cfg.resolve().unwrap();
         assert_eq!(styles.len(), 2);
         insta::with_settings!({sort_maps => true}, {
-        insta::assert_yaml_snapshot!(styles.get_catalog(), @r#"
+        insta::assert_yaml_snapshot!(catalog_with_forward_slashes(&styles), @r#"
         maplibre_demo:
           path: "../tests/fixtures/styles/maplibre_demo.json"
         osm-liberty-lite:
@@ -316,7 +331,7 @@ mod tests {
         let styles = cfg.resolve().unwrap();
         assert_eq!(styles.len(), 3);
 
-        let catalog = styles.get_catalog();
+        let catalog = catalog_with_forward_slashes(&styles);
 
         insta::with_settings!({sort_maps => true}, {
         insta::assert_json_snapshot!(catalog, @r#"

--- a/martin/src/config/file/tiles/discovery/fs.rs
+++ b/martin/src/config/file/tiles/discovery/fs.rs
@@ -654,7 +654,13 @@ mod tests {
             .expect("canonicalize")
             .to_string_lossy()
             .to_string();
-        assert_yaml_snapshot!(error.to_string().replace(&prefix, "<DIR>"), @r#""Source path is not a file: <DIR>/bad_0.mbtiles""#);
+        assert_yaml_snapshot!(
+            error
+                .to_string()
+                .replace(&prefix, "<DIR>")
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+            @r#""Source path is not a file: <DIR>/bad_0.mbtiles""#
+        );
     }
 
     #[tokio::test]

--- a/martin/tests/binary_diagnostics.rs
+++ b/martin/tests/binary_diagnostics.rs
@@ -37,7 +37,10 @@ fn run_with_bad_config(yaml: &str, extra_env: &[(&str, &str)]) -> String {
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr was not UTF-8");
     let path = cfg.path().to_str().expect("temp path was not UTF-8");
-    stderr.replace(path, "<config>")
+    // The JSON format escapes the backslashes of a Windows path.
+    stderr
+        .replace(&path.replace('\\', "\\\\"), "<config>")
+        .replace(path, "<config>")
 }
 
 #[test]


### PR DESCRIPTION
The `Unit test the server (windows-latest)` job runs on pushes to main only, and it has been red on every push since aa20fd32: #3260 got it past the CRLF failures, and the next problems were waiting behind them. Five snapshot tests build a path with `Path::join` or take one from a temp file and pin it as written with forward slashes, so on Windows the value comes back with backslashes: `style_external` in martin-core, the three style catalog snapshots in `styles.rs`, the discovery error in `fs.rs`, and the JSON diagnostic in `binary_diagnostics.rs`, where the temp path arrives with its backslashes escaped and the mask never matches. Behind those, the e2e crate imports two helpers only its `cfg(not(windows))` tests use, which the job's deny-warnings mode turns into an error. The tests now replace the platform separator before snapshotting, the way the e2e catalog and geojson tests already do, the diagnostic test masks the escaped form as well, and the two imports carry the same cfg as their users. Verified by running the job's recipe on a Windows machine with warnings denied: every package, the e2e crate and the doc tests pass.
