### PR TITLE
fix(srv): reject a transcode the source is configured not to perform

### DIFF
--- a/docs/content/postprocessing/index.md
+++ b/docs/content/postprocessing/index.md
@@ -36,7 +36,7 @@ postgres:
       convert_to_mlt: auto
     no_mlt_table:
       # Per-source: explicitly opt out
-      # Even if the client requests MLT, this source is served as MVT.
+      # This source is served as MVT; a client that accepts only MLT gets a 406.
       convert_to_mlt: disabled
 mbtiles: # gets global default
   - some/file.mbtiles

--- a/docs/content/postprocessing/mlt.md
+++ b/docs/content/postprocessing/mlt.md
@@ -95,6 +95,10 @@ If a higher level (global or source-type) enables MLT but you want one source
 to keep serving MVT, set `convert_to_mlt: disabled` or `convert_to_mvt: disabled`.
 The most-specific level wins, so this overrides any inherited `auto`.
 
+A disabled conversion is never negotiated, so a client asking only for the format
+the conversion would have produced gets `406 Not Acceptable` rather than the other
+format's bytes. Clients that also accept `*/*` still get the source format.
+
 ```yaml
 convert_to_mlt: auto              # default everywhere
 
@@ -105,7 +109,7 @@ pmtiles:
       # Inherits global `auto` -> converted on Accept: MLT
     legacy:
       path: /data/legacy.pmtiles
-      convert_to_mlt: disabled    # always served as MVT, even on Accept: MLT
+      convert_to_mlt: disabled    # served as MVT; an MLT-only Accept gets a 406
 ```
 
 ## Tuning the Encoder

--- a/e2e-tests/tests/tile_routes.rs
+++ b/e2e-tests/tests/tile_routes.rs
@@ -20,6 +20,22 @@ async fn martin_with_a_vector_and_a_raster_source() -> Martin {
         .expect("failed to start martin")
 }
 
+const OPTED_OUT_OF_MLT: &str = "
+geojson:
+  sources:
+    feature_1:
+      path: tests/fixtures/geojson/feature_1.geojson
+      convert_to_mlt: disabled
+";
+
+async fn martin_with_a_source_that_opted_out_of_mlt() -> Martin {
+    Martin::builder()
+        .config(OPTED_OUT_OF_MLT)
+        .start()
+        .await
+        .expect("failed to start martin")
+}
+
 #[rstest]
 #[case::pbf("/webp2/0/0/0.pbf")]
 #[case::mvt("/webp2/0/0/0.mvt")]
@@ -161,6 +177,48 @@ async fn a_vector_source_transcodes_to_mlt_for_an_mlt_accept_header(#[case] acce
 
     martin.stop().await;
     martin.assert_startup_warnings();
+}
+
+#[rstest]
+#[case::the_maplibre_tile_type("application/vnd.maplibre-tile")]
+#[case::its_vector_tile_alias("application/vnd.maplibre-vector-tile")]
+#[case::beside_another_unservable_type("image/png, application/vnd.maplibre-tile")]
+#[tokio::test]
+async fn a_source_that_opted_out_of_mlt_rejects_an_mlt_only_accept_header(#[case] accept: &str) {
+    let mut martin = martin_with_a_source_that_opted_out_of_mlt().await;
+
+    let response = martin
+        .get_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(response.status(), 406);
+    assert_eq!(
+        response.text(),
+        "Source produces application/x-protobuf, which does not match the Accept header"
+    );
+
+    martin.stop().await;
+    martin.assert_log_contains(
+        r#"ERROR error="Source produces application/x-protobuf, which does not match the Accept header""#,
+    );
+}
+
+#[rstest]
+#[case::a_lower_ranked_wildcard("application/vnd.maplibre-tile, */*;q=0.1")]
+#[case::an_equally_ranked_wildcard("application/vnd.maplibre-tile, */*")]
+#[tokio::test]
+async fn a_source_that_opted_out_of_mlt_serves_mvt_to_a_wildcard_fallback(#[case] accept: &str) {
+    let mut martin = martin_with_a_source_that_opted_out_of_mlt().await;
+
+    let tile = martin
+        .get_with_headers("/feature_1/0/0/0", &[("accept", accept)])
+        .await;
+    assert_eq!(tile.status(), 200);
+    assert_eq!(tile.header("content-type"), Some("application/x-protobuf"));
+    let layers = tile.mvt().layers;
+    assert_eq!(layers.len(), 1);
+    assert_eq!(layers[0].name, "feature_1");
+
+    martin.stop().await;
 }
 
 #[rstest]

