### PR TITLE
ci: attach the binaries before the release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,36 @@ jobs:
             mv "$dir" "target/$target"
             just package-assets "$target"
           done
+      - name: Save the packaged binaries for release-plz
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with: { name: 'release-files', path: 'target/files/*', retention-days: 1 }
+
+      # release-plz attaches the binaries before it publishes, so a release event
+      # only has to upload them when someone published a draft by hand.
+      - name: Look up the release
+        if: github.event_name == 'release'
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          assets=$(gh release view "$RELEASE_TAG_NAME" --json assets --jq '.assets | length')
+          if [[ "$assets" -gt 0 ]]; then
+            echo "has_assets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_assets=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Use the published binaries for the Homebrew checksums
+        if: github.event_name == 'release' && steps.release.outputs.has_assets == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          rm -rf target/files
+          gh release download "$RELEASE_TAG_NAME" --dir target/files
 
       - name: Create Homebrew config
         run: |
@@ -90,11 +120,11 @@ jobs:
         with: { name: 'homebrew-config', path: 'target/homebrew_config.yaml' }
 
       - name: Generate SLSA build provenance attestation
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.release.outputs.has_assets == 'false'
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with: { subject-path: 'target/files/*' }
       - name: Publish with artifacts
-        if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'martin-v') }}
+        if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'martin-v') && steps.release.outputs.has_assets == 'false' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
@@ -170,6 +200,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
@@ -184,6 +215,35 @@ jobs:
         with: { command: release }
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Download the packaged binaries
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { name: 'release-files', path: 'target/files' }
+      - name: Generate SLSA build provenance attestation
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with: { subject-path: 'target/files/*' }
+      - name: Attach the binaries and publish the drafted releases
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          # A PAT, so that publishing fires `release: published` for the docker tags
+          # and the Homebrew PR. Events created with GITHUB_TOKEN start no workflow.
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          RELEASES: ${{ steps.release.outputs.releases }}
+        run: |
+          set -euo pipefail
+          for tag in $(jq -r '.[].tag' <<< "$RELEASES"); do
+            if ! gh release view "$tag" --json isDraft --jq '.isDraft' | grep -qx true; then
+              echo "$tag has no draft release to publish, skipping"
+              continue
+            fi
+            if [[ "$tag" == martin-v* ]]; then
+              gh release upload "$tag" target/files/*
+              gh release edit "$tag" --verify-tag --draft=false --latest
+            else
+              gh release edit "$tag" --verify-tag --draft=false --latest=false
+            fi
+          done
       - if: ${{ steps.release.outputs.releases_created == 'false' }}
         name: If version is the same, create a PR proposing new version and changelog for the next release
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131


### PR DESCRIPTION
`martin-v1.16.0` went out with no binaries, and main's docs job has been red on every push since: the draft was published by hand before its upload ran, and that run's docs job 404s on every `releases/latest/download/*` link while an empty release is latest, which since #3255 skips the release job (https://github.com/maplibre/martin/actions/runs/34157558587).

release-plz.toml describes draft, attach, attest, then publish, but release.yml only attached on `release: published`, so a hand publish was always the first step. Now the push run that drafted the release attaches, attests and publishes it, with the release-plz PAT so the event still fires for the docker tags and the Homebrew PR. The release-event run uploads only for a draft someone published by hand, and takes the Homebrew checksums from the published assets, so attested files are never clobbered.

The publish loop and the asset lookup were run locally against 1.15.0 and 1.16.0 with `gh release view`; the workflow itself only runs on a real release.
