### PR TITLE
fix: generate the OpenAPI spec identically on every OS

### DIFF
--- a/justfile
+++ b/justfile
@@ -114,14 +114,6 @@ gen-schemas: fetch
     # attributes - keep it generated and version-controlled so editors can lean
     # on it as a starting point.
     "$gen" --target config-doc  > docs/content/files/generated_config.md
-    if [[ "{{os()}}" != linux ]]; then
-        # The rendering routes only exist in Linux builds, so the OpenAPI spec
-        # and the TS types derived from it can only be regenerated there.
-        echo "not on Linux: leaving schemas/openapi.json and martin/martin-ui/src/lib/types.gen.ts untouched"
-        {{just}} ui::_npm-install
-        martin/martin-ui/node_modules/.bin/biome check --write schemas/config.json
-        exit 0
-    fi
     "$gen" --target openapi     > schemas/openapi.json
     # Regenerate `martin/martin-ui/src/lib/types.gen.ts` from the freshly
     # written `schemas/openapi.json`. Kept after the cargo runs so the spec

--- a/martin/src/schemas.rs
+++ b/martin/src/schemas.rs
@@ -48,7 +48,7 @@ pub struct MartinOpenApi;
 
 /// Style-rendering routes - in their own derive so the rest of the API can
 /// generate schemas without pulling in the `rendering` feature's C++ build.
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[derive(OpenApi)]
 #[openapi(paths(
     crate::srv::get_rendered_tile_style,
@@ -61,7 +61,7 @@ struct MartinRenderingOpenApi;
 #[must_use]
 pub fn openapi_spec() -> serde_json::Value {
     let openapi = MartinOpenApi::openapi();
-    #[cfg(all(feature = "rendering", target_os = "linux"))]
+    #[cfg(feature = "rendering")]
     let openapi = openapi.merge_from(MartinRenderingOpenApi::openapi());
     serde_json::to_value(&openapi).expect("OpenAPI doc is always serialisable")
 }

--- a/martin/src/srv/admin.rs
+++ b/martin/src/srv/admin.rs
@@ -46,7 +46,7 @@ pub struct Catalog {
 )]
 pub struct CatalogSettings {
     /// Whether server-side style rendering endpoints are enabled.
-    #[cfg(all(feature = "rendering", feature = "styles", target_os = "linux"))]
+    #[cfg(all(feature = "rendering", feature = "styles"))]
     pub rendering: bool,
 }
 
@@ -66,6 +66,8 @@ impl Catalog {
             settings: CatalogSettings {
                 #[cfg(all(feature = "rendering", feature = "styles", target_os = "linux"))]
                 rendering: state.styles.is_rendering_enabled(),
+                #[cfg(all(feature = "rendering", feature = "styles", not(target_os = "linux")))]
+                rendering: false,
             },
         })
     }

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -53,28 +53,20 @@ mod styles;
 #[cfg(all(feature = "styles", feature = "unstable-schemas"))]
 pub use styles::{__path_get_style_json, get_style_json};
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 mod styles_rendering;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 pub use styles_rendering::redirect_tile_jpeg;
-#[cfg(all(
-    feature = "rendering",
-    target_os = "linux",
-    feature = "unstable-schemas"
-))]
+#[cfg(all(feature = "rendering", feature = "unstable-schemas"))]
 pub use styles_rendering::{__path_get_rendered_tile_style, get_rendered_tile_style};
 
 #[cfg(feature = "overlay")]
 mod overlay_body;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 mod styles_static;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 pub use styles_static::redirect_static_jpeg;
-#[cfg(all(
-    feature = "rendering",
-    target_os = "linux",
-    feature = "unstable-schemas"
-))]
+#[cfg(all(feature = "rendering", feature = "unstable-schemas"))]
 pub use styles_static::{
     __path_get_rendered_static_style, __path_post_rendered_static_style, get_rendered_static_style,
     post_rendered_static_style,

--- a/martin/src/srv/styles_rendering.rs
+++ b/martin/src/srv/styles_rendering.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    not(target_os = "linux"),
+    expect(
+        dead_code,
+        reason = "the routes are registered on Linux only, the module is compiled so utoipa can describe them"
+    )
+)]
+
 use std::io::Cursor;
 
 use actix_web::http::header::{ContentType, LOCATION};
