### PR TITLE
ci(hotpath): only profile PRs labeled "bench"

### DIFF
--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -2,6 +2,7 @@ name: Hotpath profile
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '**.md'
       - 'demo/**'
@@ -20,6 +21,7 @@ permissions:
 
 jobs:
   profile:
+    if: contains(github.event.pull_request.labels.*.name, 'bench')
     runs-on: ubuntu-latest
     env:
       PGDATABASE: test

--- a/martin/src/srv/tiles/content.rs
+++ b/martin/src/srv/tiles/content.rs
@@ -1587,7 +1587,7 @@ mod tests {
                 let src = TestSource {
                     id: if i == 0 { "a" } else { "b" },
                     tj: tilejson! { tiles: vec![] },
-                    data: vec![1_u8, 2, 3],
+                    data: TileData::from_static(&[1, 2, 3]),
                     format: Format::Mvt,
                 };
                 let pc = if *on {
@@ -1609,7 +1609,7 @@ mod tests {
         let src = TestSource {
             id: "mvt",
             tj: tilejson! { tiles: vec![] },
-            data: vec![1_u8, 2, 3],
+            data: TileData::from_static(&[1, 2, 3]),
             format: Format::Mvt,
         };
         let pc = ResolvedProcess {


### PR DESCRIPTION
Gates the Hotpath profile workflow behind a `bench` label so the expensive base+head benchmark only runs when explicitly requested.
