### PR TITLE
ci(hotpath): benchmark the base commit against its own fixtures

### DIFF
--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -77,14 +77,8 @@ jobs:
       - name: Checkout base
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
-      # The benchmark serves the compose database (the justfile exports DATABASE_URL to it), which
-      # `just start` only creates when it is not already running, so the base run was serving the
-      # head's fixtures. A fixture the head adds and the base cannot serve then failed the base run.
       - name: Drop the head's database so the base run loads its own fixtures
         run: just stop
-
-      - name: Clean slate to not have codegen cache artefact bias
-        run: cargo clean
 
       - name: Check base has hotpath support
         id: base-check

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -77,6 +77,12 @@ jobs:
       - name: Checkout base
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
+      # The benchmark serves the compose database (the justfile exports DATABASE_URL to it), which
+      # `just start` only creates when it is not already running, so the base run was serving the
+      # head's fixtures. A fixture the head adds and the base cannot serve then failed the base run.
+      - name: Drop the head's database so the base run loads its own fixtures
+        run: just stop
+
       - name: Clean slate to not have codegen cache artefact bias
         run: cargo clean
 


### PR DESCRIPTION
The profile job benchmarks the base binary against the database the head run left behind. `bench-server-hotpath` depends on `just start`, which only creates the compose database when it is not already running, and the justfile exports `DATABASE_URL` to that database, so the workflow's own PostgreSQL service is never what the benchmark serves. A fixture the head adds and the base cannot serve therefore fails the base run instead of the comparison. #3261 hit this: its Mars table has a non-EPSG SRID, main's bounds query on it is fatal at startup, and `Benchmark base` died with `Postgres error while querying table bounds`. Stopping the compose database after the base checkout makes `just start` recreate it from the base's fixtures. The head run is unchanged, and a base without hotpath support still skips as before.