@@ -105,8 +113,6 @@ pub async fn get_rendered_tile_style(
     path: Path<StyleRenderRequest>,
     styles: Data<StyleSources>,
 ) -> HttpResponse {
-    use martin_core::styles::StyleError;
-
     let style_id = &path.style_id;
     let Some(style_path) = styles.style_json_path(style_id) else {
         return HttpResponse::NotFound()
@@ -123,24 +129,33 @@ pub async fn get_rendered_tile_style(
         style_path.display()
     );
 
-    let image = styles.render(style_path, zxy.z, zxy.x, zxy.y).await;
-    let image = match image {
-        Ok(image) => image,
-        Err(StyleError::RenderingIsDisabled) => {
-            warn!("Failed to render style {style_id} because rendering is disabled");
-            return HttpResponse::Forbidden()
-                .content_type(ContentType::plaintext())
-                .body(format!("Failed to render style {style_id} at {zxy} is forbidden as rendering is disabled"));
-        }
-        Err(e) => {
-            error!("Failed to render style {style_id} at {zxy}: {e}");
-            return HttpResponse::InternalServerError()
-                .content_type(ContentType::plaintext())
-                .body("Failed to render style");
+    #[cfg(target_os = "linux")]
+    let response = {
+        use martin_core::styles::StyleError;
+
+        match styles.render(style_path, zxy.z, zxy.x, zxy.y).await {
+            Ok(image) => encode_image_response(image.as_image(), path.format),
+            Err(StyleError::RenderingIsDisabled) => rendering_disabled(style_id, zxy),
+            Err(e) => {
+                error!("Failed to render style {style_id} at {zxy}: {e}");
+                HttpResponse::InternalServerError()
+                    .content_type(ContentType::plaintext())
+                    .body("Failed to render style")
+            }
         }
     };
+    #[cfg(not(target_os = "linux"))]
+    let response = rendering_disabled(style_id, zxy);
+    response
+}
 
-    encode_image_response(image.as_image(), path.format)
+fn rendering_disabled(style_id: &str, zxy: TileCoord) -> HttpResponse {
+    warn!("Failed to render style {style_id} because rendering is disabled");
+    HttpResponse::Forbidden()
+        .content_type(ContentType::plaintext())
+        .body(format!(
+            "Failed to render style {style_id} at {zxy} is forbidden as rendering is disabled"
+        ))
 }
 
 /// `.jpeg` to `.jpg` redirect

--- a/martin/src/srv/styles_static.rs
+++ b/martin/src/srv/styles_static.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    not(target_os = "linux"),
+    expect(
+        dead_code,
+        unused_variables,
+        clippy::unused_async,
+        reason = "the routes are registered on Linux only, the module is compiled so utoipa can describe them"
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -9,14 +19,20 @@ use actix_web::http::header::{ContentType, LOCATION};
 use actix_web::web::{Bytes, Data, Path};
 use actix_web::{FromRequest, HttpRequest, HttpResponse, route};
 use martin_core::overlay::OverlaySpec;
-use martin_core::styles::{RenderParams, StyleSources};
+#[cfg(target_os = "linux")]
+use martin_core::styles::RenderParams;
+use martin_core::styles::StyleSources;
 use martin_tile_utils::{EARTH_CIRCUMFERENCE, wgs84_to_webmercator};
 use serde::Deserialize;
-use tracing::{debug, error, warn};
+#[cfg(target_os = "linux")]
+use tracing::error;
+use tracing::{debug, warn};
 
 use crate::srv::overlay_body::parse_overlay;
 use crate::srv::server::DebouncedWarning;
-use crate::srv::styles_rendering::{ImageFormatRequest, encode_image_response};
+use crate::srv::styles_rendering::ImageFormatRequest;
+#[cfg(target_os = "linux")]
+use crate::srv::styles_rendering::encode_image_response;
 
 #[derive(Deserialize, Debug)]
 #[cfg_attr(feature = "unstable-schemas", derive(utoipa::IntoParams))]
@@ -400,12 +416,21 @@ async fn handle_static_request(
         "Rendering static image"
     );
 
-    let image = match render_with_overlays(styles, style_path, &camera, size, overlays).await {
-        Ok(img) => img,
-        Err(resp) => return *resp,
+    #[cfg(target_os = "linux")]
+    let response = match render_with_overlays(styles, style_path, &camera, size, overlays).await {
+        Ok(image) => encode_image_response(image.as_image(), path.format),
+        Err(resp) => *resp,
     };
+    #[cfg(not(target_os = "linux"))]
+    let response = rendering_disabled();
+    response
+}
 
-    encode_image_response(image.as_image(), path.format)
+fn rendering_disabled() -> HttpResponse {
+    warn!("Failed to render static image because rendering is disabled");
+    HttpResponse::Forbidden()
+        .content_type(ContentType::plaintext())
+        .body("Rendering is disabled")
 }
 
 fn resolve_camera(camera: CameraRequest, size: SizeRequest) -> Camera {
@@ -479,6 +504,7 @@ fn bbox_to_center_zoom(
     (center_lon, center_lat, zoom)
 }
 
+#[cfg(target_os = "linux")]
 async fn render_with_overlays(
     styles: &StyleSources,
     style_path: std::path::PathBuf,
@@ -501,12 +527,7 @@ async fn render_with_overlays(
     .with_overlays(overlays);
     styles.render_static(params).await.map_err(|e| {
         Box::new(match e {
-            StyleError::RenderingIsDisabled => {
-                warn!("Failed to render static image because rendering is disabled");
-                HttpResponse::Forbidden()
-                    .content_type(ContentType::plaintext())
-                    .body("Rendering is disabled")
-            }
+            StyleError::RenderingIsDisabled => rendering_disabled(),
             StyleError::OverlayApply(err) => {
                 warn!("Overlay application failed: {err}");
                 HttpResponse::BadRequest()

--- a/martin/tests/geojson_server_test.rs
+++ b/martin/tests/geojson_server_test.rs
@@ -3,7 +3,7 @@
 use actix_web::http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
 use actix_web::test::{TestRequest, call_service, read_body, read_body_json};
 use indoc::indoc;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 use insta::assert_yaml_snapshot;
 use martin::config::file::srv::SrvConfig;
 use martin_tile_utils::decode_gzip;
@@ -43,7 +43,7 @@ const CONFIG: &str = indoc! {"
                 geo2: ../tests/fixtures/geojson/feature_collection_2.geojson
     "};
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn geojson_get_catalog_with_rendering_feature() {
@@ -66,7 +66,7 @@ async fn geojson_get_catalog_with_rendering_feature() {
     ");
 }
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn geojson_get_catalog_gzip_with_rendering_feature() {

--- a/martin/tests/mb_server_test.rs
+++ b/martin/tests/mb_server_test.rs
@@ -4,7 +4,7 @@
 use actix_web::http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
 use actix_web::test::{TestRequest, call_service, read_body, read_body_json};
 use indoc::formatdoc;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 use insta::assert_yaml_snapshot;
 use martin::config::file::srv::SrvConfig;
 use martin_tile_utils::{decode_brotli, decode_gzip};
@@ -94,7 +94,7 @@ async fn config(
     )
 }
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn mbt_get_catalog_with_rendering_feature() {
@@ -134,7 +134,7 @@ async fn mbt_get_catalog_with_rendering_feature() {
     "#);
 }
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn mbt_get_catalog_gzip_with_rendering_feature() {

--- a/martin/tests/pmt_server_test.rs
+++ b/martin/tests/pmt_server_test.rs
@@ -3,7 +3,7 @@
 use actix_web::http::header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE};
 use actix_web::test::{TestRequest, call_service, read_body, read_body_json};
 use indoc::indoc;
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 use insta::assert_yaml_snapshot;
 use martin::config::file::srv::SrvConfig;
 use martin_tile_utils::decode_gzip;
@@ -45,7 +45,7 @@ const CONFIG: &str = indoc! {"
                 s3: s3://pmtilestest/cb_2018_us_zcta510_500k.pmtiles
     "};
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn pmt_get_catalog_with_rendering_feature() {
@@ -68,7 +68,7 @@ async fn pmt_get_catalog_with_rendering_feature() {
     ");
 }
 
-#[cfg(all(feature = "rendering", target_os = "linux"))]
+#[cfg(feature = "rendering")]
 #[actix_rt::test]
 #[tracing_test::traced_test]
 async fn pmt_get_catalog_gzip_with_rendering_feature() {


### PR DESCRIPTION
`just gen-schemas` on macOS or Windows drops the three style-rendering routes from `schemas/openapi.json` and `types.gen.ts`, so route PRs from those machines still get the autofix-ci commit that #3276 removed for the config schema.
The rendering handler modules were compiled on Linux only, and utoipa can only describe a route whose handler exists.
Compile them wherever the `rendering` feature is on, keep route registration and the renderer calls Linux-only, and answer with the existing "rendering is disabled" 403 elsewhere.
The catalog's `settings.rendering` flag, which the committed spec already promises, follows the feature too and reads `false` where the renderer cannot run.
Drop the Linux-only branch `gen-schemas` gained in #3276.

| Platform | `just gen-schemas` result against the committed files |
|----------|--------------------------------------------------------|
| macOS 15 arm64 | all four generated files identical, full recipe |
| Windows 11 x86_64 | `openapi.json` + `config.json` identical (fresh clone) |
| Linux arm64, fresh clone (the autofix-ci job shape) | all four generated files identical, full recipe |