### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "martin"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "martin-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "actix-web",
  "approx",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "mbtiles"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ lambda-web = { version = "0.2.1", features = ["actix4"] }
 log = "0.4"
 maplibre_native = "0.9.0"
 martin-config-macros = { path = "./martin-config-macros", version = "0.1.1" }
-martin-core = { path = "./martin-core", version = "0.11.2", default-features = false }
+martin-core = { path = "./martin-core", version = "0.11.3", default-features = false }
 martin-tile-utils = { path = "./martin-tile-utils", version = "0.7.8" }
-mbtiles = { path = "./mbtiles", version = "0.19.3" }
+mbtiles = { path = "./mbtiles", version = "0.19.4" }
 md5 = "0.8.0"
 miette = { version = "7.6", features = ["fancy"] }
 mlt-core = { version = "0.12.3", default-features = false }

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./certs:/etc/ssl/certs
 
   tiles:
-    image: ghcr.io/maplibre/martin:1.16.1
+    image: ghcr.io/maplibre/martin:1.17.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/files/compose.nginx.yaml
+++ b/docs/content/files/compose.nginx.yaml
@@ -11,7 +11,7 @@ services:
       - martin
 
   martin:
-    image: ghcr.io/maplibre/martin:1.16.1
+    image: ghcr.io/maplibre/martin:1.17.0
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgres://postgres:password@db/db

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -22,7 +22,7 @@ docker run -p 3000:3000 \
            -e PGPASSWORD \
            -e DATABASE_URL=postgres://user@host:port/db \
            -v /path/to/config/dir:/config \
-           ghcr.io/maplibre/martin:1.16.1 \
+           ghcr.io/maplibre/martin:1.17.0 \
            --config /config/config.yaml
 ```
 

--- a/docs/content/run-with-docker-compose.md
+++ b/docs/content/run-with-docker-compose.md
@@ -14,7 +14,7 @@ file as a reference
 ```yml
 services:
   martin:
-    image: ghcr.io/maplibre/martin:1.16.1
+    image: ghcr.io/maplibre/martin:1.17.0
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/docs/content/run-with-docker.md
+++ b/docs/content/run-with-docker.md
@@ -15,7 +15,7 @@ You can use official Docker image [`ghcr.io/maplibre/martin`](https://ghcr.io/ma
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@postgres.example.org/db \
-  ghcr.io/maplibre/martin:1.16.1
+  ghcr.io/maplibre/martin:1.17.0
 ```
 
 ### Exposing Local Files
@@ -26,7 +26,7 @@ You can expose local files to the Docker container using the `-v` flag.
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.16.1 \
+  ghcr.io/maplibre/martin:1.17.0 \
   /files
 ```
 
@@ -36,7 +36,7 @@ You can also pass any [CLI flags](run-with-cli.md) after the image name, for exa
 docker run \
   -p 3000:3000 \
   -v /path/to/local/files:/files \
-  ghcr.io/maplibre/martin:1.16.1 \
+  ghcr.io/maplibre/martin:1.17.0 \
   --webui enable-for-all \
   /files
 ```
@@ -53,7 +53,7 @@ You would not need to export ports with `-p` because the container is already us
 docker run \
   --net=host \
   -e DATABASE_URL=postgres://postgres@localhost/db \
-  ghcr.io/maplibre/martin:1.16.1
+  ghcr.io/maplibre/martin:1.17.0
 ```
 
 ### Accessing Local PostgreSQL on macOS
@@ -64,7 +64,7 @@ For macOS, use `host.docker.internal` as hostname to access the `localhost` Post
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@host.docker.internal/db \
-  ghcr.io/maplibre/martin:1.16.1
+  ghcr.io/maplibre/martin:1.17.0
 ```
 
 ### Accessing Local PostgreSQL on Windows
@@ -75,5 +75,5 @@ For Windows, use `docker.for.win.localhost` as hostname to access the `localhost
 docker run \
   -p 3000:3000 \
   -e DATABASE_URL=postgres://postgres@docker.for.win.localhost/db \
-  ghcr.io/maplibre/martin:1.16.1
+  ghcr.io/maplibre/martin:1.17.0
 ```

--- a/docs/content/run-with-lambda.md
+++ b/docs/content/run-with-lambda.md
@@ -24,13 +24,13 @@ The CloudShell also runs in a particular AWS region.
 Lambda images must come from a public or private ECR registry. Pull the image from GHCR and push it to ECR.
 
 ```bash
-$ docker pull ghcr.io/maplibre/martin:1.16.1 --platform linux/arm64
+$ docker pull ghcr.io/maplibre/martin:1.17.0 --platform linux/arm64
 $ aws ecr create-repository --repository-name martin
 […]
         "repositoryUri": "493749042871.dkr.ecr.us-east-2.amazonaws.com/martin",
 
 # Read the repositoryUri which includes your account number
-$ docker tag ghcr.io/maplibre/martin:1.16.1 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
+$ docker tag ghcr.io/maplibre/martin:1.17.0 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest
 $ aws ecr get-login-password --region us-east-2 \
   | docker login --username AWS --password-stdin 493749042871.dkr.ecr.us-east-2.amazonaws.com
 $ docker push 493749042871.dkr.ecr.us-east-2.amazonaws.com/martin:latest

--- a/justfile
+++ b/justfile
@@ -387,7 +387,7 @@ debug-page *args: start
 
 # Build and run martin docker image
 docker-run *args:
-    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.16.1 {{args}}
+    docker run -it --rm --net host -e DATABASE_URL -v $PWD/tests:/tests ghcr.io/maplibre/martin:1.17.0 {{args}}
 
 # Build and run martin documentation
 docs:

--- a/martin-core/CHANGELOG.md
+++ b/martin-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/maplibre/martin/compare/martin-core-v0.11.2...martin-core-v0.11.3) - 2026-09-10
+
+### Other
+
+- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
+
 ## [0.11.2](https://github.com/maplibre/martin/compare/martin-core-v0.11.1...martin-core-v0.11.2) - 2026-09-06
 
 ### Added