--- a/martin/src/config/file/process.rs
+++ b/martin/src/config/file/process.rs
@@ -161,7 +161,8 @@ impl ProcessResolveError {
 pub enum MltConversion {
     /// Convert with these encoder settings.
     Encode(EncoderConfig),
-    /// Serve the MVT bytes as they are.
+    /// Never offer MLT: the MVT bytes are served as they are, and a client that
+    /// accepts nothing else gets a 406.
     Disabled,
 }
 
@@ -172,7 +173,8 @@ pub enum MvtConversion {
     /// Convert.
     #[default]
     Encode,
-    /// Serve the MLT bytes as they are.
+    /// Never offer MVT: the MLT bytes are served as they are, and a client that
+    /// accepts nothing else gets a 406.
     Disabled,
 }
 

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -28,6 +28,8 @@ use crate::config::file::ResolvedHillshade;
 use crate::config::file::ResolvedProcess;
 use crate::config::file::driver::Sink as _;
 use crate::config::file::srv::SrvConfig;
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+use crate::config::file::{MltConversion, MvtConversion};
 use crate::reload::{NewSource, ReloadAdvisory};
 use crate::srv::TileError;
 use crate::srv::server::DebouncedWarning;
@@ -296,6 +298,32 @@ fn redirect_tile_with_query(
         .finish()
 }
 
+/// Which vector transcodes every source of one request will actually perform.
+///
+/// A source opts out with `convert_to_mlt: disabled` / `convert_to_mvt: disabled`,
+/// and a composite is merged into a single format, so a target is only negotiable
+/// when all of the request's sources encode it.
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TranscodeTargets {
+    to_mlt: bool,
+    to_mvt: bool,
+}
+
+#[cfg(all(feature = "mlt", feature = "_tiles"))]
+impl TranscodeTargets {
+    fn of(sources: &[(BoxedSource, ResolvedProcess)]) -> Self {
+        Self {
+            to_mlt: sources
+                .iter()
+                .all(|(_, pc)| matches!(pc.mlt, MltConversion::Encode(_))),
+            to_mvt: sources
+                .iter()
+                .all(|(_, pc)| pc.mvt == MvtConversion::Encode),
+        }
+    }
+}
+
 pub struct DynTileSource<'a> {
     pub sources: Vec<(BoxedSource, ResolvedProcess)>,
     pub info: TileInfo,
@@ -344,8 +372,12 @@ impl<'a> DynTileSource<'a> {
             return Err(TileError::ZoomOutOfRange { zoom: z, supported });
         }
 
-        let accepted_format =
-            Self::resolve_accepted_format(&headers.accepted_formats, resolved.info.format)?;
+        let accepted_format = Self::resolve_accepted_format(
+            &headers.accepted_formats,
+            resolved.info.format,
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            TranscodeTargets::of(&resolved.sources),
+        )?;
 
         let query = if query.is_empty() {
             None
@@ -370,23 +402,28 @@ impl<'a> DynTileSource<'a> {
     /// Serving the source format verbatim beats transcoding, so it is tried first
     /// even when a convertible format was requested with a higher quality.
     /// The pre-cache pipeline can transcode between MVT and MLT, so a request
-    /// accepting the opposite vector format resolves to that target.
+    /// accepting the opposite vector format resolves to that target - but only
+    /// when every source of the request is configured to perform that transcode,
+    /// since a target nobody encodes would otherwise be answered with the source
+    /// format's bytes under the requested format's content type.
     /// A `*/*` wildcard is the last resort: it serves the source format as-is,
-    /// which is also what a request without an `Accept` header gets.
+    /// which is also what a request without an `Accept` header gets. A client that
+    /// named nothing but formats this request cannot produce gets a 406.
     fn resolve_accepted_format(
         accepted: &AcceptedFormats,
         source_format: Format,
+        #[cfg(all(feature = "mlt", feature = "_tiles"))] transcodes: TranscodeTargets,
     ) -> Result<Option<Format>, TileError> {
         let formats = &accepted.preferred;
         if formats.contains(&source_format) {
             return Ok(Some(source_format));
         }
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
-        if source_format == Format::Mvt && formats.contains(&Format::Mlt) {
+        if source_format == Format::Mvt && formats.contains(&Format::Mlt) && transcodes.to_mlt {
             return Ok(Some(Format::Mlt));
         }
         #[cfg(all(feature = "mlt", feature = "_tiles"))]
-        if source_format == Format::Mlt && formats.contains(&Format::Mvt) {
+        if source_format == Format::Mlt && formats.contains(&Format::Mvt) && transcodes.to_mvt {
             return Ok(Some(Format::Mvt));
         }
         if accepted.allow_any {
@@ -1317,6 +1354,21 @@ mod tests {
         .unwrap()
     }
 
+    fn resolve(
+        accepted: &AcceptedFormats,
+        source_format: Format,
+    ) -> Result<Option<Format>, TileError> {
+        DynTileSource::resolve_accepted_format(
+            accepted,
+            source_format,
+            #[cfg(all(feature = "mlt", feature = "_tiles"))]
+            TranscodeTargets {
+                to_mlt: true,
+                to_mvt: true,
+            },
+        )
+    }
+
     #[rstest]
     #[case::descending(&[("image/png", 1.0), ("application/x-protobuf", 0.5)], &[Format::Png, Format::Mvt])]
     #[case::ascending(&[("image/png", 0.5), ("application/x-protobuf", 1.0)], &[Format::Mvt, Format::Png])]
@@ -1368,7 +1420,7 @@ mod tests {
     #[case::source_format_with_wildcard_fallback(&["application/x-protobuf", "*/*"], Format::Mvt)]
     fn test_accept_ok(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
+        let result = resolve(&parsed, source_format);
         assert_eq!(result.unwrap(), Some(source_format));
     }
 
@@ -1385,7 +1437,7 @@ mod tests {
     ) {
         let parsed = parse_accept_header(accept_values);
         assert!(parsed.allow_any);
-        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
+        let result = resolve(&parsed, source_format);
         assert_eq!(result.unwrap(), None);
     }
 
@@ -1395,7 +1447,7 @@ mod tests {
     #[case::mvt_vs_png(&["application/x-protobuf"], Format::Png)]
     fn test_accept_406(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
+        let result = resolve(&parsed, source_format);
         result.unwrap_err();
     }
 
@@ -1405,7 +1457,7 @@ mod tests {
     #[case::mvt_vs_mlt(&["application/x-protobuf"], Format::Mlt)]
     fn test_accept_406_without_mlt(#[case] accept_values: &[&str], #[case] source_format: Format) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, source_format);
+        let result = resolve(&parsed, source_format);
         result.unwrap_err();
     }
 
@@ -1416,7 +1468,7 @@ mod tests {
     #[case::mlt_with_other(&["image/png", "application/vnd.maplibre-tile"])]
     fn test_accept_mlt_on_mvt_source_converts(#[case] accept_values: &[&str]) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
+        let result = resolve(&parsed, Format::Mvt);
         assert_eq!(result.unwrap(), Some(Format::Mlt));
     }
 
@@ -1428,7 +1480,7 @@ mod tests {
     #[case::a_higher_ranked_wildcard(&[("*/*", 1.0), ("application/vnd.maplibre-tile", 0.1)])]
     fn test_accept_mlt_wins_over_the_wildcard_fallback(#[case] accept_values: &[(&str, f32)]) {
         let parsed = parse_weighted_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
+        let result = resolve(&parsed, Format::Mvt);
         assert_eq!(result.unwrap(), Some(Format::Mlt));
     }
 
@@ -1439,7 +1491,7 @@ mod tests {
             ("application/vnd.maplibre-tile", 1.0),
             ("application/x-protobuf", 0.1),
         ]);
-        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mvt);
+        let result = resolve(&parsed, Format::Mvt);
         assert_eq!(result.unwrap(), Some(Format::Mvt));
     }
 
@@ -1450,8 +1502,146 @@ mod tests {
     #[case::mvt_with_wildcard_fallback(&["application/x-protobuf", "*/*"])]
     fn test_accept_mvt_on_mlt_source_converts(#[case] accept_values: &[&str]) {
         let parsed = parse_accept_header(accept_values);
-        let result = DynTileSource::resolve_accepted_format(&parsed, Format::Mlt);
+        let result = resolve(&parsed, Format::Mlt);
         assert_eq!(result.unwrap(), Some(Format::Mvt));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    const NO_MLT: TranscodeTargets = TranscodeTargets {
+        to_mlt: false,
+        to_mvt: true,
+    };
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    const NO_MVT: TranscodeTargets = TranscodeTargets {
+        to_mlt: true,
+        to_mvt: false,
+    };
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::mlt_disabled(&["application/vnd.maplibre-tile"], Format::Mvt, NO_MLT)]
+    #[case::mlt_disabled_beside_an_unservable_type(&["image/png", "application/vnd.maplibre-tile"], Format::Mvt, NO_MLT)]
+    #[case::mvt_disabled(&["application/x-protobuf"], Format::Mlt, NO_MVT)]
+    #[case::mvt_disabled_beside_an_unservable_type(&["image/png", "application/x-protobuf"], Format::Mlt, NO_MVT)]
+    fn test_accept_406_when_the_transcode_is_disabled(
+        #[case] accept_values: &[&str],
+        #[case] source_format: Format,
+        #[case] transcodes: TranscodeTargets,
+    ) {
+        let parsed = parse_accept_header(accept_values);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format, transcodes);
+        assert!(matches!(result, Err(TileError::UnacceptableFormat(f)) if f == source_format));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::mlt_disabled(&[("application/vnd.maplibre-tile", 1.0), ("*/*", 0.1)], Format::Mvt, NO_MLT)]
+    #[case::mlt_disabled_with_a_leading_wildcard(&[("*/*", 0.1), ("application/vnd.maplibre-tile", 1.0)], Format::Mvt, NO_MLT)]
+    #[case::mvt_disabled(&[("application/x-protobuf", 1.0), ("*/*", 0.1)], Format::Mlt, NO_MVT)]
+    fn test_accept_disabled_transcode_falls_back_to_the_source_format(
+        #[case] accept_values: &[(&str, f32)],
+        #[case] source_format: Format,
+        #[case] transcodes: TranscodeTargets,
+    ) {
+        let parsed = parse_weighted_accept_header(accept_values);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format, transcodes);
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::to_mlt(&["application/vnd.maplibre-tile"], Format::Mvt, NO_MVT, Format::Mlt)]
+    #[case::to_mvt(&["application/x-protobuf"], Format::Mlt, NO_MLT, Format::Mvt)]
+    fn test_accept_an_enabled_transcode_still_converts(
+        #[case] accept_values: &[&str],
+        #[case] source_format: Format,
+        #[case] transcodes: TranscodeTargets,
+        #[case] expected: Format,
+    ) {
+        let parsed = parse_accept_header(accept_values);
+        let result = DynTileSource::resolve_accepted_format(&parsed, source_format, transcodes);
+        assert_eq!(result.unwrap(), Some(expected));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::all_enabled(&[true, true], true)]
+    #[case::one_disabled(&[true, false], false)]
+    #[case::all_disabled(&[false, false], false)]
+    fn a_composite_only_transcodes_when_every_source_does(
+        #[case] enabled: &[bool],
+        #[case] expected: bool,
+    ) {
+        let sources: Vec<(BoxedSource, ResolvedProcess)> = enabled
+            .iter()
+            .enumerate()
+            .map(|(i, on)| {
+                let src = TestSource {
+                    id: if i == 0 { "a" } else { "b" },
+                    tj: tilejson! { tiles: vec![] },
+                    data: vec![1_u8, 2, 3],
+                    format: Format::Mvt,
+                };
+                let pc = if *on {
+                    ResolvedProcess::default()
+                } else {
+                    ResolvedProcess {
+                        mlt: MltConversion::Disabled,
+                        ..Default::default()
+                    }
+                };
+                (Box::new(src) as BoxedSource, pc)
+            })
+            .collect();
+        assert_eq!(TranscodeTargets::of(&sources).to_mlt, expected);
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    fn mlt_disabled_manager() -> TileSourceManager {
+        let src = TestSource {
+            id: "mvt",
+            tj: tilejson! { tiles: vec![] },
+            data: vec![1_u8, 2, 3],
+            format: Format::Mvt,
+        };
+        let pc = ResolvedProcess {
+            mlt: MltConversion::Disabled,
+            ..Default::default()
+        };
+        TileSourceManager::from_sources(None, OnInvalid::Abort, vec![vec![(Box::new(src), pc)]])
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[test]
+    fn a_disabled_mlt_source_rejects_a_bare_mlt_accept() {
+        let mgr = mlt_disabled_manager();
+        let headers = TileRequestHeaders {
+            accepted_formats: parse_accept_header(&["application/vnd.maplibre-tile"]),
+            ..Default::default()
+        };
+        let Err(err) = DynTileSource::new(&mgr, "mvt", None, "", headers) else {
+            panic!("a bare MLT accept must not resolve against a source that will not encode it");
+        };
+        assert!(matches!(err, TileError::UnacceptableFormat(Format::Mvt)));
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[actix_rt::test]
+    async fn a_disabled_mlt_source_serves_mvt_to_a_wildcard_fallback() {
+        let mgr = mlt_disabled_manager();
+        let headers = TileRequestHeaders {
+            accepted_formats: parse_weighted_accept_header(&[
+                ("application/vnd.maplibre-tile", 1.0),
+                ("*/*", 0.1),
+            ]),
+            ..Default::default()
+        };
+        let src = DynTileSource::new(&mgr, "mvt", None, "", headers).unwrap();
+        assert_eq!(src.accepted_format, None);
+        let tile = src.get_tile_content(ORIGIN).await.unwrap();
+        assert_eq!(tile.info.format, Format::Mvt);
+        assert_eq!(tile.data, vec![1_u8, 2, 3]);
     }
 
     #[actix_rt::test]

--- a/martin/src/srv/tiles/process/mod.rs
+++ b/martin/src/srv/tiles/process/mod.rs
@@ -129,10 +129,14 @@ impl From<ProcessError> for actix_web::Error {
 /// Currently supports:
 /// - MVT -> MLT conversion when the client requests `application/vnd.maplibre-tile`
 ///   (requires `mlt` feature). Encoder settings come from `config.mlt`, resolved from
-///   `convert_to_mlt` at startup, and `disabled` skips conversion entirely
-///   even if the client asked for MLT - the original MVT bytes are returned.
+///   `convert_to_mlt` at startup.
 /// - MLT -> MVT conversion when the client requests `application/vnd.mapbox-vector-tile`
-///   from an MLT source (requires `mlt` feature). `convert_to_mvt: disabled` skips it.
+///   from an MLT source (requires `mlt` feature), settings from `config.mvt`.
+///
+/// A `disabled` conversion is never negotiated as the accepted format - the request
+/// either falls back to the source format or is rejected with a 406 before any tile
+/// is fetched - so the matching `Disabled` arms here are only reached by callers that
+/// pass a target the config does not encode, and leave the tile untouched.
 ///
 /// Runs inside the cache miss path so cached entries are already post-processed.
 /// MVT and MLT requests are keyed separately in the tile cache, so both formats
@@ -170,6 +174,8 @@ mod tests {
     use martin_core::tiles::Tile;
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     use martin_tile_utils::{Encoding, Format, TileInfo};
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    use mlt_core::encoder::EncoderConfig;
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
     use rstest::rstest;
 
@@ -247,16 +253,69 @@ mod tests {
         assert_eq!(result.info.format, Format::Mlt);
     }
 
+    /// `Accept` negotiation never resolves to a target a `disabled` source would
+    /// have to encode - such a request is a 406, or falls back to the source format
+    /// with `accepted` unset - so the pipeline only ever sees `None` for those.
     #[cfg(all(feature = "mlt", feature = "_tiles"))]
-    #[test]
-    fn mlt_accept_with_disabled_serves_mvt_unchanged() {
-        let tile = make_tile(empty_layer_mvt_bytes(), Format::Mvt, Encoding::Uncompressed);
+    #[rstest]
+    #[case::mlt_disabled(MltConversion::Disabled, MvtConversion::Encode, Format::Mvt)]
+    #[case::mvt_disabled(
+        MltConversion::Encode(EncoderConfig::default()),
+        MvtConversion::Disabled,
+        Format::Mlt
+    )]
+    fn a_disabled_conversion_is_never_negotiated(
+        #[case] mlt: MltConversion,
+        #[case] mvt: MvtConversion,
+        #[case] source_format: Format,
+    ) {
+        let tile = make_tile(
+            empty_layer_mvt_bytes(),
+            source_format,
+            Encoding::Uncompressed,
+        );
         let config = ResolvedProcess {
-            mlt: MltConversion::Disabled,
+            mlt,
+            mvt,
             ..Default::default()
         };
-        let result = apply_pre_cache_processors(tile, &config, Some(Format::Mlt)).unwrap();
-        assert_eq!(result.info.format, Format::Mvt);
+        let result = apply_pre_cache_processors(tile, &config, None).unwrap();
+        assert_eq!(result.info.format, source_format);
+        assert_eq!(result.data, empty_layer_mvt_bytes());
+    }
+
+    #[cfg(all(feature = "mlt", feature = "_tiles"))]
+    #[rstest]
+    #[case::mlt_disabled(
+        MltConversion::Disabled,
+        MvtConversion::Encode,
+        Format::Mvt,
+        Format::Mlt
+    )]
+    #[case::mvt_disabled(
+        MltConversion::Encode(EncoderConfig::default()),
+        MvtConversion::Disabled,
+        Format::Mlt,
+        Format::Mvt
+    )]
+    fn a_disabled_conversion_leaves_the_tile_untouched(
+        #[case] mlt: MltConversion,
+        #[case] mvt: MvtConversion,
+        #[case] source_format: Format,
+        #[case] accepted: Format,
+    ) {
+        let tile = make_tile(
+            empty_layer_mvt_bytes(),
+            source_format,
+            Encoding::Uncompressed,
+        );
+        let config = ResolvedProcess {
+            mlt,
+            mvt,
+            ..Default::default()
+        };
+        let result = apply_pre_cache_processors(tile, &config, Some(accepted)).unwrap();
+        assert_eq!(result.info.format, source_format);
         assert_eq!(result.data, empty_layer_mvt_bytes());
     }
 


### PR DESCRIPTION
Negotiates an MVT <-> MLT transcode only when every source of the request will actually perform it.
A `disabled` conversion answers `406` before fetching a tile instead of `200` carrying the other format's bytes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
