### PR TITLE
fix(srv): let an explicit Accept type outrank a `*/*` wildcard

### DIFF
--- a/e2e-tests/tests/tile_routes.rs
+++ b/e2e-tests/tests/tile_routes.rs
@@ -116,6 +116,8 @@ async fn a_redirect_is_issued_before_the_source_is_resolved(#[case] path: &str) 
 #[case::anything("*/*")]
 #[case::a_list_containing_the_source_format("image/png, application/x-protobuf")]
 #[case::the_least_preferred_of_a_list("image/png;q=0.9, application/x-protobuf;q=0.1")]
+#[case::a_wildcard_behind_an_unservable_type("image/png, */*")]
+#[case::a_wildcard_behind_a_type_that_is_no_tile_format("text/html, */*")]
 #[tokio::test]
 async fn a_vector_source_serves_mvt_when_the_accept_header_allows_it(#[case] accept: &str) {
     let mut martin = martin_with_a_vector_and_a_raster_source().await;
@@ -137,6 +139,8 @@ async fn a_vector_source_serves_mvt_when_the_accept_header_allows_it(#[case] acc
 #[rstest]
 #[case::the_maplibre_tile_type("application/vnd.maplibre-tile")]
 #[case::its_vector_tile_alias("application/vnd.maplibre-vector-tile")]
+#[case::before_a_lower_ranked_wildcard("application/vnd.maplibre-tile, */*;q=0.1")]
+#[case::before_an_equally_ranked_wildcard("application/vnd.maplibre-tile, */*")]
 #[tokio::test]
 async fn a_vector_source_transcodes_to_mlt_for_an_mlt_accept_header(#[case] accept: &str) {
     let mut martin = martin_with_a_vector_and_a_raster_source().await;

--- a/martin/src/srv/mod.rs
+++ b/martin/src/srv/mod.rs
@@ -35,7 +35,7 @@ pub(crate) mod tiles;
 #[cfg(all(feature = "_tiles", feature = "unstable-schemas"))]
 pub use tiles::content::{__path_get_tile, get_tile};
 #[cfg(feature = "_tiles")]
-pub use tiles::content::{DynTileSource, TileRequestHeaders};
+pub use tiles::content::{AcceptedFormats, DynTileSource, TileRequestHeaders};
 #[cfg(feature = "_tiles")]
 pub use tiles::metadata::merge_tilejson;
 #[cfg(all(feature = "_tiles", feature = "unstable-schemas"))]

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::sync::Arc;
 
 use actix_http::ContentEncoding;
@@ -116,33 +117,60 @@ pub async fn get_tile(
 #[derive(Debug, Default, Clone)]
 pub struct TileRequestHeaders {
     /// Formats the client will accept, parsed from the `Accept` header.
-    /// `None` means any format is acceptable (no `Accept` header, empty, or `*/*`).
-    /// Wildcards like `image/*` are expanded into all image formats.
-    pub accepted_formats: Option<Vec<Format>>,
+    pub accepted_formats: AcceptedFormats,
     pub accept_enc: Option<AcceptEncoding>,
     pub if_none_match: Option<IfNoneMatch>,
     pub preferred_enc: Option<PreferredEncoding>,
 }
 
-/// Parse the `Accept` header into a flat list of [`Format`] values.
+/// The formats a client will accept, parsed from the `Accept` header.
 ///
-/// Returns `Ok(None)` (= accept anything) when
-/// - the header is absent,
-/// - is empty, or
-/// - contains a `*/*` wildcard.
+/// A `*/*` wildcard is a fallback rather than a short-circuit: an explicitly named
+/// type is more specific than the wildcard and wins over it regardless of quality,
+/// so [`allow_any`](Self::allow_any) only decides what happens when none of the
+/// [`preferred`](Self::preferred) formats can be served.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcceptedFormats {
+    /// The explicitly named formats, most preferred first.
+    /// `image/*` is expanded into all image formats.
+    pub preferred: Vec<Format>,
+    /// Whether a format outside `preferred` may be served, i.e. the header carried a `*/*`.
+    pub allow_any: bool,
+}
+
+impl AcceptedFormats {
+    /// Any format is acceptable: no `Accept` header, an empty one, or a bare `*/*`.
+    pub const ANY: Self = Self {
+        preferred: Vec::new(),
+        allow_any: true,
+    };
+}
+
+impl Default for AcceptedFormats {
+    fn default() -> Self {
+        Self::ANY
+    }
+}
+
+/// Parse the `Accept` header into the formats the client will accept.
 ///
-/// `image/*` is expanded into all image formats.
+/// Items with `q=0` are dropped, the remaining explicit types are ordered by
+/// descending quality (ties keep the header's order), and `image/*` is expanded
+/// into all image formats. A `*/*` sets [`AcceptedFormats::allow_any`].
+///
+/// Returns [`AcceptedFormats::ANY`] when the header is absent or empty.
 ///
 /// Returns `Err(406)` if
-/// - the header is present but contains no recognized tile formats.
-fn parse_accept(accept: Option<Accept>) -> ActixResult<Option<Vec<Format>>> {
+/// - the header is present but names neither a recognized tile format nor a wildcard.
+fn parse_accept(accept: Option<Accept>) -> ActixResult<AcceptedFormats> {
     let Some(accept) = accept else {
-        return Ok(None);
+        return Ok(AcceptedFormats::ANY);
     };
     if accept.0.is_empty() {
-        return Ok(None);
+        return Ok(AcceptedFormats::ANY);
     }
-    let mut formats = Vec::new();
+    let mut allow_any = false;
+    let mut weighted: Vec<(Quality, Format)> = Vec::new();
     for qi in &accept.0 {
         if qi.quality == Quality::ZERO {
             continue;
@@ -150,22 +178,27 @@ fn parse_accept(accept: Option<Accept>) -> ActixResult<Option<Vec<Format>>> {
         let mt = &qi.item;
         let (supertype, subtype) = (mt.type_().as_str(), mt.subtype().as_str());
         match (supertype, subtype) {
-            ("*", "*") => return Ok(None),
-            ("image", "*") => formats.extend_from_slice(Format::IMAGE_FORMATS),
+            ("*", "*") => allow_any = true,
+            ("image", "*") => {
+                weighted.extend(Format::IMAGE_FORMATS.iter().map(|f| (qi.quality, *f)));
+            }
             _ => {
                 if let Some(fmt) = Format::from_content_type(supertype, subtype) {
-                    formats.push(fmt);
+                    weighted.push((qi.quality, fmt));
                 }
             }
         }
     }
-    if formats.is_empty() {
-        Err(ErrorNotAcceptable(
+    if weighted.is_empty() && !allow_any {
+        return Err(ErrorNotAcceptable(
             "Accept header does not contain any supported tile format",
-        ))
-    } else {
-        Ok(Some(formats))
+        ));
     }
+    weighted.sort_by_key(|(quality, _)| Reverse(*quality));
+    Ok(AcceptedFormats {
+        preferred: weighted.into_iter().map(|(_, format)| format).collect(),
+        allow_any,
+    })
 }
 
 #[derive(Deserialize, Clone)]
@@ -311,10 +344,8 @@ impl<'a> DynTileSource<'a> {
             return Err(TileError::ZoomOutOfRange { zoom: z, supported });
         }
 
-        let accepted_format = Self::resolve_accepted_format(
-            headers.accepted_formats.as_deref(),
-            resolved.info.format,
-        )?;
+        let accepted_format =
+            Self::resolve_accepted_format(&headers.accepted_formats, resolved.info.format)?;
 
         let query = if query.is_empty() {
             None
@@ -336,16 +367,17 @@ impl<'a> DynTileSource<'a> {
 
     /// Checks the pre-parsed accepted formats against the source format.
     ///
+    /// Serving the source format verbatim beats transcoding, so it is tried first
+    /// even when a convertible format was requested with a higher quality.
     /// The pre-cache pipeline can transcode between MVT and MLT, so a request
     /// accepting the opposite vector format resolves to that target.
-    /// Otherwise the source format must appear in the accepted list verbatim.
+    /// A `*/*` wildcard is the last resort: it serves the source format as-is,
+    /// which is also what a request without an `Accept` header gets.
     fn resolve_accepted_format(
-        accepted: Option<&[Format]>,
+        accepted: &AcceptedFormats,
         source_format: Format,
     ) -> Result<Option<Format>, TileError> {
-        let Some(formats) = accepted else {
-            return Ok(None);
-        };
+        let formats = &accepted.preferred;
         if formats.contains(&source_format) {
             return Ok(Some(source_format));
         }
@@ -356,6 +388,9 @@ impl<'a> DynTileSource<'a> {
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
         if source_format == Format::Mlt && formats.contains(&Format::Mvt) {
             return Ok(Some(Format::Mvt));
+        }
+        if accepted.allow_any {
+            return Ok(None);
         }
         Err(TileError::UnacceptableFormat(source_format))
     }
@@ -1242,7 +1277,7 @@ mod tests {
     #[case::empty(Some(Accept(vec![])))]
     #[case::wildcard(Some(Accept(vec![QualityItem::max("*/*".parse().unwrap())])))]
     fn test_parse_accept_any(#[case] accept: Option<Accept>) {
-        assert_eq!(parse_accept(accept).unwrap(), None);
+        assert_eq!(parse_accept(accept).unwrap(), AcceptedFormats::ANY);
     }
 
     #[test]
@@ -1260,7 +1295,7 @@ mod tests {
         parse_accept(accept).unwrap_err();
     }
 
-    fn parse_accept_header(values: &[&str]) -> Option<Vec<Format>> {
+    fn parse_accept_header(values: &[&str]) -> AcceptedFormats {
         parse_accept(Some(Accept(
             values
                 .iter()
@@ -1268,6 +1303,55 @@ mod tests {
                 .collect(),
         )))
         .unwrap()
+    }
+
+    fn parse_weighted_accept_header(values: &[(&str, f32)]) -> AcceptedFormats {
+        parse_accept(Some(Accept(
+            values
+                .iter()
+                .map(|(value, quality)| {
+                    QualityItem::new(value.parse().unwrap(), Quality::try_from(*quality).unwrap())
+                })
+                .collect(),
+        )))
+        .unwrap()
+    }
+
+    #[rstest]
+    #[case::descending(&[("image/png", 1.0), ("application/x-protobuf", 0.5)], &[Format::Png, Format::Mvt])]
+    #[case::ascending(&[("image/png", 0.5), ("application/x-protobuf", 1.0)], &[Format::Mvt, Format::Png])]
+    #[case::ties_keep_the_header_order(&[("image/png", 1.0), ("application/x-protobuf", 1.0)], &[Format::Png, Format::Mvt])]
+    #[case::a_q_zero_type_is_dropped(&[("image/png", 0.0), ("application/x-protobuf", 0.5)], &[Format::Mvt])]
+    fn parse_accept_orders_explicit_types_by_quality(
+        #[case] accept_values: &[(&str, f32)],
+        #[case] expected: &[Format],
+    ) {
+        let parsed = parse_weighted_accept_header(accept_values);
+        assert_eq!(parsed.preferred, expected);
+        assert!(!parsed.allow_any);
+    }
+
+    #[rstest]
+    #[case::alone(&[("*/*", 0.0)])]
+    #[case::with_an_unknown_type(&[("text/html", 1.0), ("*/*", 0.0)])]
+    fn parse_accept_q_zero_wildcard_does_not_allow_any(#[case] accept_values: &[(&str, f32)]) {
+        parse_accept(Some(Accept(
+            accept_values
+                .iter()
+                .map(|(value, quality)| {
+                    QualityItem::new(value.parse().unwrap(), Quality::try_from(*quality).unwrap())
+                })
+                .collect(),
+        )))
+        .unwrap_err();
+    }
+
+    #[test]
+    fn parse_accept_keeps_explicit_types_alongside_a_wildcard() {
+        let parsed =
+            parse_weighted_accept_header(&[("application/vnd.maplibre-tile", 1.0), ("*/*", 0.1)]);
+        assert_eq!(parsed.preferred, [Format::Mlt]);
+        assert!(parsed.allow_any);
     }
 
     #[rstest]
@@ -1281,10 +1365,28 @@ mod tests {
     #[case::image_multi_wildcard_jpeg(&["image/*", "image/png"], Format::Jpeg)]
     #[case::multi_with_match(&["image/png", "application/x-protobuf"], Format::Mvt)]
     #[case::multi_with_match(&["application/x-protobuf", "image/png"], Format::Mvt)]
+    #[case::source_format_with_wildcard_fallback(&["application/x-protobuf", "*/*"], Format::Mvt)]
     fn test_accept_ok(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(parsed.as_deref(), source_format);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
         assert_eq!(result.unwrap(), Some(source_format));
+    }
+
+    #[rstest]
+    #[case::unservable_type_then_wildcard(&["image/png", "*/*"], Format::Mvt)]
+    #[case::wildcard_then_unservable_type(&["*/*", "image/png"], Format::Mvt)]
+    #[case::image_wildcard_then_wildcard(&["image/*", "*/*"], Format::Mvt)]
+    #[case::unknown_type_then_wildcard(&["text/html", "*/*"], Format::Mvt)]
+    #[case::unknown_type_then_wildcard_raster(&["text/html", "*/*"], Format::Png)]
+    #[case::vector_type_then_wildcard_raster(&["application/x-protobuf", "*/*"], Format::Png)]
+    fn test_accept_wildcard_falls_back_to_the_source_format(
+        #[case] accept_values: &[&str],
+        #[case] source_format: Format,
+    ) {
+        let parsed = parse_accept_header(accept_values);
+        assert!(parsed.allow_any);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
+        assert_eq!(result.unwrap(), None);
     }
 
     #[rstest]
@@ -1293,7 +1395,7 @@ mod tests {
     #[case::mvt_vs_png(&["application/x-protobuf"], Format::Png)]
     fn test_accept_406(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(parsed.as_deref(), source_format);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
         result.unwrap_err();
     }
 
@@ -1303,7 +1405,7 @@ mod tests {
     #[case::mvt_vs_mlt(&["application/x-protobuf"], Format::Mlt)]
     fn test_accept_406_without_mlt(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(parsed.as_deref(), source_format);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
         result.unwrap_err();
     }
 
@@ -1314,17 +1416,41 @@ mod tests {
     #[case::mlt_with_other(&["image/png", "application/vnd.maplibre-tile"])]
     fn test_accept_mlt_on_mvt_source_converts(#[case] accept_values: &[&str]) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(parsed.as_deref(), Format::Mvt);
+        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
         assert_eq!(result.unwrap(), Some(Format::Mlt));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::a_lower_ranked_wildcard(&[("application/vnd.maplibre-tile", 1.0), ("*/*", 0.1)])]
+    #[case::an_equally_ranked_wildcard(&[("application/vnd.maplibre-tile", 1.0), ("*/*", 1.0)])]
+    #[case::a_leading_wildcard(&[("*/*", 1.0), ("application/vnd.maplibre-tile", 1.0)])]
+    #[case::a_higher_ranked_wildcard(&[("*/*", 1.0), ("application/vnd.maplibre-tile", 0.1)])]
+    fn test_accept_mlt_wins_over_the_wildcard_fallback(#[case] accept_values: &[(&str, f32)]) {
+        let parsed = parse_weighted_accept_header(accept_values);
+        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
+        assert_eq!(result.unwrap(), Some(Format::Mlt));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[test]
+    fn accept_prefers_the_source_format_over_a_higher_ranked_transcode() {
+        let parsed = parse_weighted_accept_header(&[
+            ("application/vnd.maplibre-tile", 1.0),
+            ("application/x-protobuf", 0.1),
+        ]);
+        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
+        assert_eq!(result.unwrap(), Some(Format::Mvt));
     }
 
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     #[rstest]
     #[case::mvt_only(&["application/x-protobuf"])]
     #[case::mvt_with_other(&["image/png", "application/x-protobuf"])]
+    #[case::mvt_with_wildcard_fallback(&["application/x-protobuf", "*/*"])]
     fn test_accept_mvt_on_mlt_source_converts(#[case] accept_values: &[&str]) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(parsed.as_deref(), Format::Mlt);
+        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mlt);
         assert_eq!(result.unwrap(), Some(Format::Mvt));
     }
 


### PR DESCRIPTION
Parses `Accept` into the explicitly named formats plus a separate `*/*` fallback flag, ordered by quality, so a wildcard anywhere in the header no longer discards every named type and a client can ask for a transcode with a safe fallback.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
