### PR TITLE
fix(webui): request MLT tiles with an Accept header

### DIFF
--- a/docs/content/postprocessing/mlt.md
+++ b/docs/content/postprocessing/mlt.md
@@ -40,6 +40,33 @@ pmtiles:
 
 Sources that produce other formats (raster, etc.) are unaffected.
 
+## Setting up the Client
+
+Conversion is negotiated per request: Martin only returns MLT if the client asks for it with `Accept: application/vnd.maplibre-tile`.
+A client that declares `"encoding": "mlt"` on a source but omits the header receives MVT bytes and fails to parse them.
+
+!!! warning "MapLibre GL JS does not send the header yet"
+
+    Up to and including v6, MapLibre GL JS sends no `Accept` header on tile requests.
+    Until [maplibre-gl-js#7483](https://github.com/maplibre/maplibre-gl-js/pull/7483) is released, add it yourself via the [`transformRequest`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/RequestTransformFunction/) option.
+    Once that PR ships, MapLibre GL JS derives the header from the source's `encoding` and this workaround can be removed.
+
+```js
+const map = new maplibregl.Map({
+  container: 'map',
+  style: 'https://example.org/style.json',
+  transformRequest: (url, resourceType) =>
+    resourceType === 'Tile' && url.startsWith('https://example.org/my_mlt_source/')
+      ? { url, headers: { Accept: 'application/vnd.maplibre-tile' } }
+      : undefined
+});
+```
+
+Scope the header to the sources you actually serve as MLT.
+Attaching it to every request means a source configured with `convert_to_mlt: auto` is transcoded to MLT while the client still decodes it as MVT.
+
+For MapLibre Native (including the static renderer), the equivalent support is tracked in [maplibre-native#4231](https://github.com/maplibre/maplibre-native/pull/4231).
+
 ## Scoping MLT Conversion
 
 You don't have to convert everything.

--- a/docs/content/postprocessing/mlt.md
+++ b/docs/content/postprocessing/mlt.md
@@ -45,27 +45,23 @@ Sources that produce other formats (raster, etc.) are unaffected.
 Conversion is negotiated per request: Martin only returns MLT if the client asks for it with `Accept: application/vnd.maplibre-tile`.
 A client that declares `"encoding": "mlt"` on a source but omits the header receives MVT bytes and fails to parse them.
 
-!!! warning "MapLibre GL JS does not send the header yet"
+!!! warning "MapLibre GL JS and Maplibre Native do not send the headers yet"
 
-    Up to and including v6, MapLibre GL JS sends no `Accept` header on tile requests.
-    Until [maplibre-gl-js#7483](https://github.com/maplibre/maplibre-gl-js/pull/7483) is released, add it yourself via the [`transformRequest`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/RequestTransformFunction/) option.
-    Once that PR ships, MapLibre GL JS derives the header from the source's `encoding` and this workaround can be removed.
+    Until [maplibre-gl-js#7483](https://github.com/maplibre/maplibre-gl-js/pull/7483) and [maplibre-native#4231](https://github.com/maplibre/maplibre-native/pull/4231) is released, add it yourself via the [`transformRequest`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/RequestTransformFunction/) option or similar plugin facilities on native.
 
-```js
-const map = new maplibregl.Map({
-  container: 'map',
-  style: 'https://example.org/style.json',
-  transformRequest: (url, resourceType) =>
-    resourceType === 'Tile' && url.startsWith('https://example.org/my_mlt_source/')
-      ? { url, headers: { Accept: 'application/vnd.maplibre-tile' } }
-      : undefined
-});
-```
+    ```js
+    const map = new maplibregl.Map({
+      container: 'map',
+      style: 'https://example.org/style.json',
+      transformRequest: (url, resourceType) =>
+        resourceType === 'Tile' && url.startsWith('https://example.org/my_mlt_source/')
+          ? { url, headers: { Accept: 'application/vnd.maplibre-tile' } }
+          : undefined
+    });
+    ```
 
-Scope the header to the sources you actually serve as MLT.
-Attaching it to every request means a source configured with `convert_to_mlt: auto` is transcoded to MLT while the client still decodes it as MVT.
-
-For MapLibre Native (including the static renderer), the equivalent support is tracked in [maplibre-native#4231](https://github.com/maplibre/maplibre-native/pull/4231).
+    Scope the header to the sources you actually serve as MLT.
+    Attaching it to every request means a source configured with `convert_to_mlt: auto` assumes you have `encoding: mlt` set for all sources.
 
 ## Scoping MLT Conversion
 

--- a/martin/martin-ui/__tests__/lib/mlt.test.ts
+++ b/martin/martin-ui/__tests__/lib/mlt.test.ts
@@ -1,0 +1,74 @@
+import type { Map as MapLibre, ResourceType, VectorTileSource } from 'maplibre-gl';
+import { describe, expect, it } from 'vitest';
+import { mltAcceptTransformRequest } from '@/lib/mlt';
+
+const TILE: ResourceType = 'Tile' as ResourceType;
+const SOURCE: ResourceType = 'Source' as ResourceType;
+
+function fakeMap(sources: Record<string, Partial<VectorTileSource>>, isStyleLoaded = true) {
+  return {
+    getSource: (id: string) => sources[id],
+    getStyle: () => ({ sources }),
+    isStyleLoaded: () => isStyleLoaded,
+  } as unknown as MapLibre;
+}
+
+const mltSource: Partial<VectorTileSource> = {
+  encoding: 'mlt',
+  tiles: ['http://localhost:3000/mlt_source/{z}/{x}/{y}'],
+  type: 'vector',
+};
+
+const mvtSource: Partial<VectorTileSource> = {
+  encoding: 'mvt',
+  tiles: ['http://localhost:3000/mvt_source/{z}/{x}/{y}'],
+  type: 'vector',
+};
+
+describe('mltAcceptTransformRequest', () => {
+  it('adds the Accept header for a tile of an mlt-encoded source', () => {
+    const transform = mltAcceptTransformRequest(() => fakeMap({ mlt_source: mltSource }));
+
+    expect(transform('http://localhost:3000/mlt_source/0/0/0', TILE)).toEqual({
+      headers: { Accept: 'application/vnd.maplibre-tile' },
+      url: 'http://localhost:3000/mlt_source/0/0/0',
+    });
+  });
+
+  it('leaves non-tile resources alone', () => {
+    const transform = mltAcceptTransformRequest(() => fakeMap({ mlt_source: mltSource }));
+
+    expect(transform('http://localhost:3000/mlt_source', SOURCE)).toBeUndefined();
+    expect(transform('http://localhost:3000/mlt_source/0/0/0', undefined)).toBeUndefined();
+  });
+
+  it('leaves mvt-encoded sources alone', () => {
+    const transform = mltAcceptTransformRequest(() => fakeMap({ mvt_source: mvtSource }));
+
+    expect(transform('http://localhost:3000/mvt_source/0/0/0', TILE)).toBeUndefined();
+  });
+
+  it('leaves tiles of a different source alone', () => {
+    const transform = mltAcceptTransformRequest(() =>
+      fakeMap({ mlt_source: mltSource, mvt_source: mvtSource }),
+    );
+
+    expect(transform('http://localhost:3000/mvt_source/0/0/0', TILE)).toBeUndefined();
+    expect(transform('http://localhost:3000/mlt_source/0/0/0', TILE)).toEqual({
+      headers: { Accept: 'application/vnd.maplibre-tile' },
+      url: 'http://localhost:3000/mlt_source/0/0/0',
+    });
+  });
+
+  it('does nothing without a loaded map', () => {
+    expect(mltAcceptTransformRequest(() => undefined)('http://localhost:3000/x/0/0/0', TILE)).toBe(
+      undefined,
+    );
+    expect(
+      mltAcceptTransformRequest(() => fakeMap({ mlt_source: mltSource }, false))(
+        'http://localhost:3000/mlt_source/0/0/0',
+        TILE,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/martin/martin-ui/src/components/catalogs/styles.tsx
+++ b/martin/martin-ui/src/components/catalogs/styles.tsx
@@ -8,14 +8,18 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { TooltipCopyText } from '@/components/ui/tooltip-copy-text';
 import { buildMartinUrl } from '@/lib/api';
+import { mltAcceptTransformRequest } from '@/lib/mlt';
 import type { Catalog } from '@/lib/types.gen';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { FullscreenControl, Map as MapLibreMap } from '@vis.gl/react-maplibre';
+import { FullscreenControl, Map as MapLibreMap, type MapRef } from '@vis.gl/react-maplibre';
+import { useRef } from 'react';
 
 function StylePreviewMap({ styleName }: { styleName: string }) {
+  const mapRef = useRef<MapRef>(null);
   return (
     <MapLibreMap
       mapStyle={buildMartinUrl(`/style/${styleName}`)}
+      ref={mapRef}
       reuseMaps
       style={{
         aspectRatio: 16 / 9,
@@ -24,6 +28,7 @@ function StylePreviewMap({ styleName }: { styleName: string }) {
         borderRadius: 'var(--radius)',
         width: '100%',
       }}
+      transformRequest={mltAcceptTransformRequest(() => mapRef.current?.getMap())}
     >
       <FullscreenControl />
     </MapLibreMap>

--- a/martin/martin-ui/src/components/dialogs/style-integration-guide.tsx
+++ b/martin/martin-ui/src/components/dialogs/style-integration-guide.tsx
@@ -269,6 +269,21 @@ function MyMap() {
                   </h4>
                   <CodeBlock code={reactCode} />
                 </div>
+
+                <p className="text-sm text-muted-foreground">
+                  MapLibre GL JS does not send an <code>Accept</code> header on tile requests yet.
+                  Sources served as MLT additionally need a <code>transformRequest</code> that adds
+                  it &mdash; see the{' '}
+                  <a
+                    className="underline"
+                    href="https://maplibre.org/martin/postprocessing/mlt/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    MLT guide
+                  </a>
+                  .
+                </p>
               </div>
             </TabsContent>
 

--- a/martin/martin-ui/src/components/dialogs/style-integration-guide.tsx
+++ b/martin/martin-ui/src/components/dialogs/style-integration-guide.tsx
@@ -273,7 +273,7 @@ function MyMap() {
                 <p className="text-sm text-muted-foreground">
                   MapLibre GL JS does not send an <code>Accept</code> header on tile requests yet.
                   Sources served as MLT additionally need a <code>transformRequest</code> that adds
-                  it &mdash; see the{' '}
+                  it. See the{' '}
                   <a
                     className="underline"
                     href="https://maplibre.org/martin/postprocessing/mlt/"

--- a/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
+++ b/martin/martin-ui/src/components/dialogs/tile-inspect-map.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useUnderlayPreference } from '@/hooks/use-underlay-preference';
 import { buildMartinUrl } from '@/lib/api';
 import { martinClient } from '@/lib/martin-client';
+import { mltAcceptTransformRequest } from '@/lib/mlt';
 import type { Catalog } from '@/lib/types.gen';
 import { ErrorBoundary } from '../error/error-boundary';
 import { UnderlayPicker } from './underlay-picker';
@@ -284,6 +285,7 @@ export function TileInspectDialogMap({ name, source }: TileInspectDialogMapProps
               height: '500px',
               width: '100%',
             }}
+            transformRequest={mltAcceptTransformRequest(() => mapRef.current?.getMap())}
           ></MapLibreMap>
         )}
       </div>

--- a/martin/martin-ui/src/lib/mlt.ts
+++ b/martin/martin-ui/src/lib/mlt.ts
@@ -1,0 +1,28 @@
+import type { Map as MapLibre, RequestTransformFunction, VectorTileSource } from 'maplibre-gl';
+
+const MLT_MIME = 'application/vnd.maplibre-tile';
+
+function servesMlt(map: MapLibre | undefined, url: string): boolean {
+  if (!map?.isStyleLoaded()) return false;
+  return Object.keys(map.getStyle().sources).some((id) => {
+    const source = map.getSource(id) as VectorTileSource | undefined;
+    return (
+      source?.type === 'vector' &&
+      source.encoding === 'mlt' &&
+      source.tiles?.some((tile) => url.startsWith(tile.split('{')[0]))
+    );
+  });
+}
+
+/**
+ * Workaround for maplibre-gl not sending an `Accept` header on tile requests, which Martin
+ * requires to serve MLT. Delete once https://github.com/maplibre/maplibre-gl-js/pull/7483 ships.
+ */
+export function mltAcceptTransformRequest(
+  getMap: () => MapLibre | undefined,
+): RequestTransformFunction {
+  return (url, resourceType) =>
+    resourceType === 'Tile' && servesMlt(getMap(), url)
+      ? { headers: { Accept: MLT_MIME }, url }
+      : undefined;
+}


### PR DESCRIPTION
Adds a `transformRequest` that attaches `Accept: application/vnd.maplibre-tile` to tiles of sources declaring `encoding: 'mlt'`
- documents https://github.com/maplibre/maplibre-gl-js/pull/7483 so it can be deleted once that ships

Fixes #3283

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