--- a/martin-core/Cargo.toml
+++ b/martin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin-core"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "Basic building blocks of MapLibre's Martin tile server."
 keywords = ["maps", "tiles", "mvt", "tileserver"]

--- a/martin/CHANGELOG.md
+++ b/martin/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0](https://github.com/maplibre/martin/compare/martin-v1.16.1...martin-v1.17.0) - 2026-09-10
+
+### Added
+
+- *(cog)* detect and reload replaced remote objects ([#3268](https://github.com/maplibre/martin/pull/3268))
+
+### Other
+
+- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
+
 ## [1.16.1](https://github.com/maplibre/martin/compare/martin-v1.16.0...martin-v1.16.1) - 2026-09-07
 
 ### Fixed

--- a/martin/Cargo.toml
+++ b/martin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martin"
-version = "1.16.1"
+version = "1.17.0"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
     "Yuri Astrakhan <YuriAstrakhan@gmail.com>",

--- a/martin/martin-ui/package-lock.json
+++ b/martin/martin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "martin-ui",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "martin-ui",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "dependencies": {
         "@maplibre/maplibre-gl-inspect": "1.9.0",
         "@radix-ui/react-dialog": "1.1.23",

--- a/martin/martin-ui/package.json
+++ b/martin/martin-ui/package.json
@@ -71,5 +71,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.16.1"
+  "version": "1.17.0"
 }

--- a/martin/src/tui/snapshots/martin__tui__tests__a_fresh_dashboard_shows_the_address_and_an_empty_map.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__a_fresh_dashboard_shows_the_address_and_an_empty_map.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render(&dashboard, started + Duration::from_secs(5))"
 ---
-" Martin v1.16.1  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
+" Martin v1.17.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
 "┌ Sources ─────────────────────────────┐┌ Tile requests, last minute ──────────────────────────────┐"
 "│source   requests errors avg ms last z││             ⢀⣀⣤⢤⣤⣤⣄⣠⣠⠤⢄⢠⣠⣀⡀  ⢀⣀⣀⡀  ⣀⡀     ⢀⣀⡀            │"
 "│                                      ││⣤⡀⣀⠤⠤⢄⣀⣀⣤⣾⣿⣿⣿⣿⣿⣟⣿⡭⣗⠒⣦  ⢀⣠⡾⠁   ⠈⣉⡭⢤⣀⣀⣀⢴⣖⣻⣤⠴⠖⠒⠋⠉⠛⠒⠴⠢⠴⠶⠲⠆⢤⣀⣀⣠│"

--- a/martin/src/tui/snapshots/martin__tui__tests__an_expanded_log_takes_the_screen.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__an_expanded_log_takes_the_screen.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render_with(&dashboard, started + Duration::from_secs(5), LogView\n{ size: LogSize::Expanded, scroll: 0, })"
 ---
-" Martin v1.16.1  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
+" Martin v1.17.0  http://127.0.0.1:3000/  up 00:00:05  0 requests  0 error q quit   c clear counters "
 "┌ Log   l shrink ──────────────────────────────────────────────────────────────────────────────────┐"
 "│INFO Starting Martin                                                                              │"
 "│                                                                                                  │"

--- a/martin/src/tui/snapshots/martin__tui__tests__requests_fill_the_sources_the_map_and_the_rate.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__requests_fill_the_sources_the_map_and_the_rate.snap
@@ -2,7 +2,7 @@
 source: martin/src/tui/tests.rs
 expression: "render(&dashboard, at(20))"
 ---
-" Martin v1.16.1  http://127.0.0.1:3000/  up 00:00:20  7 requests  1 error q quit   c clear counters "
+" Martin v1.17.0  http://127.0.0.1:3000/  up 00:00:20  7 requests  1 error q quit   c clear counters "
 "┌ Sources ─────────────────────────────┐┌ Tile requests, last minute ──────────────────────────────┐"
 "│source   requests errors avg ms last z││             ⢀⣀⣤⢤⣤⣤⣄⣠⣠⠤⢄⢠⣠⣀⡀  ⢀⣀⣀⡀  ⣀⡀     ⢀⣀⡀            │"
 "│berlin   3        0      9.7    14    ││⣤⡀⣀⠤⠤⢄⣀⣀⣤⣾⣿⣿⣿⣿⣿⣟⣿⡭⣗⠒⣦  ⢀⣠⡾⠁   ⠈⣉⡭⢤⣀⣀⣀⢴⣖⣻⣤⠴⠖⠒⠋⠉⠛⠒⠴⠢⠴⠶⠲⠆⢤⣀⣀⣠│"

--- a/martin/src/tui/snapshots/martin__tui__tests__the_log_paints_the_parts_of_a_line_the_way_pretty_does.snap
+++ b/martin/src/tui/snapshots/martin__tui__tests__the_log_paints_the_parts_of_a_line_the_way_pretty_does.snap
@@ -5,7 +5,7 @@ expression: terminal.backend().buffer()
 Buffer {
     area: Rect { x: 0, y: 0, width: 110, height: 8 },
     content: [
-        " Martin v1.16.1  http://127.0.0.1:3000/  up 00:00:01  0 requests  0 errors  0.0 req q quit   c clear counters ",
+        " Martin v1.17.0  http://127.0.0.1:3000/  up 00:00:01  0 requests  0 errors  0.0 req q quit   c clear counters ",
         "┌ Log   l shrink ────────────────────────────────────────────────────────────────────────────────────────────┐",
         "│  2026-09-05T09:41:12.123456Z  INFO martin::srv::server: Starting Martin, port: 3000                        │",
         "│    at martin/src/srv/server.rs:120                                                                         │",

--- a/mbtiles/CHANGELOG.md
+++ b/mbtiles/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/maplibre/martin/compare/mbtiles-v0.19.3...mbtiles-v0.19.4) - 2026-09-10
+
+### Other
+
+- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
+
 ## [0.19.3](https://github.com/maplibre/martin/compare/mbtiles-v0.19.2...mbtiles-v0.19.3) - 2026-09-06
 
 ### Added

--- a/mbtiles/Cargo.toml
+++ b/mbtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbtiles"
-version = "0.19.3"
+version = "0.19.4"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 description = "A simple low-level Mbtiles access and processing library, with some tile format detection and other relevant heuristics."
 keywords = ["mbtiles", "maps", "tiles", "mvt", "tilejson"]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -340,7 +340,7 @@
       "name": "MIT OR Apache-2.0"
     },
     "title": "Martin",
-    "version": "1.16.1"
+    "version": "1.17.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION



## 🤖 New release

* `mbtiles`: 0.19.3 -> 0.19.4 (✓ API compatible changes)
* `martin-core`: 0.11.2 -> 0.11.3 (✓ API compatible changes)
* `martin`: 1.16.1 -> 1.17.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbtiles`

<blockquote>

## [0.19.4](https://github.com/maplibre/martin/compare/mbtiles-v0.19.3...mbtiles-v0.19.4) - 2026-09-10

### Other

- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
</blockquote>

## `martin-core`

<blockquote>

## [0.11.3](https://github.com/maplibre/martin/compare/martin-core-v0.11.2...martin-core-v0.11.3) - 2026-09-10

### Other

- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
</blockquote>

## `martin`

<blockquote>

## [1.17.0](https://github.com/maplibre/martin/compare/martin-v1.16.1...martin-v1.17.0) - 2026-09-10

### Added

- *(cog)* detect and reload replaced remote objects ([#3268](https://github.com/maplibre/martin/pull/3268))

### Other

- fix a few clippy lints findings ([#3273](https://github.com/maplibre/martin/pull/3273))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).