### PR TITLE
perf(pmtiles): read local files in place instead of through object_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6862,6 +6862,7 @@ dependencies = [
  "countio",
  "fast_hilbert",
  "flate2",
+ "memmap2",
  "object_store",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ notify = "8.2.0"
 num_cpus = "1"
 object_store = { version = "0.14.1", features = ["gcp", "aws", "azure", "fs", "http"] }
 pbf_font_tools = { version = "3.1.1", features = ["freetype"] }
-pmtiles = { version = "0.24.0", default-features = false, features = ["tilejson", "object-store"] }
+pmtiles = { version = "0.24.0", default-features = false, features = ["tilejson", "object-store", "mmap-async-tokio"] }
 png = "0.18.0"
 postgis = "0.9"
 postgres = { version = "0.19", features = [

--- a/martin-core/src/tiles/pmtiles/backend.rs
+++ b/martin-core/src/tiles/pmtiles/backend.rs
@@ -1,80 +1,41 @@
 //! Byte-range backends behind a [`PmtilesSource`](super::PmtilesSource).
 
-use std::fs::{File, Metadata};
-use std::future::ready;
-use std::io;
+use std::fs::Metadata;
 #[cfg(unix)]
-use std::os::unix::fs::{FileExt as _, MetadataExt as _};
-#[cfg(windows)]
-use std::os::windows::fs::FileExt as _;
+use std::os::unix::fs::MetadataExt as _;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use pmtiles::{AsyncBackend, BackendResponse, ObjectStoreBackend, PmtResult};
+use derive_debug::Dbg;
+use pmtiles::{AsyncBackend, BackendResponse, MmapBackend, ObjectStoreBackend, PmtResult};
 
-/// Reads a local `PMTiles` file in place with positional reads on one open handle.
+/// Reads a local `PMTiles` file through a memory map.
 ///
 /// Every read reports the file's inode, size and modification time as its data version.
 /// A replaced file therefore surfaces as [`pmtiles::PmtError::SourceModified`].
-#[derive(Debug)]
+#[derive(Dbg)]
 pub(crate) struct PmtFileBackend {
-    file: File,
+    #[dbg(skip)]
+    mmap: MmapBackend,
     path: PathBuf,
 }
 
 impl PmtFileBackend {
-    /// Opens `path` for reading.
-    pub(crate) fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
+    /// Maps `path` for reading.
+    pub(crate) async fn open(path: impl Into<PathBuf>) -> PmtResult<Self> {
         let path = path.into();
-        let file = File::open(&path)?;
-        Ok(Self { file, path })
-    }
-
-    /// Reads `length` bytes at `offset`, clamped to the end of the file.
-    fn read_blocking(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
-        let meta = std::fs::metadata(&self.path)?;
-        let available = meta.len().saturating_sub(offset as u64);
-        let length = usize::try_from(available).map_or(length, |a| length.min(a));
-        let mut buf = vec![0_u8; length];
-        read_exact_at(&self.file, &mut buf, offset as u64)?;
-        Ok(BackendResponse::new_with_version(
-            buf.into(),
-            data_version(&meta),
-        ))
+        let mmap = MmapBackend::try_from(&path).await?;
+        Ok(Self { mmap, path })
     }
 }
 
 impl AsyncBackend for PmtFileBackend {
-    fn read(
-        &self,
-        offset: usize,
-        length: usize,
-    ) -> impl Future<Output = PmtResult<BackendResponse>> + Send {
-        // A page cache read is cheaper than a hop to the blocking pool, so it runs inline.
-        ready(self.read_blocking(offset, length))
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
+        let version = data_version(&std::fs::metadata(&self.path)?);
+        let mut response = self.mmap.read(offset, length).await?;
+        response.data_version_string = Some(version);
+        Ok(response)
     }
-}
-
-#[cfg(unix)]
-fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
-    file.read_exact_at(buf, offset)
-}
-
-/// Windows has no `read_exact_at`, so the loop lives here.
-#[cfg(windows)]
-fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> io::Result<()> {
-    while !buf.is_empty() {
-        match file.seek_read(buf, offset) {
-            Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()),
-            Ok(n) => {
-                buf = &mut buf[n..];
-                offset += n as u64;
-            }
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(())
 }
 
 /// The inode, modification time and size of the file.
@@ -96,7 +57,7 @@ fn data_version(meta: &Metadata) -> String {
 /// Where a [`PmtilesSource`](super::PmtilesSource) reads its bytes from.
 #[derive(Debug)]
 pub(crate) enum PmtBackend {
-    /// A file on the local filesystem, read in place.
+    /// A file on the local filesystem.
     File(PmtFileBackend),
     /// A location in an [`object_store::ObjectStore`] such as S3, GCS, Azure or HTTP.
     ObjectStore(ObjectStoreBackend),

--- a/martin-core/src/tiles/pmtiles/backend.rs
+++ b/martin-core/src/tiles/pmtiles/backend.rs
@@ -10,12 +10,12 @@ use std::os::windows::fs::FileExt as _;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use pmtiles::{AsyncBackend, BackendResponse, ObjectStoreBackend, PmtError, PmtResult};
+use pmtiles::{AsyncBackend, BackendResponse, ObjectStoreBackend, PmtResult};
 
 /// Reads a local `PMTiles` file in place with positional reads on one open handle.
 ///
 /// Every read reports the file's inode, size and modification time as its data version.
-/// A replaced file therefore surfaces as [`PmtError::SourceModified`].
+/// A replaced file therefore surfaces as [`pmtiles::PmtError::SourceModified`].
 #[derive(Debug)]
 pub(crate) struct PmtFileBackend {
     file: File,
@@ -30,23 +30,13 @@ impl PmtFileBackend {
         Ok(Self { file, path })
     }
 
-    /// Reads up to `length` bytes at `offset`.
-    /// Returns fewer bytes at the end of the file.
+    /// Reads `length` bytes at `offset`, clamped to the end of the file.
     fn read_blocking(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let meta = std::fs::metadata(&self.path)?;
         let available = meta.len().saturating_sub(offset as u64);
         let length = usize::try_from(available).map_or(length, |a| length.min(a));
         let mut buf = vec![0_u8; length];
-        let mut filled = 0;
-        while filled < length {
-            match read_at(&self.file, &mut buf[filled..], (offset + filled) as u64) {
-                Ok(0) => break,
-                Ok(n) => filled += n,
-                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
-                Err(e) => return Err(PmtError::Reading(e)),
-            }
-        }
-        buf.truncate(filled);
+        read_exact_at(&self.file, &mut buf, offset as u64)?;
         Ok(BackendResponse::new_with_version(
             buf.into(),
             data_version(&meta),
@@ -66,13 +56,25 @@ impl AsyncBackend for PmtFileBackend {
 }
 
 #[cfg(unix)]
-fn read_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-    file.read_at(buf, offset)
+fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    file.read_exact_at(buf, offset)
 }
 
+/// Windows has no `read_exact_at`, so the loop lives here.
 #[cfg(windows)]
-fn read_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-    file.seek_read(buf, offset)
+fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> io::Result<()> {
+    while !buf.is_empty() {
+        match file.seek_read(buf, offset) {
+            Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()),
+            Ok(n) => {
+                buf = &mut buf[n..];
+                offset += n as u64;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
 }
 
 /// The inode, modification time and size of the file.

--- a/martin-core/src/tiles/pmtiles/backend.rs
+++ b/martin-core/src/tiles/pmtiles/backend.rs
@@ -1,0 +1,110 @@
+//! Byte-range backends behind a [`PmtilesSource`](super::PmtilesSource).
+
+use std::fs::{File, Metadata};
+use std::future::ready;
+use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::{FileExt as _, MetadataExt as _};
+#[cfg(windows)]
+use std::os::windows::fs::FileExt as _;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use pmtiles::{AsyncBackend, BackendResponse, ObjectStoreBackend, PmtError, PmtResult};
+
+/// Reads a local `PMTiles` file in place with positional reads on one open handle.
+///
+/// Every read reports the file's inode, size and modification time as its data version.
+/// A replaced file therefore surfaces as [`PmtError::SourceModified`].
+#[derive(Debug)]
+pub(crate) struct PmtFileBackend {
+    file: File,
+    path: PathBuf,
+}
+
+impl PmtFileBackend {
+    /// Opens `path` for reading.
+    pub(crate) fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let file = File::open(&path)?;
+        Ok(Self { file, path })
+    }
+
+    /// Reads up to `length` bytes at `offset`.
+    /// Returns fewer bytes at the end of the file.
+    fn read_blocking(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
+        let meta = std::fs::metadata(&self.path)?;
+        let available = meta.len().saturating_sub(offset as u64);
+        let length = usize::try_from(available).map_or(length, |a| length.min(a));
+        let mut buf = vec![0_u8; length];
+        let mut filled = 0;
+        while filled < length {
+            match read_at(&self.file, &mut buf[filled..], (offset + filled) as u64) {
+                Ok(0) => break,
+                Ok(n) => filled += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(PmtError::Reading(e)),
+            }
+        }
+        buf.truncate(filled);
+        Ok(BackendResponse::new_with_version(
+            buf.into(),
+            data_version(&meta),
+        ))
+    }
+}
+
+impl AsyncBackend for PmtFileBackend {
+    fn read(
+        &self,
+        offset: usize,
+        length: usize,
+    ) -> impl Future<Output = PmtResult<BackendResponse>> + Send {
+        // A page cache read is cheaper than a hop to the blocking pool, so it runs inline.
+        ready(self.read_blocking(offset, length))
+    }
+}
+
+#[cfg(unix)]
+fn read_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+    file.read_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn read_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+    file.seek_read(buf, offset)
+}
+
+/// The inode, modification time and size of the file.
+/// This is the fingerprint `object_store` uses as an `ETag`.
+fn data_version(meta: &Metadata) -> String {
+    #[cfg(unix)]
+    let inode = meta.ino();
+    #[cfg(not(unix))]
+    let inode = 0_u64;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{inode:x}-{mtime:x}-{:x}", meta.len())
+}
+
+/// Where a [`PmtilesSource`](super::PmtilesSource) reads its bytes from.
+#[derive(Debug)]
+pub(crate) enum PmtBackend {
+    /// A file on the local filesystem, read in place.
+    File(PmtFileBackend),
+    /// A location in an [`object_store::ObjectStore`] such as S3, GCS, Azure or HTTP.
+    ObjectStore(ObjectStoreBackend),
+}
+
+impl AsyncBackend for PmtBackend {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
+        match self {
+            Self::File(backend) => backend.read(offset, length).await,
+            Self::ObjectStore(backend) => backend.read(offset, length).await,
+        }
+    }
+}

--- a/martin-core/src/tiles/pmtiles/backend.rs
+++ b/martin-core/src/tiles/pmtiles/backend.rs
@@ -7,17 +7,20 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use derive_debug::Dbg;
-use pmtiles::{AsyncBackend, BackendResponse, MmapBackend, ObjectStoreBackend, PmtResult};
+use pmtiles::{
+    AsyncBackend, BackendResponse, MmapBackend, ObjectStoreBackend, PmtError, PmtResult,
+};
 
 /// Reads a local `PMTiles` file through a memory map.
 ///
-/// Every read reports the file's inode, size and modification time as its data version.
-/// A replaced file therefore surfaces as [`pmtiles::PmtError::SourceModified`].
+/// Every read stats the file first and fails with [`PmtError::SourceModified`] when its inode, size or modification time changed.
+/// The mapping is not read once the file changed underneath it.
 #[derive(Dbg)]
 pub(crate) struct PmtFileBackend {
     #[dbg(skip)]
     mmap: MmapBackend,
     path: PathBuf,
+    version: String,
 }
 
 impl PmtFileBackend {
@@ -25,13 +28,21 @@ impl PmtFileBackend {
     pub(crate) async fn open(path: impl Into<PathBuf>) -> PmtResult<Self> {
         let path = path.into();
         let mmap = MmapBackend::try_from(&path).await?;
-        Ok(Self { mmap, path })
+        let version = data_version(&std::fs::metadata(&path)?);
+        Ok(Self {
+            mmap,
+            path,
+            version,
+        })
     }
 }
 
 impl AsyncBackend for PmtFileBackend {
     async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let version = data_version(&std::fs::metadata(&self.path)?);
+        if version != self.version {
+            return Err(PmtError::SourceModified);
+        }
         let mut response = self.mmap.read(offset, length).await?;
         response.data_version_string = Some(version);
         Ok(response)

--- a/martin-core/src/tiles/pmtiles/mod.rs
+++ b/martin-core/src/tiles/pmtiles/mod.rs
@@ -4,5 +4,7 @@ pub use error::PmtilesError;
 mod source;
 pub use source::PmtilesSource;
 
+mod backend;
+
 mod cache;
 pub use cache::{NO_PMT_CACHE, OptPmtCache, PmtCache, PmtCacheInstance};

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -81,9 +81,9 @@ impl PmtilesSource {
         cache_zoom: CacheZoomRange,
     ) -> Result<Self, PmtilesError> {
         let path = path.into();
-        let backend = PmtFileBackend::open(&path).map_err(|e| {
-            PmtilesError::PmtErrorWithCtx(PmtError::Reading(e), path.display().to_string())
-        })?;
+        let backend = PmtFileBackend::open(&path)
+            .await
+            .map_err(|e| PmtilesError::PmtErrorWithCtx(e, path.display().to_string()))?;
         let location = PmtLocation::File(path);
         Self::from_backend(cache, id, PmtBackend::File(backend), location, cache_zoom).await
     }

--- a/martin-core/src/tiles/pmtiles/source.rs
+++ b/martin-core/src/tiles/pmtiles/source.rs
@@ -1,5 +1,6 @@
 //! `PMTiles` tile source implementations.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -13,14 +14,27 @@ use tracing::{trace, warn};
 use crate::CacheZoomRange;
 use crate::tiles::pmtiles::PmtCacheInstance;
 use crate::tiles::pmtiles::PmtilesError::{self, InvalidMetadata};
+use crate::tiles::pmtiles::backend::{PmtBackend, PmtFileBackend};
 use crate::tiles::{BoxedSource, MartinCoreError, MartinCoreResult, Source, UrlQuery};
 
-/// A source for `PMTiles` files using `ObjectStoreBackend`
+/// Where a [`PmtilesSource`] reads from.
+#[derive(Clone)]
+enum PmtLocation {
+    /// A local file, read by [`PmtFileBackend`].
+    File(PathBuf),
+    /// A location in an [`ObjectStore`], read by [`ObjectStoreBackend`].
+    ObjectStore {
+        store: Arc<dyn ObjectStore>,
+        path: object_store::path::Path,
+    },
+}
+
+/// A source for `PMTiles` files on the local filesystem or in an [`ObjectStore`]
 #[derive(Clone, Dbg)]
 pub struct PmtilesSource {
     id: String,
     #[dbg(skip)]
-    pmtiles: Arc<AsyncPmTilesReader<ObjectStoreBackend, PmtCacheInstance>>,
+    pmtiles: Arc<AsyncPmTilesReader<PmtBackend, PmtCacheInstance>>,
     #[dbg(skip)]
     tilejson: TileJSON,
     #[dbg(skip)]
@@ -29,9 +43,7 @@ pub struct PmtilesSource {
     cache_zoom: CacheZoomRange,
 
     #[dbg(skip)]
-    store: Arc<dyn ObjectStore>,
-    #[dbg(skip)]
-    path: object_store::path::Path,
+    location: PmtLocation,
     #[dbg(skip)]
     pmt_cache: PmtCacheInstance,
 }
@@ -48,11 +60,51 @@ impl PmtilesSource {
         let path = path.into();
         // Wrap in Arc so we can clone the store cheaply for try_reload.
         let store: Arc<dyn ObjectStore> = Arc::from(store);
-        let store_to_string = store.to_string();
         let backend = ObjectStoreBackend::new(Box::new(Arc::clone(&store)), path.clone());
+        let location = PmtLocation::ObjectStore { store, path };
+        Self::from_backend(
+            cache,
+            id,
+            PmtBackend::ObjectStore(backend),
+            location,
+            cache_zoom,
+        )
+        .await
+    }
+
+    /// Create a new `PmtilesSource` from an id and the path of a local `.pmtiles` file.
+    /// The file is read in place.
+    pub async fn new_local(
+        cache: PmtCacheInstance,
+        id: String,
+        path: impl Into<PathBuf>,
+        cache_zoom: CacheZoomRange,
+    ) -> Result<Self, PmtilesError> {
+        let path = path.into();
+        let backend = PmtFileBackend::open(&path).map_err(|e| {
+            PmtilesError::PmtErrorWithCtx(PmtError::Reading(e), path.display().to_string())
+        })?;
+        let location = PmtLocation::File(path);
+        Self::from_backend(cache, id, PmtBackend::File(backend), location, cache_zoom).await
+    }
+
+    async fn from_backend(
+        cache: PmtCacheInstance,
+        id: String,
+        backend: PmtBackend,
+        location: PmtLocation,
+        cache_zoom: CacheZoomRange,
+    ) -> Result<Self, PmtilesError> {
+        let (store_name, path) = match &location {
+            PmtLocation::File(file) => (
+                file.display().to_string(),
+                object_store::path::Path::from(file.to_string_lossy().as_ref()),
+            ),
+            PmtLocation::ObjectStore { store, path } => (store.to_string(), path.clone()),
+        };
         let reader = AsyncPmTilesReader::try_from_cached_source(backend, cache.clone())
             .await
-            .map_err(|e| PmtilesError::PmtErrorWithCtx(e, store_to_string.clone()))?;
+            .map_err(|e| PmtilesError::PmtErrorWithCtx(e, store_name.clone()))?;
 
         let hdr = &reader.get_header();
 
@@ -62,7 +114,7 @@ impl PmtilesSource {
                     "Format {:?} and compression {:?} are not yet supported",
                     hdr.tile_type, hdr.tile_compression
                 ),
-                path.clone(),
+                path,
             ));
         }
 
@@ -74,7 +126,7 @@ impl PmtilesSource {
                     Compression::Unknown => {
                         warn!(
                             source.id = %id,
-                            store = %store_to_string,
+                            store = %store_name,
                             path = %path,
                             "MVT tiles have unknown compression"
                         );
@@ -93,8 +145,8 @@ impl PmtilesSource {
             TileType::Mlt => Format::Mlt.into(),
             TileType::Unknown => {
                 return Err(PmtilesError::UnknownTileType {
-                    source_id: id.clone(),
-                    store: store_to_string.clone(),
+                    source_id: id,
+                    store: store_name,
                     path: path.to_string(),
                 });
             }
@@ -111,8 +163,7 @@ impl PmtilesSource {
             tilejson,
             tile_info: format,
             cache_zoom,
-            store,
-            path,
+            location,
             pmt_cache: cache,
         })
     }
@@ -143,16 +194,26 @@ impl Source for PmtilesSource {
     }
 
     async fn try_reload(&self) -> MartinCoreResult<BoxedSource> {
-        Self::new(
-            self.pmt_cache.fork(),
-            self.id.clone(),
-            Box::new(Arc::clone(&self.store)),
-            self.path.clone(),
-            self.cache_zoom,
-        )
-        .await
-        .map(|s| Box::new(s) as BoxedSource)
-        .map_err(MartinCoreError::from)
+        let cache = self.pmt_cache.fork();
+        let id = self.id.clone();
+        let reloaded = match &self.location {
+            PmtLocation::File(path) => {
+                Self::new_local(cache, id, path.clone(), self.cache_zoom).await
+            }
+            PmtLocation::ObjectStore { store, path } => {
+                Self::new(
+                    cache,
+                    id,
+                    Box::new(Arc::clone(store)),
+                    path.clone(),
+                    self.cache_zoom,
+                )
+                .await
+            }
+        };
+        reloaded
+            .map(|s| Box::new(s) as BoxedSource)
+            .map_err(MartinCoreError::from)
     }
 
     fn cache_zoom(&self) -> CacheZoomRange {

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -748,29 +748,30 @@ async fn dir_assert_miss(cache: &PmtCacheInstance, offset: usize) {
 }
 
 #[tokio::test]
-async fn a_replaced_local_file_is_detected_and_reloaded() {
+async fn a_file_renamed_over_the_source_reloads_to_the_new_contents() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("source.pmtiles");
-    let fixture = fixtures_dir().join("stamen_toner__raster_CC-BY+ODbL_z3.pmtiles");
-    std::fs::copy(&fixture, &path).expect("copy fixture");
+    std::fs::copy(
+        fixtures_dir().join("stamen_toner__raster_CC-BY+ODbL_z3.pmtiles"),
+        &path,
+    )
+    .expect("copy the first archive");
     let source = PmtilesSource::new_local(
         test_cache_bytes(0),
-        "replaced".to_owned(),
+        "renamed_over".to_owned(),
         path.clone(),
         CacheZoomRange::default(),
     )
     .await
     .expect("source created");
-
     let coord = TileCoord::new_unchecked(0, 0, 0);
     let before = source
         .get_tile(coord, None)
         .await
         .expect("first read succeeds");
-    assert!(!before.is_empty(), "first tile should have data");
 
     let staged = dir.path().join("source.pmtiles.new");
-    std::fs::copy(&fixture, &staged).expect("stage the replacement");
+    std::fs::copy(fixtures_dir().join("png.pmtiles"), &staged).expect("stage the second archive");
     std::fs::rename(&staged, &path).expect("rename over the source");
 
     let err = source
@@ -787,5 +788,74 @@ async fn a_replaced_local_file_is_detected_and_reloaded() {
         .get_tile(coord, None)
         .await
         .expect("read after reload succeeds");
-    assert_eq!(after, before);
+    let expected = create_source("png.pmtiles", "second", test_cache_bytes(0))
+        .await
+        .get_tile(coord, None)
+        .await
+        .expect("read the second archive directly");
+    assert_ne!(after, before);
+    assert_eq!(after, expected);
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn a_file_rewritten_in_place_reloads_to_the_new_contents() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("source.pmtiles");
+    std::fs::copy(fixtures_dir().join("png.pmtiles"), &path).expect("copy the first archive");
+    let source = PmtilesSource::new_local(
+        test_cache_bytes(0),
+        "rewritten".to_owned(),
+        path.clone(),
+        CacheZoomRange::default(),
+    )
+    .await
+    .expect("source created");
+    let coord = TileCoord::new_unchecked(0, 0, 0);
+    let before = source
+        .get_tile(coord, None)
+        .await
+        .expect("first read succeeds");
+
+    let smaller = std::fs::read(
+        fixtures_dir()
+            .parent()
+            .unwrap()
+            .join("pmtiles2")
+            .join("webp2.pmtiles"),
+    )
+    .expect("read the smaller archive");
+    std::fs::write(&path, smaller).expect("rewrite the source in place");
+
+    let err = source
+        .get_tile(coord, None)
+        .await
+        .expect_err("a rewritten file needs a reload");
+    assert_matches!(err, MartinCoreError::SourceNeedsReload);
+
+    let reloaded = source
+        .try_reload()
+        .await
+        .expect("reload opens the rewritten file");
+    let after = reloaded
+        .get_tile(coord, None)
+        .await
+        .expect("read after reload succeeds");
+    let expected = PmtilesSource::new_local(
+        test_cache_bytes(0),
+        "smaller".to_owned(),
+        fixtures_dir()
+            .parent()
+            .unwrap()
+            .join("pmtiles2")
+            .join("webp2.pmtiles"),
+        CacheZoomRange::default(),
+    )
+    .await
+    .expect("open the smaller archive directly")
+    .get_tile(coord, None)
+    .await
+    .expect("read the smaller archive directly");
+    assert_ne!(after, before);
+    assert_eq!(after, expected);
 }

--- a/martin-core/tests/pmtiles_test.rs
+++ b/martin-core/tests/pmtiles_test.rs
@@ -37,11 +37,7 @@ fn fixtures_dir() -> PathBuf {
 
 async fn create_source(filename: &str, id: &str, cache: PmtCacheInstance) -> PmtilesSource {
     let path = fixtures_dir().join(filename);
-    let store = Box::new(LocalFileSystem::new());
-    let path = object_store::path::Path::from_filesystem_path(&path)
-        .expect("Failed to convert filesystem path");
-
-    PmtilesSource::new(cache, id.to_owned(), store, path, CacheZoomRange::default())
+    PmtilesSource::new_local(cache, id.to_owned(), path, CacheZoomRange::default())
         .await
         .expect("Failed to create PMTiles source")
 }
@@ -749,4 +745,47 @@ async fn dir_assert_miss(cache: &PmtCacheInstance, offset: usize) {
         .await
         .unwrap();
     assert!(rx.try_recv().is_ok(), "expected cache miss, but got a hit");
+}
+
+#[tokio::test]
+async fn a_replaced_local_file_is_detected_and_reloaded() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("source.pmtiles");
+    let fixture = fixtures_dir().join("stamen_toner__raster_CC-BY+ODbL_z3.pmtiles");
+    std::fs::copy(&fixture, &path).expect("copy fixture");
+    let source = PmtilesSource::new_local(
+        test_cache_bytes(0),
+        "replaced".to_owned(),
+        path.clone(),
+        CacheZoomRange::default(),
+    )
+    .await
+    .expect("source created");
+
+    let coord = TileCoord::new_unchecked(0, 0, 0);
+    let before = source
+        .get_tile(coord, None)
+        .await
+        .expect("first read succeeds");
+    assert!(!before.is_empty(), "first tile should have data");
+
+    let staged = dir.path().join("source.pmtiles.new");
+    std::fs::copy(&fixture, &staged).expect("stage the replacement");
+    std::fs::rename(&staged, &path).expect("rename over the source");
+
+    let err = source
+        .get_tile(coord, None)
+        .await
+        .expect_err("a replaced file needs a reload");
+    assert_matches!(err, MartinCoreError::SourceNeedsReload);
+
+    let reloaded = source
+        .try_reload()
+        .await
+        .expect("reload opens the new file");
+    let after = reloaded
+        .get_tile(coord, None)
+        .await
+        .expect("read after reload succeeds");
+    assert_eq!(after, before);
 }

--- a/martin/src/config/file/tiles/pmtiles.rs
+++ b/martin/src/config/file/tiles/pmtiles.rs
@@ -271,18 +271,7 @@ impl TileSourceConfiguration for PmtConfig {
         let path = path
             .canonicalize()
             .map_err(|e| ConfigFileError::IoError(e, path))?;
-        // path->url conversion requires absolute path, otherwise it errors
-        let path = std::path::absolute(&path).map_err(|e| ConfigFileError::IoError(e, path))?;
-        // windows needs unix style paths, I.e. replace backslashes with forward slashes
-        // a simple "add file://" does not work on windows
-        // example: C:\Users\martin\Documents\pmtiles -> file://C:/Users/martin/Documents/pmtiles
-        let url = Url::from_file_path(&path)
-            .or(Err(ConfigFileError::PathNotConvertibleToUrl(path.clone())))?;
-        trace!(
-            "Pmtiles source {id} ({}) will be loaded as {url}",
-            path.display()
-        );
-        self.new_sources_url(id, url, cache).await
+        self.new_local_source(id, path, cache).await
     }
 
     async fn new_sources_url(
@@ -291,11 +280,31 @@ impl TileSourceConfiguration for PmtConfig {
         url: Url,
         cache: CachePolicy,
     ) -> SourceBuildResult<BoxedSource> {
+        if url.scheme() == "file"
+            && let Ok(path) = url.to_file_path()
+        {
+            return self.new_local_source(id, path, cache).await;
+        }
         let (store, path) = self
             .parse_url_opts(&url)
             .map_err(|e| ConfigFileError::ObjectStoreUrlParsing(e, id.clone()))?;
         let dir_cache = PmtCacheInstance::new_auto_id(self.pmtiles_directory_cache.clone());
         let source = PmtilesSource::new(dir_cache, id, store, path, cache.zoom()).await?;
+        Ok(Box::new(source))
+    }
+}
+
+impl PmtConfig {
+    /// Builds a source that reads the file at `path` in place.
+    async fn new_local_source(
+        &self,
+        id: String,
+        path: PathBuf,
+        cache: CachePolicy,
+    ) -> SourceBuildResult<BoxedSource> {
+        trace!("Pmtiles source {id} will be read from {}", path.display());
+        let dir_cache = PmtCacheInstance::new_auto_id(self.pmtiles_directory_cache.clone());
+        let source = PmtilesSource::new_local(dir_cache, id, path, cache.zoom()).await?;
         Ok(Box::new(source))
     }
 }


### PR DESCRIPTION
A local PMTiles source under concurrent load holds one blocking thread per in-flight request, and in a CPU-limited container the scheduler throttles the whole process for most of every second while the same archive as MBTiles runs unthrottled.

Local files went through object_store's `LocalFileSystem`, which takes two `spawn_blocking` hops per read, one to open and stat the file and one to read the range. Local paths and `file://` URLs now go through the pmtiles crate's `MmapBackend`, as they did before #2251, and remote stores are unchanged. Each read stamps the file's inode, mtime and size as the data version, so a replaced file still surfaces as `SourceModified` and reloads as in #2858. Each read stats the file before touching the mapping and fails with `SourceModified` when it changed, so a file rewritten in place is detected before any page of it is read; only a rewrite racing the read itself can still fault, the same exposure as before #2251. Windows refuses to write a mapped file in place, so replacement there is by rename, which works.

Measured on the 40 MB Berlin archive from the warefeats tile server benchmark, one z14 tile, `cache: disable`, 4 workers, Docker with `cpus: 4`, oha inside the container's network namespace, 12 s passes, threads sampled mid-pass. The MBTiles rows serve the same tiles from the MBTiles copy of the archive and are not changed by this PR.

| Source | Build | Connections | Threads | req/s | p50 ms | p99 ms | Throttled periods | Memory after load |
|---------|---------|------------:|--------:|-------:|-------:|-------:|------------------:|------------------:|
| MBTiles | main | 10 | 20 | 17,340 | 0.54 | 1.09 | 78 of 174 | 21 MB |
| PMTiles | main | 10 | 43 | 19,764 | 0.46 | 0.88 | 149 of 174 | 36 MB |
| PMTiles | this PR | 10 | 10 | 39,746 | 0.25 | 0.39 | 11 of 175 | 14 MB |
| MBTiles | main | 100 | 20 | 12,995 | 7.61 | 9.58 | 0 of 173 | 95 MB |
| PMTiles | main | 100 | 165 | 17,718 | 4.39 | 35.4 | 166 of 174 | 130 MB |
| PMTiles | this PR | 100 | 10 | 33,646 | 2.69 | 5.05 | 32 of 175 | 26 MB |

Throttled periods are `nr_throttled` of `nr_periods` from the container's `cpu.stat`, memory is the `docker stats` usage.
