### PR TITLE
fix: generate the config schema identically on every OS

### DIFF
--- a/justfile
+++ b/justfile
@@ -109,12 +109,20 @@ gen-schemas: fetch
     cargo build --quiet --features unstable-schemas --bin gen-schemas
     gen="${CARGO_TARGET_DIR:-target}/debug/gen-schemas"
     "$gen" --target config      > schemas/config.json
-    "$gen" --target openapi     > schemas/openapi.json
     # The annotated config doc (markdown wrapping a fenced YAML block) is
     # derived from `schemas/config.json` and the `#[schemars(example = ...)]`
     # attributes - keep it generated and version-controlled so editors can lean
     # on it as a starting point.
     "$gen" --target config-doc  > docs/content/files/generated_config.md
+    if [[ "{{os()}}" != linux ]]; then
+        # The rendering routes only exist in Linux builds, so the OpenAPI spec
+        # and the TS types derived from it can only be regenerated there.
+        echo "not on Linux: leaving schemas/openapi.json and martin/martin-ui/src/lib/types.gen.ts untouched"
+        {{just}} ui::_npm-install
+        martin/martin-ui/node_modules/.bin/biome check --write schemas/config.json
+        exit 0
+    fi
+    "$gen" --target openapi     > schemas/openapi.json
     # Regenerate `martin/martin-ui/src/lib/types.gen.ts` from the freshly
     # written `schemas/openapi.json`. Kept after the cargo runs so the spec
     # is up-to-date by the time `openapi-typescript` reads it.

--- a/martin/src/config/file/resources/styles.rs
+++ b/martin/src/config/file/resources/styles.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
@@ -13,7 +13,7 @@ use crate::config::file::{
     CollectUnrecognizedKeys, ConfigFileError, ConfigFileResult, ConfigurationLivecycleHooks,
     FileConfigEnum, UnrecognizedValues, subdirectories,
 };
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 use crate::config::primitives::OptBoolObj;
 
 #[derive(
@@ -34,7 +34,7 @@ pub struct InnerStyleConfig {
     /// Note on EXPERIMENTAL status:
     /// We are not currently happy with the performance of this endpoint and intend to improve this in the future
     /// Marking this experimental means that we are not stuck with single threaded performance as a default until v2.0
-    #[cfg(all(feature = "rendering", target_os = "linux"))]
+    #[cfg(feature = "rendering")]
     #[serde(default, skip_serializing_if = "OptBoolObj::is_none")]
     pub rendering: OptBoolObj<RendererConfig>,
 
@@ -43,7 +43,7 @@ pub struct InnerStyleConfig {
     pub unrecognized: UnrecognizedValues,
 }
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[derive(
     Clone,
     Debug,
@@ -100,6 +100,14 @@ impl StyleConfig {
                 results
                     .enable_rendering(o.workers)
                     .map_err(ConfigFileError::RendererPoolSpawnFailed)?;
+            }
+        }
+        #[cfg(all(feature = "rendering", not(target_os = "linux")))]
+        match cfg.custom.rendering {
+            OptBoolObj::NoValue | OptBoolObj::Bool(false) => {}
+            OptBoolObj::Object(ref o) if !o.enabled => {}
+            OptBoolObj::Bool(true) | OptBoolObj::Object(_) => {
+                warn!("rendering is configured, but only available in Linux builds. Ignoring it.");
             }
         }
 
@@ -234,7 +242,7 @@ mod tests {
         assert_eq!(paths, vec![PathBuf::from("/data")]);
     }
 
-    #[cfg(all(feature = "rendering", target_os = "linux"))]
+    #[cfg(feature = "rendering")]
     #[test]
     fn renderer_config_parses_workers() {
         use std::num::NonZeroUsize;
@@ -252,7 +260,7 @@ mod tests {
         assert_eq!(renderer.workers, NonZeroUsize::new(4));
     }
 
-    #[cfg(all(feature = "rendering", target_os = "linux"))]
+    #[cfg(feature = "rendering")]
     #[test]
     fn renderer_config_rejects_zero_workers() {
         let yaml = indoc! {"


### PR DESCRIPTION
`just gen-schemas` on macOS or Windows drops the `styles.rendering` block from `schemas/config.json` and `generated_config.md`, so config-field PRs from those machines always got an autofix-ci commit on top (#3229, #3230, #3231).
`RendererConfig` and the field were gated on `target_os = "linux"` as well as the `rendering` feature, although only the renderer itself needs Linux.
Gate them on the feature alone, keep the render pool Linux-only, and warn that rendering is Linux-only where `styles.rendering` used to land in unrecognized keys.
Off Linux, `gen-schemas` now leaves `schemas/openapi.json` and `types.gen.ts` untouched and says so, since the rendering routes only exist there.

| Platform | `just gen-schemas` result against the committed files |
|----------|--------------------------------------------------------|
| macOS 15 arm64 | `config.json` + `generated_config.md` identical, OpenAPI half skipped |
| Windows 11 x86_64 | `config.json` + `generated_config.md` identical (fresh shallow clone, `gen-schemas --target config` / `config-doc`) |
| Linux arm64, fresh clone (the autofix-ci job shape) | all four generated files identical after the full recipe (npm install, gen-types, biome) |